### PR TITLE
feat(mobile): ID Token 自動付与・自動更新と起動時プロフィール取得を配線

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -17,10 +17,7 @@ import { TamaguiProvider } from 'tamagui';
 
 import config from '../tamagui.config';
 import { AuthGate } from '@/shared/components/AuthGate';
-import {
-  refreshIdToken,
-  subscribeIdTokenChanged,
-} from '@/shared/lib/firebase';
+import { refreshIdToken, subscribeIdTokenChanged } from '@/shared/lib/firebase';
 import { setTokenProvider, setTokenRefresher } from '@/shared/lib/api';
 import { queryClient } from '@/shared/lib/queryClient';
 import { getAuthIdToken, useAuthStore } from '@/shared/stores/authStore';

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,6 +1,14 @@
 /**
  * ルートレイアウト。Tamagui と TanStack Query の Provider を組み込み、
  * AuthGate で認証 / オンボーディング状態に応じたリダイレクトを行う。
+ *
+ * Firebase ID Token 周りの配線もここで行う。
+ * - `setTokenProvider`: API リクエスト毎に最新の ID Token を Authorization に差し込む
+ * - `setTokenRefresher`: 401 を受けた際に Firebase から ID Token を再取得させる
+ * - `subscribeIdTokenChanged`: Firebase の onIdTokenChanged を購読して authStore に反映する
+ *
+ * authStore に uid / idToken が入ると AuthGate 配下の `useProfile` が有効化され、
+ * 起動時にユーザープロフィール（/users/me/profile）が取得される。
  */
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
@@ -9,13 +17,32 @@ import { TamaguiProvider } from 'tamagui';
 
 import config from '../tamagui.config';
 import { AuthGate } from '@/shared/components/AuthGate';
-import { setTokenProvider } from '@/shared/lib/api';
+import {
+  refreshIdToken,
+  subscribeIdTokenChanged,
+} from '@/shared/lib/firebase';
+import { setTokenProvider, setTokenRefresher } from '@/shared/lib/api';
 import { queryClient } from '@/shared/lib/queryClient';
-import { getAuthIdToken } from '@/shared/stores/authStore';
+import { getAuthIdToken, useAuthStore } from '@/shared/stores/authStore';
 
 export default function RootLayout() {
   useEffect(() => {
     setTokenProvider(() => getAuthIdToken());
+    setTokenRefresher(() => refreshIdToken());
+
+    const unsubscribe = subscribeIdTokenChanged((session) => {
+      const { setSession, clear } = useAuthStore.getState();
+      if (session === null) {
+        clear();
+      } else {
+        setSession(session.uid, session.idToken);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      setTokenRefresher(null);
+    };
   }, []);
 
   return (

--- a/mobile/src/shared/lib/__tests__/api.test.ts
+++ b/mobile/src/shared/lib/__tests__/api.test.ts
@@ -1,0 +1,115 @@
+/**
+ * api.ts の Authorization 付与と 401 時の自動リフレッシュ挙動を検証する。
+ *
+ * fetch はグローバルをモックし、tokenProvider / tokenRefresher は
+ * このテスト内で差し込む。
+ */
+import { api, setTokenProvider, setTokenRefresher } from '../api';
+
+type FetchMock = jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+
+const originalFetch = global.fetch;
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getAuthHeader(call: [RequestInfo | URL, RequestInit?]): string | null {
+  const init = call[1];
+  if (init === undefined) return null;
+  const headers = init.headers;
+  if (headers instanceof Headers) {
+    return headers.get('Authorization');
+  }
+  return null;
+}
+
+describe('api', () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    setTokenProvider(() => null);
+    setTokenRefresher(null);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('tokenProvider が返した ID Token を Authorization ヘッダーに付与する', async () => {
+    setTokenProvider(() => 'token-initial');
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await api.get('/users/me/profile');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getAuthHeader(fetchMock.mock.calls[0]!)).toBe('Bearer token-initial');
+  });
+
+  it('tokenProvider が null を返したときは Authorization を付けない', async () => {
+    setTokenProvider(() => null);
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await api.get('/users/me/profile');
+
+    expect(getAuthHeader(fetchMock.mock.calls[0]!)).toBeNull();
+  });
+
+  it('401 を受けたら tokenRefresher を呼び、取得した新トークンで 1 回だけ再送する', async () => {
+    setTokenProvider(() => 'token-expired');
+    const refresher = jest.fn<Promise<string | null>, []>().mockResolvedValue('token-fresh');
+    setTokenRefresher(refresher);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }))
+      .mockResolvedValueOnce(jsonResponse(200, { id: 'u1' }));
+
+    const result = await api.get<{ id: string }>('/users/me/profile');
+
+    expect(result.data).toEqual({ id: 'u1' });
+    expect(refresher).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getAuthHeader(fetchMock.mock.calls[0]!)).toBe('Bearer token-expired');
+    expect(getAuthHeader(fetchMock.mock.calls[1]!)).toBe('Bearer token-fresh');
+  });
+
+  it('tokenRefresher が null を返したときは再送せず 401 を失敗として返す', async () => {
+    setTokenProvider(() => 'token-expired');
+    const refresher = jest.fn<Promise<string | null>, []>().mockResolvedValue(null);
+    setTokenRefresher(refresher);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }));
+
+    await expect(api.get('/users/me/profile')).rejects.toThrow('HTTP 401');
+    expect(refresher).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('tokenRefresher が未設定のときは 401 を受けても再送しない', async () => {
+    setTokenProvider(() => 'token-expired');
+    setTokenRefresher(null);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }));
+
+    await expect(api.get('/users/me/profile')).rejects.toThrow('HTTP 401');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('200 のときは tokenRefresher を呼ばない', async () => {
+    setTokenProvider(() => 'token-initial');
+    const refresher = jest.fn<Promise<string | null>, []>().mockResolvedValue('token-fresh');
+    setTokenRefresher(refresher);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    await api.get('/users/me/profile');
+
+    expect(refresher).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/shared/lib/__tests__/firebase.test.ts
+++ b/mobile/src/shared/lib/__tests__/firebase.test.ts
@@ -1,0 +1,72 @@
+/**
+ * firebase.ts の差し込み機構（registerAuthImpl / subscribe / refresh）を検証する。
+ * 実 Firebase SDK は呼ばず、差し込み口のデフォルト挙動と差し替え挙動だけを確認する。
+ */
+import {
+  refreshIdToken,
+  registerAuthImpl,
+  resetAuthImpl,
+  subscribeIdTokenChanged,
+  type AuthSession,
+} from '../firebase';
+
+describe('firebase auth 差し込み', () => {
+  afterEach(() => {
+    resetAuthImpl();
+  });
+
+  it('未登録のとき subscribe は何もせず unsubscribe だけ返す', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeIdTokenChanged(listener);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it('未登録のとき refreshIdToken は null を返す', async () => {
+    await expect(refreshIdToken()).resolves.toBeNull();
+  });
+
+  it('registerAuthImpl で差し込んだ subscribe が呼ばれ、listener に session が届く', () => {
+    const listener = jest.fn();
+    const unsubscribeSpy = jest.fn();
+    const subscribeSpy = jest.fn((l: (session: AuthSession | null) => void) => {
+      l({ uid: 'u1', idToken: 'token-1' });
+      return unsubscribeSpy;
+    });
+
+    registerAuthImpl({
+      subscribeIdTokenChanged: subscribeSpy,
+      refreshIdToken: async () => null,
+    });
+
+    const unsubscribe = subscribeIdTokenChanged(listener);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ uid: 'u1', idToken: 'token-1' });
+
+    unsubscribe();
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('registerAuthImpl で差し込んだ refresh が呼ばれ、返値がそのまま返る', async () => {
+    const refreshSpy = jest.fn<Promise<string | null>, []>().mockResolvedValue('token-fresh');
+    registerAuthImpl({
+      subscribeIdTokenChanged: () => () => {},
+      refreshIdToken: refreshSpy,
+    });
+
+    await expect(refreshIdToken()).resolves.toBe('token-fresh');
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetAuthImpl で差し込みが初期状態に戻る', async () => {
+    registerAuthImpl({
+      subscribeIdTokenChanged: () => () => {},
+      refreshIdToken: async () => 'token-fresh',
+    });
+
+    resetAuthImpl();
+
+    await expect(refreshIdToken()).resolves.toBeNull();
+  });
+});

--- a/mobile/src/shared/lib/api.ts
+++ b/mobile/src/shared/lib/api.ts
@@ -1,25 +1,40 @@
 /**
  * 共通 HTTP クライアント。
  *
- * 共通ラッパー経由で fetch を利用し、Authorization ヘッダーへ
- * Firebase ID Token を自動で差し込む。
- * トークン取得ロジックは Epic #2 で `authStore` から注入する。
+ * fetch を薄くラップし、以下の責務を持たせる。
+ * - Authorization ヘッダーへ Firebase ID Token を自動で差し込む（自動付与）
+ * - 401 を受けたら refresher を呼んで ID Token を再取得し 1 回だけリトライする（自動更新）
+ *
+ * トークン取得・更新ロジックは `setTokenProvider` / `setTokenRefresher` で差し込む。
+ * 実装は Epic #2（Firebase Auth 初期化）で authStore から注入する。
  */
 import Constants from 'expo-constants';
 
 type TokenProvider = () => Promise<string | null> | string | null;
+type TokenRefresher = () => Promise<string | null>;
 type ApiResponse<T> = {
   data: T;
 };
 
 let tokenProvider: TokenProvider = () => null;
+let tokenRefresher: TokenRefresher | null = null;
 
 /**
  * 認証トークンの取得関数を差し込む。
- * Epic #2 で authStore.getIdToken を渡す想定。
+ * authStore から最新の idToken を読み出す形で渡す想定。
  */
 export function setTokenProvider(provider: TokenProvider): void {
   tokenProvider = provider;
+}
+
+/**
+ * 期限切れトークンの再取得関数を差し込む。
+ * Firebase Auth の `getIdToken(true)` に対応する関数を渡す想定。
+ * 再取得後は authStore に反映してから最新値を return する。
+ * 未設定の場合は 401 リトライを行わない。
+ */
+export function setTokenRefresher(refresher: TokenRefresher | null): void {
+  tokenRefresher = refresher;
 }
 
 const baseURL =
@@ -34,13 +49,15 @@ function buildUrl(path: string): string {
   return `${normalizedBaseUrl}${normalizedPath}`;
 }
 
-async function buildHeaders(init?: HeadersInit): Promise<Headers> {
+async function buildHeaders(init?: HeadersInit, overrideToken?: string | null): Promise<Headers> {
   const headers = new Headers(init);
-  const token = await tokenProvider();
+  const token = overrideToken !== undefined ? overrideToken : await tokenProvider();
 
   headers.set('Accept', 'application/json');
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
+  } else {
+    headers.delete('Authorization');
   }
 
   return headers;
@@ -65,33 +82,57 @@ class ApiClient {
   }
 
   async patch<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
-    const headers = await buildHeaders({ 'Content-Type': 'application/json' });
-
     return this.request<T>(path, {
       method: 'PATCH',
-      headers,
+      headers: { 'Content-Type': 'application/json' },
       body: body === undefined ? undefined : JSON.stringify(body),
     });
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<ApiResponse<T>> {
+    const response = await this.fetchWithAuth(path, init);
+    const data = await parseResponseBody<T>(response);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    return { data };
+  }
+
+  /**
+   * 1 回目を現在のトークンで送り、401 の場合だけ refresher を呼んで再送する。
+   * refresher が未設定、または refresher が null を返したときはそのまま 401 を返す。
+   */
+  private async fetchWithAuth(path: string, init: RequestInit): Promise<Response> {
+    const firstResponse = await this.fetchOnce(path, init);
+    if (firstResponse.status !== 401 || tokenRefresher === null) {
+      return firstResponse;
+    }
+
+    const refreshedToken = await tokenRefresher();
+    if (refreshedToken === null) {
+      return firstResponse;
+    }
+
+    return this.fetchOnce(path, init, refreshedToken);
+  }
+
+  private async fetchOnce(
+    path: string,
+    init: RequestInit,
+    overrideToken?: string | null,
+  ): Promise<Response> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
 
     try {
-      const headers = init.headers instanceof Headers ? init.headers : await buildHeaders(init.headers);
-      const response = await fetch(buildUrl(path), {
+      const headers = await buildHeaders(init.headers, overrideToken);
+      return await fetch(buildUrl(path), {
         ...init,
         headers,
         signal: controller.signal,
       });
-      const data = await parseResponseBody<T>(response);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      return { data };
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         throw new Error('Request timed out');

--- a/mobile/src/shared/lib/firebase.ts
+++ b/mobile/src/shared/lib/firebase.ts
@@ -1,8 +1,18 @@
 /**
- * Firebase Web SDK の初期化。
- * 実際の initializeApp は Epic #2（認証）で行う。
- * ここでは差し込みポイントだけ用意しておく。
+ * Firebase Auth との橋渡し。
+ *
+ * Firebase JS SDK の初期化本体は Epic #2 で導入する。
+ * 本モジュールは ID Token の監視と強制更新の差し込み口だけを公開し、
+ * api.ts と RootLayout がこの口経由で Firebase に依存せずに動くようにする。
+ *
+ * - `subscribeIdTokenChanged(listener)`: Firebase の `onIdTokenChanged` 相当。
+ *   サインイン / サインアウト / トークン更新のたびに通知を受ける。
+ * - `refreshIdToken()`: Firebase の `getIdToken(true)` 相当。
+ *   api クライアントが 401 を受けた際の再取得に使う。
+ * - `registerAuthImpl(impl)`: Epic #2 で Firebase SDK を初期化した際に
+ *   実装を差し込む。差し込みが無い間は subscribe は何もせず、refresh は null を返す。
  */
+
 export type FirebaseConfig = {
   apiKey: string;
   authDomain: string;
@@ -13,4 +23,45 @@ export type FirebaseConfig = {
 export function getFirebaseConfig(): FirebaseConfig | null {
   // Epic #2 で expo-constants から読み込む実装にする
   return null;
+}
+
+export type AuthSession = {
+  uid: string;
+  idToken: string;
+};
+
+export type AuthSessionListener = (session: AuthSession | null) => void;
+export type Unsubscribe = () => void;
+
+export type AuthImpl = {
+  subscribeIdTokenChanged: (listener: AuthSessionListener) => Unsubscribe;
+  refreshIdToken: () => Promise<string | null>;
+};
+
+const NOOP_IMPL: AuthImpl = {
+  subscribeIdTokenChanged: () => () => {},
+  refreshIdToken: async () => null,
+};
+
+let currentImpl: AuthImpl = NOOP_IMPL;
+
+/**
+ * Firebase SDK 側から subscribe / refresh の実装を差し込む。
+ * Epic #2 の Firebase 初期化コードから一度だけ呼ぶ想定。テストでも mock を差し込める。
+ */
+export function registerAuthImpl(impl: AuthImpl): void {
+  currentImpl = impl;
+}
+
+/** 差し込み実装を初期状態に戻す。テストのクリーンアップで使う。 */
+export function resetAuthImpl(): void {
+  currentImpl = NOOP_IMPL;
+}
+
+export function subscribeIdTokenChanged(listener: AuthSessionListener): Unsubscribe {
+  return currentImpl.subscribeIdTokenChanged(listener);
+}
+
+export async function refreshIdToken(): Promise<string | null> {
+  return currentImpl.refreshIdToken();
 }


### PR DESCRIPTION
## Summary
- API リクエストの Authorization ヘッダーへ Firebase ID Token を自動で差し込む仕組みに、401 応答時の自動リトライ（`setTokenRefresher`）を追加
- `firebase.ts` に `subscribeIdTokenChanged` / `refreshIdToken` の差し込み口を用意し、Epic #2 で Firebase SDK を差し込めば自動更新が即機能する形に整えた
- RootLayout で tokenProvider / tokenRefresher / ID Token 監視を配線し、監視結果を `authStore` に反映させることで、AuthGate 配下の `useProfile` が起動時にユーザープロフィールを取得する流れを完成

## 補足
- `/api/v1/users/me` 自体は backend 未実装のため、現時点で起動時取得の対象になるのは既に実装済みの `/users/me/profile`。Epic #2 側で `/users/me` を実装した際に `profileApi` 側の URL を差し替える想定
- Firebase JS SDK 本体の導入は既存コメントどおり Epic #2 に委ねる。本 PR 時点では `registerAuthImpl` 未差し込みでも NOOP で安全に動く（subscribe は no-op、refresh は null 返し）

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`（api.ts の 401 → refresher → リトライ、refresher が null / 未設定のときの挙動、200 時に refresher を呼ばないこと、`firebase.ts` の登録・subscribe・refresh の差し込み挙動を追加）
- [ ] 実機で dev mock サインイン → `/users/me/profile` が起動時に取得されることを確認（Firebase 差し込みは未、dev mock 経由で idToken 注入されるフロー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)