### PR TITLE
feat: ホーム画面から学習セッションを開始する UI と sessions API を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage/
 # AI ツールのローカルキャッシュ（チェックインしたい設定は除外しない）
 .aider*
 .cursorignore.local
+.claude/scheduled_tasks.lock

--- a/backend/db/migrations/versions/a47617ee9c12_create_sessions_table.py
+++ b/backend/db/migrations/versions/a47617ee9c12_create_sessions_table.py
@@ -1,0 +1,57 @@
+"""create sessions table
+
+Revision ID: a47617ee9c12
+Revises: f1bccca64dab
+Create Date: 2026-04-15 16:48:51.353234
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a47617ee9c12"
+down_revision: str | None = "f1bccca64dab"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("subject", sa.String(length=50), nullable=False),
+        sa.Column("topic", sa.String(length=200), nullable=False),
+        sa.Column("input_minutes", sa.Integer(), nullable=False),
+        sa.Column("output_minutes", sa.Integer(), nullable=False),
+        sa.Column("break_minutes", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_sessions_user_id",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("ix_sessions_user_id", "sessions", ["user_id"])
+    op.create_index(
+        "ix_sessions_user_id_started_at",
+        "sessions",
+        ["user_id", sa.text("started_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sessions_user_id_started_at", table_name="sessions")
+    op.drop_index("ix_sessions_user_id", table_name="sessions")
+    op.drop_table("sessions")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -133,15 +133,14 @@ type = "forbidden"
 source_modules = ["src.infrastructure"]
 forbidden_modules = ["src.presentation"]
 
+# presentation は app.state 経由で依存物を受け取るだけに留める。
+# import グラフ上では infrastructure と Composition Root を参照してはならない。
 [[tool.importlinter.contracts]]
-name = "Presentation は infrastructure を直接 import しない（Composition Root 経由のみ）"
+name = "Presentation は infrastructure / Composition Root を import しない"
 type = "forbidden"
 source_modules = ["src.presentation"]
-forbidden_modules = ["src.infrastructure"]
-ignore_imports = [
-    # Composition Root から infrastructure を間接参照する経路は許容する。
-    # presentation は domain の抽象を介してのみ infrastructure の振る舞いを利用する。
-    "src.container -> src.infrastructure.persistence.database",
-    "src.container -> src.infrastructure.persistence.repositories.pg_user_repository",
-    "src.container -> src.infrastructure.auth.firebase_auth",
+forbidden_modules = [
+    "src.infrastructure",
+    "src.container",
+    "src.main",
 ]

--- a/backend/src/application/dto/session_dto.py
+++ b/backend/src/application/dto/session_dto.py
@@ -1,4 +1,38 @@
 """セッション関連ユースケースの入出力 DTO。
 
-実装は Epic #3 で追加する。
+CQRS 的な命名で役割を明示する。
+- `CreateSessionCommand`: セッション作成の意図を表すコマンド
+- `SessionView`: クライアントに返却する読み出し用ビュー
 """
+
+from datetime import datetime
+from uuid import UUID
+
+from src.common.models import FrozenModel
+from src.domain.value_objects.session_status import SessionStatus
+
+
+class CreateSessionCommand(FrozenModel):
+    """POST /sessions の入力コマンド。"""
+
+    subject: str
+    topic: str
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+
+
+class SessionView(FrozenModel):
+    """セッション情報のレスポンス元ビュー。"""
+
+    id: UUID
+    user_id: UUID
+    status: SessionStatus
+    subject: str
+    topic: str
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+    started_at: datetime
+    completed_at: datetime | None
+    created_at: datetime

--- a/backend/src/application/use_cases/create_session.py
+++ b/backend/src/application/use_cases/create_session.py
@@ -1,4 +1,47 @@
-"""セッション作成のユースケース。
+"""POST /sessions の UseCase。"""
 
-実装は Epic #3 で追加する。
-"""
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from src.application.dto.session_dto import CreateSessionCommand, SessionView
+from src.domain.entities.session import Session
+from src.domain.entities.user import User
+from src.domain.repositories.session_repository import SessionRepository
+from src.domain.value_objects.session_status import SessionStatus
+
+
+class CreateSession:
+    """新規 Session を作成し、初期ステータス INPUT で永続化する。"""
+
+    def __init__(self, session_repository: SessionRepository) -> None:
+        self._session_repository = session_repository
+
+    async def execute(self, current_user: User, command: CreateSessionCommand) -> SessionView:
+        now = datetime.now(UTC)
+        session = Session(
+            id=uuid4(),
+            user_id=current_user.id,
+            status=SessionStatus.INPUT,
+            subject=command.subject,
+            topic=command.topic,
+            input_minutes=command.input_minutes,
+            output_minutes=command.output_minutes,
+            break_minutes=command.break_minutes,
+            started_at=now,
+            completed_at=None,
+            created_at=now,
+        )
+        await self._session_repository.add(session)
+        return SessionView(
+            id=session.id,
+            user_id=session.user_id,
+            status=session.status,
+            subject=session.subject,
+            topic=session.topic,
+            input_minutes=session.input_minutes,
+            output_minutes=session.output_minutes,
+            break_minutes=session.break_minutes,
+            started_at=session.started_at,
+            completed_at=session.completed_at,
+            created_at=session.created_at,
+        )

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -6,13 +6,18 @@ presentation からは `request.app.state.container` 経由で参照する。
 
 from pydantic import BaseModel, ConfigDict
 
+from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
+from src.domain.repositories.session_repository import SessionRepository
 from src.domain.repositories.user_repository import UserRepository
 from src.domain.services.auth_verifier import AuthVerifier
 from src.infrastructure.auth.firebase_auth import FirebaseAuthVerifier
 from src.infrastructure.persistence.database import Database
+from src.infrastructure.persistence.repositories.pg_session_repository import (
+    PgSessionRepository,
+)
 from src.infrastructure.persistence.repositories.pg_user_repository import PgUserRepository
 
 
@@ -28,8 +33,10 @@ class Container(BaseModel):
     database: Database
     auth_verifier: AuthVerifier
     user_repository: UserRepository
+    session_repository: SessionRepository
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
+    create_session: CreateSession
 
 
 def build_container(settings: Settings) -> Container:
@@ -37,13 +44,17 @@ def build_container(settings: Settings) -> Container:
     database = Database(database_url=settings.database_url)
     auth_verifier: AuthVerifier = FirebaseAuthVerifier(settings=settings)
     user_repository: UserRepository = PgUserRepository(database=database)
+    session_repository: SessionRepository = PgSessionRepository(database=database)
     get_user_profile = GetUserProfile()
     update_user_profile = UpdateUserProfile(user_repository=user_repository)
+    create_session = CreateSession(session_repository=session_repository)
     return Container(
         settings=settings,
         database=database,
         auth_verifier=auth_verifier,
         user_repository=user_repository,
+        session_repository=session_repository,
         get_user_profile=get_user_profile,
         update_user_profile=update_user_profile,
+        create_session=create_session,
     )

--- a/backend/src/domain/entities/session.py
+++ b/backend/src/domain/entities/session.py
@@ -1,23 +1,28 @@
 """Session エンティティ。学習 1 サイクル（input/output/break/result）。
 
-詳細フィールド（started_at の正確な型, ended_at, timer_settings 等）は
-Epic #3 で追加する。
+要件書 4.3.3 と Issue #13 の方針に従い、subject / topic とユーザ毎のタイマー設定を
+セッション単位で保持する。タイマー設定はユーザ設定（user_settings）の値で初期化された
+うえで、開始時にカスタム値で上書きされる場合があるため、セッション側にも実値を持つ。
 """
 
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
-
+from src.common.models import FrozenModel
 from src.domain.value_objects.session_status import SessionStatus
 
 
-class Session(BaseModel):
+class Session(FrozenModel):
     """学習 1 サイクルを表現するエンティティ。"""
-
-    model_config = ConfigDict(frozen=True)
 
     id: UUID
     user_id: UUID
     status: SessionStatus
+    subject: str
+    topic: str
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
     started_at: datetime
+    completed_at: datetime | None
+    created_at: datetime

--- a/backend/src/infrastructure/persistence/models/session_model.py
+++ b/backend/src/infrastructure/persistence/models/session_model.py
@@ -1,1 +1,36 @@
-"""Session の SQLAlchemy ORM モデル。Epic #3 で実装する。"""
+"""sessions テーブルの SQLAlchemy モデル。要件書 4.3.3 に対応。"""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.models.base import Base
+
+
+class SessionModel(Base):
+    """学習 1 サイクルを表す sessions レコード。"""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    subject: Mapped[str] = mapped_column(String(50), nullable=False)
+    topic: Mapped[str] = mapped_column(String(200), nullable=False)
+    input_minutes: Mapped[int] = mapped_column(Integer(), nullable=False)
+    output_minutes: Mapped[int] = mapped_column(Integer(), nullable=False)
+    break_minutes: Mapped[int] = mapped_column(Integer(), nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/src/infrastructure/persistence/repositories/pg_session_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_session_repository.py
@@ -1,1 +1,53 @@
-"""Session リポジトリの PostgreSQL 実装。Epic #3 で実装する。"""
+"""Session リポジトリの PostgreSQL 実装。
+
+本 PR では Issue #38 / #39 のスコープに合わせて `add` のみ実装する。
+`find_by_id` / `update` / `list_by_user` は Epic #3 の後続 Task で実装するため、
+呼び出された時点で `NotImplementedError` を投げて気づけるようにしておく。
+"""
+
+from uuid import UUID
+
+from src.domain.entities.session import Session
+from src.domain.repositories.session_repository import SessionRepository
+from src.infrastructure.persistence.database import Database
+from src.infrastructure.persistence.models.session_model import SessionModel
+
+
+class PgSessionRepository(SessionRepository):
+    """PostgreSQL 実装。`Database` から都度セッションを開いて操作する。"""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    async def add(self, session: Session) -> None:
+        async with self._database.session() as db_session:
+            db_session.add(
+                SessionModel(
+                    id=session.id,
+                    user_id=session.user_id,
+                    status=session.status.value,
+                    subject=session.subject,
+                    topic=session.topic,
+                    input_minutes=session.input_minutes,
+                    output_minutes=session.output_minutes,
+                    break_minutes=session.break_minutes,
+                    started_at=session.started_at,
+                    completed_at=session.completed_at,
+                    created_at=session.created_at,
+                )
+            )
+            await db_session.commit()
+
+    async def find_by_id(self, session_id: UUID) -> Session | None:
+        raise NotImplementedError("Epic #3 後続 Task で実装する")
+
+    async def update(self, session: Session) -> None:
+        raise NotImplementedError("Epic #3 後続 Task で実装する")
+
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        cursor: str | None,
+        limit: int,
+    ) -> tuple[list[Session], str | None]:
+        raise NotImplementedError("Epic #3 後続 Task で実装する")

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -5,7 +5,9 @@
 
 from fastapi import APIRouter
 
+from src.presentation.api.v1.sessions import sessions_router
 from src.presentation.api.v1.users import users_router
 
 api_v1_router = APIRouter()
 api_v1_router.include_router(users_router)
+api_v1_router.include_router(sessions_router)

--- a/backend/src/presentation/api/v1/sessions.py
+++ b/backend/src/presentation/api/v1/sessions.py
@@ -1,9 +1,57 @@
-"""セッションエンドポイント。Epic #3 で実装する。
+"""セッションエンドポイント。
 
-- POST  /api/v1/sessions
-- GET   /api/v1/sessions/{id}
-- PATCH /api/v1/sessions/{id}
-- GET   /api/v1/sessions
-- POST  /api/v1/sessions/{id}/output
-- GET   /api/v1/sessions/{id}/judgment
+本 PR では Issue #38 / #39 のスコープに合わせて `POST /api/v1/sessions` のみ実装する。
+他エンドポイント（GET / PATCH / output / judgment）は Epic #3 後続 Task で追加する。
 """
+
+from fastapi import APIRouter, Depends, Request, status
+
+from src.application.dto.session_dto import CreateSessionCommand, SessionView
+from src.container import Container
+from src.domain.entities.user import User
+from src.presentation.middleware.auth_middleware import get_current_user
+from src.presentation.schemas.session_schema import (
+    CreateSessionRequest,
+    SessionResponse,
+)
+
+sessions_router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+@sessions_router.post(
+    "",
+    response_model=SessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_session(
+    body: CreateSessionRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> SessionResponse:
+    """新規セッションを作成し、初期ステータス input でレスポンスする。"""
+    container: Container = request.app.state.container
+    command = CreateSessionCommand(
+        subject=body.subject,
+        topic=body.topic,
+        input_minutes=body.input_minutes,
+        output_minutes=body.output_minutes,
+        break_minutes=body.break_minutes,
+    )
+    view = await container.create_session.execute(current_user, command)
+    return _to_response(view)
+
+
+def _to_response(view: SessionView) -> SessionResponse:
+    return SessionResponse(
+        id=view.id,
+        user_id=view.user_id,
+        status=view.status,
+        subject=view.subject,
+        topic=view.topic,
+        input_minutes=view.input_minutes,
+        output_minutes=view.output_minutes,
+        break_minutes=view.break_minutes,
+        started_at=view.started_at,
+        completed_at=view.completed_at,
+        created_at=view.created_at,
+    )

--- a/backend/src/presentation/api/v1/sessions.py
+++ b/backend/src/presentation/api/v1/sessions.py
@@ -7,8 +7,8 @@
 from fastapi import APIRouter, Depends, Request, status
 
 from src.application.dto.session_dto import CreateSessionCommand, SessionView
-from src.container import Container
 from src.domain.entities.user import User
+from src.presentation.container_access import get_presentation_container
 from src.presentation.middleware.auth_middleware import get_current_user
 from src.presentation.schemas.session_schema import (
     CreateSessionRequest,
@@ -29,7 +29,7 @@ async def create_session(
     current_user: User = Depends(get_current_user),  # noqa: B008
 ) -> SessionResponse:
     """新規セッションを作成し、初期ステータス input でレスポンスする。"""
-    container: Container = request.app.state.container
+    container = get_presentation_container(request)
     command = CreateSessionCommand(
         subject=body.subject,
         topic=body.topic,

--- a/backend/src/presentation/api/v1/users.py
+++ b/backend/src/presentation/api/v1/users.py
@@ -7,8 +7,8 @@
 from fastapi import APIRouter, Depends, Request
 
 from src.application.dto.user_dto import UpdateUserProfileCommand, UserProfileView
-from src.container import Container
 from src.domain.entities.user import User
+from src.presentation.container_access import get_presentation_container
 from src.presentation.middleware.auth_middleware import get_current_user
 from src.presentation.schemas.user_schema import (
     UpdateUserProfileRequest,
@@ -24,7 +24,7 @@ async def get_my_profile(
     current_user: User = Depends(get_current_user),  # noqa: B008
 ) -> UserProfileResponse:
     """自分のプロフィールを取得する。未オンボーディング時は onboarding_completed=false。"""
-    container: Container = request.app.state.container
+    container = get_presentation_container(request)
     dto = await container.get_user_profile.execute(current_user)
     return _to_response(dto)
 
@@ -36,7 +36,7 @@ async def update_my_profile(
     current_user: User = Depends(get_current_user),  # noqa: B008
 ) -> UserProfileResponse:
     """プロフィールを更新する。age_group がセットされると onboarding_completed=true になる。"""
-    container: Container = request.app.state.container
+    container = get_presentation_container(request)
     command = UpdateUserProfileCommand(
         display_name=body.display_name,
         age_group=body.age_group,

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -1,0 +1,36 @@
+"""presentation 層から app.state.container を型付きで取得するヘルパ。"""
+
+from abc import ABC, abstractmethod
+from typing import cast
+
+from fastapi import Request
+
+from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.update_user_profile import UpdateUserProfile
+from src.domain.repositories.user_repository import UserRepository
+from src.domain.services.auth_verifier import AuthVerifier
+
+
+class PingableDatabase(ABC):
+    """ヘルスチェックで必要な最小限の DB インタフェース。"""
+
+    @abstractmethod
+    async def ping(self) -> bool:
+        """接続確認を返す。"""
+
+
+class PresentationContainer(ABC):
+    """presentation 層から参照する依存物だけを切り出した型。"""
+
+    database: PingableDatabase
+    auth_verifier: AuthVerifier
+    user_repository: UserRepository
+    get_user_profile: GetUserProfile
+    update_user_profile: UpdateUserProfile
+    create_session: CreateSession
+
+
+def get_presentation_container(request: Request) -> PresentationContainer:
+    """app.state.container を presentation 用の ABC として返す。"""
+    return cast(PresentationContainer, request.app.state.container)

--- a/backend/src/presentation/health.py
+++ b/backend/src/presentation/health.py
@@ -9,7 +9,7 @@ from typing import Literal
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
-from src.container import Container
+from src.presentation.container_access import get_presentation_container
 
 health_router = APIRouter(tags=["health"])
 
@@ -36,7 +36,7 @@ async def health() -> HealthResponse:
 @health_router.get("/health/ready", response_model=ReadinessResponse)
 async def ready(request: Request) -> ReadinessResponse:
     """DB を含む準備完了確認。DB に到達できなければ degraded を返す。"""
-    container: Container = request.app.state.container
+    container = get_presentation_container(request)
     db_ok = await container.database.ping()
     return ReadinessResponse(
         status="ok" if db_ok else "degraded",

--- a/backend/src/presentation/middleware/auth_middleware.py
+++ b/backend/src/presentation/middleware/auth_middleware.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from src.container import Container
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
 from src.domain.services.auth_verifier import (
@@ -20,6 +19,10 @@ from src.domain.services.auth_verifier import (
     VerifiedToken,
 )
 from src.domain.value_objects.auth_provider import AuthProvider
+from src.presentation.container_access import (
+    PresentationContainer,
+    get_presentation_container,
+)
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -36,7 +39,7 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    container: Container = request.app.state.container
+    container = get_presentation_container(request)
     verifier: AuthVerifier = container.auth_verifier
     try:
         verified = verifier.verify_id_token(credentials.credentials)
@@ -53,7 +56,7 @@ async def get_current_user(
     return await _auto_create_user(container, verified)
 
 
-async def _auto_create_user(container: Container, verified: VerifiedToken) -> User:
+async def _auto_create_user(container: PresentationContainer, verified: VerifiedToken) -> User:
     """未登録ユーザを users + user_settings 付きで作成して返す。"""
     now = datetime.now(UTC)
     provider = _to_auth_provider(verified["sign_in_provider"])

--- a/backend/src/presentation/schemas/session_schema.py
+++ b/backend/src/presentation/schemas/session_schema.py
@@ -1,1 +1,39 @@
-"""セッション API の Pydantic スキーマ。Epic #3 で実装する。"""
+"""/api/v1/sessions 系の Pydantic スキーマ。"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from src.common.models import FrozenModel, StrictRequestModel
+from src.domain.value_objects.session_status import SessionStatus
+
+
+class CreateSessionRequest(StrictRequestModel):
+    """POST /sessions の body。
+
+    要件書 4.3.3 の sessions テーブル定義に揃えてバリデーション範囲を決める。
+    タイマーは 1〜120 分の整数を許可する。
+    """
+
+    subject: str = Field(min_length=1, max_length=50)
+    topic: str = Field(min_length=1, max_length=200)
+    input_minutes: int = Field(ge=1, le=120)
+    output_minutes: int = Field(ge=1, le=120)
+    break_minutes: int = Field(ge=1, le=120)
+
+
+class SessionResponse(FrozenModel):
+    """POST /sessions / GET /sessions/{id} のレスポンス。"""
+
+    id: UUID
+    user_id: UUID
+    status: SessionStatus
+    subject: str
+    topic: str
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+    started_at: datetime
+    completed_at: datetime | None
+    created_at: datetime

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@
 
 - `settings` ... テスト用に DB URL などを上書きした Settings
 - `fake_user_repository` ... in-memory UserRepository
+- `fake_session_repository` ... in-memory SessionRepository
 - `fake_auth_verifier` ... 固定挙動の AuthVerifier
 - `container` ... 上記 fake を差し込んだ Container
 - `client` ... 上記 container を注入した FastAPI アプリへ httpx の AsyncClient
@@ -13,6 +14,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
@@ -20,6 +22,7 @@ from src.container import Container
 from src.infrastructure.persistence.database import Database
 from src.main import create_app
 from tests.fakes.fake_auth_verifier import FakeAuthVerifier
+from tests.fakes.fake_session_repository import FakeSessionRepository
 from tests.fakes.fake_user_repository import FakeUserRepository
 
 
@@ -41,6 +44,11 @@ def fake_user_repository() -> FakeUserRepository:
 
 
 @pytest.fixture
+def fake_session_repository() -> FakeSessionRepository:
+    return FakeSessionRepository()
+
+
+@pytest.fixture
 def fake_auth_verifier() -> FakeAuthVerifier:
     return FakeAuthVerifier()
 
@@ -49,6 +57,7 @@ def fake_auth_verifier() -> FakeAuthVerifier:
 def container(
     settings: Settings,
     fake_user_repository: FakeUserRepository,
+    fake_session_repository: FakeSessionRepository,
     fake_auth_verifier: FakeAuthVerifier,
 ) -> Container:
     """fake 実装を差し込んだ Container。"""
@@ -58,8 +67,10 @@ def container(
         database=database,
         auth_verifier=fake_auth_verifier,
         user_repository=fake_user_repository,
+        session_repository=fake_session_repository,
         get_user_profile=GetUserProfile(),
         update_user_profile=UpdateUserProfile(user_repository=fake_user_repository),
+        create_session=CreateSession(session_repository=fake_session_repository),
     )
 
 

--- a/backend/tests/fakes/fake_session_repository.py
+++ b/backend/tests/fakes/fake_session_repository.py
@@ -1,0 +1,31 @@
+"""インメモリな SessionRepository 実装。"""
+
+from uuid import UUID
+
+from src.domain.entities.session import Session
+from src.domain.repositories.session_repository import SessionRepository
+
+
+class FakeSessionRepository(SessionRepository):
+    """in-memory な SessionRepository。テスト以外で使用しない。"""
+
+    def __init__(self) -> None:
+        self.sessions: dict[UUID, Session] = {}
+
+    async def add(self, session: Session) -> None:
+        self.sessions[session.id] = session
+
+    async def find_by_id(self, session_id: UUID) -> Session | None:
+        return self.sessions.get(session_id)
+
+    async def update(self, session: Session) -> None:
+        self.sessions[session.id] = session
+
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        cursor: str | None,  # noqa: ARG002
+        limit: int,
+    ) -> tuple[list[Session], str | None]:
+        items = [s for s in self.sessions.values() if s.user_id == user_id]
+        return items[:limit], None

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -1,0 +1,101 @@
+"""`/api/v1/sessions` の API integration test。
+
+FakeAuthVerifier + FakeSessionRepository 経由で、実 DB / Firebase 無しで経路を検証する。
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+def _valid_body() -> dict[str, object]:
+    return {
+        "subject": "英語",
+        "topic": "関係代名詞",
+        "input_minutes": 20,
+        "output_minutes": 5,
+        "break_minutes": 5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_session_requires_authorization_header(client: AsyncClient):
+    response = await client.post("/api/v1/sessions", json=_valid_body())
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_invalid_token(client: AsyncClient):
+    response = await client.post(
+        "/api/v1/sessions",
+        headers={"Authorization": "Bearer invalid-token"},
+        json=_valid_body(),
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_201_with_session_view(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-001"}
+    response = await client.post("/api/v1/sessions", headers=headers, json=_valid_body())
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "input"
+    assert body["subject"] == "英語"
+    assert body["topic"] == "関係代名詞"
+    assert body["input_minutes"] == 20
+    assert body["output_minutes"] == 5
+    assert body["break_minutes"] == 5
+    assert body["completed_at"] is None
+    assert body["id"]
+    assert body["user_id"]
+    assert body["started_at"]
+    assert body["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_empty_subject(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-002"}
+    payload = _valid_body() | {"subject": ""}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_overlong_subject(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-003"}
+    payload = _valid_body() | {"subject": "あ" * 51}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_overlong_topic(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-004"}
+    payload = _valid_body() | {"topic": "あ" * 201}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_zero_minutes(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-005"}
+    payload = _valid_body() | {"input_minutes": 0}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_too_long_minutes(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-006"}
+    payload = _valid_body() | {"input_minutes": 121}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_session_forbids_extra_fields(client: AsyncClient):
+    headers = {"Authorization": "Bearer user-007"}
+    payload = _valid_body() | {"unknown": "x"}
+    response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422

--- a/backend/tests/unit/test_use_cases/test_create_session.py
+++ b/backend/tests/unit/test_use_cases/test_create_session.py
@@ -1,0 +1,80 @@
+"""CreateSession UseCase の振る舞い。"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from src.application.dto.session_dto import CreateSessionCommand
+from src.application.use_cases.create_session import CreateSession
+from src.domain.entities.user import User
+from src.domain.value_objects.auth_provider import AuthProvider
+from src.domain.value_objects.session_status import SessionStatus
+from tests.fakes.fake_session_repository import FakeSessionRepository
+
+
+def _make_user() -> User:
+    now = datetime.now(UTC)
+    return User(
+        id=uuid4(),
+        firebase_uid="uid-001",
+        auth_provider=AuthProvider.GOOGLE,
+        display_name=None,
+        age_group=None,
+        onboarding_completed=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_input_status_session():
+    repo = FakeSessionRepository()
+    user = _make_user()
+    use_case = CreateSession(session_repository=repo)
+
+    view = await use_case.execute(
+        user,
+        CreateSessionCommand(
+            subject="英語",
+            topic="関係代名詞",
+            input_minutes=20,
+            output_minutes=5,
+            break_minutes=5,
+        ),
+    )
+
+    assert view.user_id == user.id
+    assert view.status is SessionStatus.INPUT
+    assert view.subject == "英語"
+    assert view.topic == "関係代名詞"
+    assert view.input_minutes == 20
+    assert view.output_minutes == 5
+    assert view.break_minutes == 5
+    assert view.completed_at is None
+    assert view.started_at == view.created_at
+    # リポジトリにも保存されている
+    saved = repo.sessions[view.id]
+    assert saved.user_id == user.id
+    assert saved.status is SessionStatus.INPUT
+
+
+@pytest.mark.asyncio
+async def test_create_session_uses_custom_timer_values():
+    repo = FakeSessionRepository()
+    use_case = CreateSession(session_repository=repo)
+
+    view = await use_case.execute(
+        _make_user(),
+        CreateSessionCommand(
+            subject="数学",
+            topic="極限",
+            input_minutes=30,
+            output_minutes=10,
+            break_minutes=3,
+        ),
+    )
+
+    assert view.input_minutes == 30
+    assert view.output_minutes == 10
+    assert view.break_minutes == 3

--- a/mobile/src/features/profile/screens/__tests__/AgeGroupSelectScreen.test.tsx
+++ b/mobile/src/features/profile/screens/__tests__/AgeGroupSelectScreen.test.tsx
@@ -18,7 +18,10 @@ jest.mock('@/features/profile/api/profileApi');
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
   });
   return render(
     <TamaguiProvider config={config} defaultTheme="light">

--- a/mobile/src/features/session/api/sessionApi.ts
+++ b/mobile/src/features/session/api/sessionApi.ts
@@ -1,3 +1,10 @@
 /**
- * セッション関連 API。Epic #3 / Epic #4 で実装する。
+ * POST /api/v1/sessions の API 呼び出し。
  */
+import { api } from '@/shared/lib/api';
+import type { CreateSessionInput, Session } from '@/features/session/types';
+
+export async function createSession(input: CreateSessionInput): Promise<Session> {
+  const { data } = await api.post<Session>('/sessions', input);
+  return data;
+}

--- a/mobile/src/features/session/components/TimerCustomFields.tsx
+++ b/mobile/src/features/session/components/TimerCustomFields.tsx
@@ -1,0 +1,59 @@
+/**
+ * カスタムタイマー入力欄。
+ * input_minutes / output_minutes / break_minutes をそれぞれ数値入力で受け取る。
+ */
+import { Controller, type Control, type FieldErrors } from 'react-hook-form';
+import { Input, SizableText, YStack } from 'tamagui';
+
+type FormShape = {
+  input_minutes: number;
+  output_minutes: number;
+  break_minutes: number;
+};
+
+type Props<T extends FormShape> = {
+  control: Control<T>;
+  errors: FieldErrors<T>;
+};
+
+const FIELDS: { name: keyof FormShape; label: string; testID: string }[] = [
+  { name: 'input_minutes', label: 'インプット (分)', testID: 'home-input-minutes' },
+  { name: 'output_minutes', label: 'アウトプット (分)', testID: 'home-output-minutes' },
+  { name: 'break_minutes', label: '休憩 (分)', testID: 'home-break-minutes' },
+];
+
+export function TimerCustomFields<T extends FormShape>({ control, errors }: Props<T>) {
+  return (
+    <YStack gap="$3">
+      {FIELDS.map((field) => (
+        <YStack key={field.name} gap="$1">
+          <SizableText size="$3">{field.label}</SizableText>
+          <Controller
+            control={control}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            name={field.name as any}
+            render={({ field: { onChange, value } }) => (
+              <Input
+                testID={field.testID}
+                keyboardType="number-pad"
+                value={Number.isFinite(value) ? String(value) : ''}
+                onChangeText={(text) => {
+                  if (text === '') {
+                    onChange(Number.NaN);
+                  } else {
+                    onChange(Number(text));
+                  }
+                }}
+              />
+            )}
+          />
+          {errors[field.name] ? (
+            <SizableText color="$red10" size="$2">
+              {String(errors[field.name]?.message ?? '値が不正です')}
+            </SizableText>
+          ) : null}
+        </YStack>
+      ))}
+    </YStack>
+  );
+}

--- a/mobile/src/features/session/components/TimerPresetSelector.tsx
+++ b/mobile/src/features/session/components/TimerPresetSelector.tsx
@@ -4,7 +4,11 @@
  */
 import { RadioGroup, SizableText, XStack, YStack } from 'tamagui';
 
-import { TIMER_PRESET_KEYS, TIMER_PRESET_LABELS, type TimerPresetKey } from '@/features/session/config';
+import {
+  TIMER_PRESET_KEYS,
+  TIMER_PRESET_LABELS,
+  type TimerPresetKey,
+} from '@/features/session/config';
 
 type Props = {
   value: TimerPresetKey;

--- a/mobile/src/features/session/components/TimerPresetSelector.tsx
+++ b/mobile/src/features/session/components/TimerPresetSelector.tsx
@@ -1,0 +1,36 @@
+/**
+ * セッション開始フォーム用のプリセット選択コンポーネント。
+ * RadioGroup で「おすすめ」と「カスタム」を選ぶ。
+ */
+import { RadioGroup, SizableText, XStack, YStack } from 'tamagui';
+
+import { TIMER_PRESET_KEYS, TIMER_PRESET_LABELS, type TimerPresetKey } from '@/features/session/config';
+
+type Props = {
+  value: TimerPresetKey;
+  onChange: (key: TimerPresetKey) => void;
+};
+
+export function TimerPresetSelector({ value, onChange }: Props) {
+  return (
+    <RadioGroup value={value} onValueChange={(v) => onChange(v as TimerPresetKey)}>
+      <YStack gap="$2">
+        {TIMER_PRESET_KEYS.map((key) => (
+          <XStack key={key} alignItems="center" gap="$3">
+            <RadioGroup.Item
+              value={key}
+              id={`home-preset-${key}`}
+              testID={`home-preset-${key}`}
+              size="$4"
+            >
+              <RadioGroup.Indicator />
+            </RadioGroup.Item>
+            <SizableText htmlFor={`home-preset-${key}`} size="$4">
+              {TIMER_PRESET_LABELS[key]}
+            </SizableText>
+          </XStack>
+        ))}
+      </YStack>
+    </RadioGroup>
+  );
+}

--- a/mobile/src/features/session/config.ts
+++ b/mobile/src/features/session/config.ts
@@ -1,0 +1,24 @@
+/**
+ * セッション開始フォームのデフォルト値とプリセット定義。
+ *
+ * 本来は `user_settings` API（Epic #5 / #6）から取得した値を用いるが、
+ * 当該 API は未実装のため、要件書 4.3.2 の DEFAULT 値（20/5/5）に揃えた定数で代替する。
+ * settings API 実装後は、`useDefaultTimer()` のようなフックでフェッチした値で上書きする想定。
+ */
+
+export const DEFAULT_TIMER = {
+  input_minutes: 20,
+  output_minutes: 5,
+  break_minutes: 5,
+} as const;
+
+export const TIMER_PRESET_KEYS = ['recommended', 'custom'] as const;
+export type TimerPresetKey = (typeof TIMER_PRESET_KEYS)[number];
+
+export const TIMER_PRESET_LABELS: Record<TimerPresetKey, string> = {
+  recommended: 'おすすめ (インプット20分 / アウトプット5分 / 休憩5分)',
+  custom: 'カスタム',
+};
+
+export const TIMER_MIN = 1;
+export const TIMER_MAX = 120;

--- a/mobile/src/features/session/hooks/useCreateSession.ts
+++ b/mobile/src/features/session/hooks/useCreateSession.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /sessions のための useMutation hook。
+ * 成功時はそのまま `/session/{id}/input` に push 遷移する。
+ */
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+
+import { createSession } from '@/features/session/api/sessionApi';
+import type { CreateSessionInput, Session } from '@/features/session/types';
+
+export function useCreateSession() {
+  const router = useRouter();
+  return useMutation<Session, Error, CreateSessionInput>({
+    mutationFn: (input) => createSession(input),
+    onSuccess: (session) => {
+      router.push(`/session/${session.id}/input`);
+    },
+  });
+}

--- a/mobile/src/features/session/screens/HomeScreen.tsx
+++ b/mobile/src/features/session/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@
  * 送信成功時は `useCreateSession` 内で `/session/{id}/input` に push 遷移する。
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { Button, H2, Input, Paragraph, SizableText, Spinner, TextArea, YStack } from 'tamagui';
@@ -57,6 +57,7 @@ type FormValues = z.infer<typeof schema>;
 
 export function HomeScreen() {
   const createSession = useCreateSession();
+  const previousPresetRef = useRef<TimerPresetKey | null>(null);
   const {
     control,
     handleSubmit,
@@ -78,7 +79,10 @@ export function HomeScreen() {
   const preset: TimerPresetKey = watch('preset');
 
   useEffect(() => {
-    if (preset === 'recommended') {
+    const previousPreset = previousPresetRef.current;
+    previousPresetRef.current = preset;
+
+    if (preset === 'recommended' && previousPreset === 'custom') {
       setValue('input_minutes', DEFAULT_TIMER.input_minutes, { shouldValidate: true });
       setValue('output_minutes', DEFAULT_TIMER.output_minutes, { shouldValidate: true });
       setValue('break_minutes', DEFAULT_TIMER.break_minutes, { shouldValidate: true });
@@ -165,9 +169,7 @@ export function HomeScreen() {
             />
           </YStack>
 
-          {preset === 'custom' ? (
-            <TimerCustomFields control={control} errors={errors} />
-          ) : null}
+          {preset === 'custom' ? <TimerCustomFields control={control} errors={errors} /> : null}
 
           {createSession.error ? (
             <SizableText color="$red10" size="$3">

--- a/mobile/src/features/session/screens/HomeScreen.tsx
+++ b/mobile/src/features/session/screens/HomeScreen.tsx
@@ -1,9 +1,190 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * ホーム画面。subject / topic / 時間設定を入力してセッションを開始する。
+ *
+ * デフォルト時間（おすすめプリセット）は `config.ts` の DEFAULT_TIMER から取得する。
+ * 将来 user_settings API（Epic #5 / #6）が実装されたら同フックで取得した値で置き換える。
+ *
+ * 送信成功時は `useCreateSession` 内で `/session/{id}/input` に push 遷移する。
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { Button, H2, Input, Paragraph, SizableText, Spinner, TextArea, YStack } from 'tamagui';
+import { z } from 'zod';
+
+import { TimerCustomFields } from '@/features/session/components/TimerCustomFields';
+import { TimerPresetSelector } from '@/features/session/components/TimerPresetSelector';
+import {
+  DEFAULT_TIMER,
+  TIMER_MAX,
+  TIMER_MIN,
+  TIMER_PRESET_KEYS,
+  type TimerPresetKey,
+} from '@/features/session/config';
+import { useCreateSession } from '@/features/session/hooks/useCreateSession';
+
+const schema = z.object({
+  subject: z
+    .string()
+    .trim()
+    .min(1, '科目を入力してください')
+    .max(50, '科目は 50 文字以内で入力してください'),
+  topic: z
+    .string()
+    .trim()
+    .min(1, 'トピックを入力してください')
+    .max(200, 'トピックは 200 文字以内で入力してください'),
+  preset: z.enum(TIMER_PRESET_KEYS),
+  input_minutes: z
+    .number({ invalid_type_error: 'インプット時間を入力してください' })
+    .int('整数で入力してください')
+    .min(TIMER_MIN, `${TIMER_MIN} 分以上にしてください`)
+    .max(TIMER_MAX, `${TIMER_MAX} 分以下にしてください`),
+  output_minutes: z
+    .number({ invalid_type_error: 'アウトプット時間を入力してください' })
+    .int('整数で入力してください')
+    .min(TIMER_MIN, `${TIMER_MIN} 分以上にしてください`)
+    .max(TIMER_MAX, `${TIMER_MAX} 分以下にしてください`),
+  break_minutes: z
+    .number({ invalid_type_error: '休憩時間を入力してください' })
+    .int('整数で入力してください')
+    .min(TIMER_MIN, `${TIMER_MIN} 分以上にしてください`)
+    .max(TIMER_MAX, `${TIMER_MAX} 分以下にしてください`),
+});
+
+type FormValues = z.infer<typeof schema>;
 
 export function HomeScreen() {
+  const createSession = useCreateSession();
+  const {
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      subject: '',
+      topic: '',
+      preset: 'recommended',
+      ...DEFAULT_TIMER,
+    },
+  });
+
+  const preset: TimerPresetKey = watch('preset');
+
+  useEffect(() => {
+    if (preset === 'recommended') {
+      setValue('input_minutes', DEFAULT_TIMER.input_minutes, { shouldValidate: true });
+      setValue('output_minutes', DEFAULT_TIMER.output_minutes, { shouldValidate: true });
+      setValue('break_minutes', DEFAULT_TIMER.break_minutes, { shouldValidate: true });
+    }
+  }, [preset, setValue]);
+
+  const onSubmit = handleSubmit((values) => {
+    createSession.mutate({
+      subject: values.subject,
+      topic: values.topic,
+      input_minutes: values.input_minutes,
+      output_minutes: values.output_minutes,
+      break_minutes: values.break_minutes,
+    });
+  });
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>ホーム (placeholder)</H1>
-    </YStack>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
+        <YStack flex={1} padding="$4" gap="$4">
+          <YStack gap="$2">
+            <H2>セッションを開始</H2>
+            <Paragraph theme="alt2">
+              科目とトピック、時間設定を入力して学習サイクルを始めましょう。
+            </Paragraph>
+          </YStack>
+
+          <YStack gap="$1">
+            <SizableText size="$3">科目</SizableText>
+            <Controller
+              control={control}
+              name="subject"
+              render={({ field: { onChange, value } }) => (
+                <Input
+                  testID="home-subject-input"
+                  placeholder="例: 英語"
+                  value={value}
+                  onChangeText={onChange}
+                  maxLength={50}
+                />
+              )}
+            />
+            {errors.subject ? (
+              <SizableText color="$red10" size="$2">
+                {errors.subject.message}
+              </SizableText>
+            ) : null}
+          </YStack>
+
+          <YStack gap="$1">
+            <SizableText size="$3">トピック</SizableText>
+            <Controller
+              control={control}
+              name="topic"
+              render={({ field: { onChange, value } }) => (
+                <TextArea
+                  testID="home-topic-input"
+                  placeholder="例: 関係代名詞 (who / which) の使い分け"
+                  value={value}
+                  onChangeText={onChange}
+                  maxLength={200}
+                  minHeight={88}
+                />
+              )}
+            />
+            {errors.topic ? (
+              <SizableText color="$red10" size="$2">
+                {errors.topic.message}
+              </SizableText>
+            ) : null}
+          </YStack>
+
+          <YStack gap="$2">
+            <SizableText size="$3">時間設定</SizableText>
+            <Controller
+              control={control}
+              name="preset"
+              render={({ field: { onChange, value } }) => (
+                <TimerPresetSelector value={value} onChange={onChange} />
+              )}
+            />
+          </YStack>
+
+          {preset === 'custom' ? (
+            <TimerCustomFields control={control} errors={errors} />
+          ) : null}
+
+          {createSession.error ? (
+            <SizableText color="$red10" size="$3">
+              セッションの開始に失敗しました。通信環境を確認してもう一度お試しください。
+            </SizableText>
+          ) : null}
+
+          <Button
+            onPress={onSubmit}
+            disabled={createSession.isPending}
+            themeInverse
+            testID="home-start-button"
+          >
+            {createSession.isPending ? <Spinner /> : '開始する'}
+          </Button>
+        </YStack>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }

--- a/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * HomeScreen の基本的な振る舞いを検証する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { HomeScreen } from '@/features/session/screens/HomeScreen';
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/features/session/api/sessionApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('HomeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('初期表示は preset=recommended、subject / topic は空でカスタム入力欄は表示しない', () => {
+    const { getByTestId, queryByTestId } = renderWithProviders(<HomeScreen />);
+
+    expect(getByTestId('home-subject-input').props.value).toBe('');
+    expect(getByTestId('home-topic-input').props.value).toBe('');
+    expect(queryByTestId('home-input-minutes')).toBeNull();
+    expect(queryByTestId('home-output-minutes')).toBeNull();
+    expect(queryByTestId('home-break-minutes')).toBeNull();
+  });
+
+  it('subject / topic 未入力で start を押しても createSession は呼ばれない', async () => {
+    const { getByTestId } = renderWithProviders(<HomeScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('home-start-button'));
+    });
+    expect(sessionApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('preset を custom にするとカスタム入力欄が表示される', async () => {
+    const { getByTestId, findByTestId } = renderWithProviders(<HomeScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('home-preset-custom'));
+    });
+    expect(await findByTestId('home-input-minutes')).toBeTruthy();
+    expect(getByTestId('home-output-minutes')).toBeTruthy();
+    expect(getByTestId('home-break-minutes')).toBeTruthy();
+  });
+
+  it('正常入力で start を押すと createSession が呼ばれ、成功時に push 遷移する', async () => {
+    (sessionApi.createSession as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      user_id: 'usr-1',
+      status: 'input',
+      subject: '英語',
+      topic: '関係代名詞',
+      input_minutes: 20,
+      output_minutes: 5,
+      break_minutes: 5,
+      started_at: '2026-04-15T10:00:00Z',
+      completed_at: null,
+      created_at: '2026-04-15T10:00:00Z',
+    });
+
+    const { getByTestId } = renderWithProviders(<HomeScreen />);
+    await act(async () => {
+      fireEvent.changeText(getByTestId('home-subject-input'), '英語');
+      fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('home-start-button'));
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.createSession).toHaveBeenCalledWith({
+        subject: '英語',
+        topic: '関係代名詞',
+        input_minutes: 20,
+        output_minutes: 5,
+        break_minutes: 5,
+      });
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/session/ses-123/input');
+    });
+  });
+
+  it('カスタム時間で start を押すとカスタム値が createSession に渡る', async () => {
+    (sessionApi.createSession as jest.Mock).mockResolvedValue({
+      id: 'ses-456',
+      user_id: 'usr-1',
+      status: 'input',
+      subject: '数学',
+      topic: '極限',
+      input_minutes: 30,
+      output_minutes: 10,
+      break_minutes: 3,
+      started_at: '2026-04-15T11:00:00Z',
+      completed_at: null,
+      created_at: '2026-04-15T11:00:00Z',
+    });
+
+    const { getByTestId } = renderWithProviders(<HomeScreen />);
+    await act(async () => {
+      fireEvent.changeText(getByTestId('home-subject-input'), '数学');
+      fireEvent.changeText(getByTestId('home-topic-input'), '極限');
+      fireEvent.press(getByTestId('home-preset-custom'));
+    });
+    await act(async () => {
+      fireEvent.changeText(getByTestId('home-input-minutes'), '30');
+      fireEvent.changeText(getByTestId('home-output-minutes'), '10');
+      fireEvent.changeText(getByTestId('home-break-minutes'), '3');
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('home-start-button'));
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.createSession).toHaveBeenCalledWith({
+        subject: '数学',
+        topic: '極限',
+        input_minutes: 30,
+        output_minutes: 10,
+        break_minutes: 3,
+      });
+    });
+  });
+
+  it('createSession が失敗するとエラー文言が表示される', async () => {
+    (sessionApi.createSession as jest.Mock).mockRejectedValue(new Error('HTTP 500'));
+
+    const { getByTestId, findByText } = renderWithProviders(<HomeScreen />);
+    await act(async () => {
+      fireEvent.changeText(getByTestId('home-subject-input'), '英語');
+      fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('home-start-button'));
+    });
+
+    expect(await findByText(/セッションの開始に失敗しました/)).toBeTruthy();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
@@ -1,8 +1,12 @@
 /**
  * HomeScreen の基本的な振る舞いを検証する。
+ *
+ * react-hook-form + zodResolver の validation は非同期で errors state を更新するため、
+ * `fireEvent` 直後ではなく `findBy*` / `waitFor` で UI への反映を待ってから assertion する
+ * ことで act(...) 警告を回避する。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
@@ -19,7 +23,10 @@ jest.mock('@/features/session/api/sessionApi');
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
   });
   return render(
     <TamaguiProvider config={config} defaultTheme="light">
@@ -44,18 +51,16 @@ describe('HomeScreen', () => {
   });
 
   it('subject / topic 未入力で start を押しても createSession は呼ばれない', async () => {
-    const { getByTestId } = renderWithProviders(<HomeScreen />);
-    await act(async () => {
-      fireEvent.press(getByTestId('home-start-button'));
-    });
+    const { getByTestId, findByText } = renderWithProviders(<HomeScreen />);
+    fireEvent.press(getByTestId('home-start-button'));
+    // バリデーションエラー表示を待つことで、非同期の errors state 更新の完了を待つ
+    expect(await findByText('科目を入力してください')).toBeTruthy();
     expect(sessionApi.createSession).not.toHaveBeenCalled();
   });
 
   it('preset を custom にするとカスタム入力欄が表示される', async () => {
     const { getByTestId, findByTestId } = renderWithProviders(<HomeScreen />);
-    await act(async () => {
-      fireEvent.press(getByTestId('home-preset-custom'));
-    });
+    fireEvent.press(getByTestId('home-preset-custom'));
     expect(await findByTestId('home-input-minutes')).toBeTruthy();
     expect(getByTestId('home-output-minutes')).toBeTruthy();
     expect(getByTestId('home-break-minutes')).toBeTruthy();
@@ -77,13 +82,9 @@ describe('HomeScreen', () => {
     });
 
     const { getByTestId } = renderWithProviders(<HomeScreen />);
-    await act(async () => {
-      fireEvent.changeText(getByTestId('home-subject-input'), '英語');
-      fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
-    });
-    await act(async () => {
-      fireEvent.press(getByTestId('home-start-button'));
-    });
+    fireEvent.changeText(getByTestId('home-subject-input'), '英語');
+    fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
+    fireEvent.press(getByTestId('home-start-button'));
 
     await waitFor(() => {
       expect(sessionApi.createSession).toHaveBeenCalledWith({
@@ -114,20 +115,16 @@ describe('HomeScreen', () => {
       created_at: '2026-04-15T11:00:00Z',
     });
 
-    const { getByTestId } = renderWithProviders(<HomeScreen />);
-    await act(async () => {
-      fireEvent.changeText(getByTestId('home-subject-input'), '数学');
-      fireEvent.changeText(getByTestId('home-topic-input'), '極限');
-      fireEvent.press(getByTestId('home-preset-custom'));
-    });
-    await act(async () => {
-      fireEvent.changeText(getByTestId('home-input-minutes'), '30');
-      fireEvent.changeText(getByTestId('home-output-minutes'), '10');
-      fireEvent.changeText(getByTestId('home-break-minutes'), '3');
-    });
-    await act(async () => {
-      fireEvent.press(getByTestId('home-start-button'));
-    });
+    const { getByTestId, findByTestId } = renderWithProviders(<HomeScreen />);
+    fireEvent.changeText(getByTestId('home-subject-input'), '数学');
+    fireEvent.changeText(getByTestId('home-topic-input'), '極限');
+    fireEvent.press(getByTestId('home-preset-custom'));
+    // カスタム入力欄の表示を待ってから値を入れる
+    await findByTestId('home-input-minutes');
+    fireEvent.changeText(getByTestId('home-input-minutes'), '30');
+    fireEvent.changeText(getByTestId('home-output-minutes'), '10');
+    fireEvent.changeText(getByTestId('home-break-minutes'), '3');
+    fireEvent.press(getByTestId('home-start-button'));
 
     await waitFor(() => {
       expect(sessionApi.createSession).toHaveBeenCalledWith({
@@ -144,13 +141,9 @@ describe('HomeScreen', () => {
     (sessionApi.createSession as jest.Mock).mockRejectedValue(new Error('HTTP 500'));
 
     const { getByTestId, findByText } = renderWithProviders(<HomeScreen />);
-    await act(async () => {
-      fireEvent.changeText(getByTestId('home-subject-input'), '英語');
-      fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
-    });
-    await act(async () => {
-      fireEvent.press(getByTestId('home-start-button'));
-    });
+    fireEvent.changeText(getByTestId('home-subject-input'), '英語');
+    fireEvent.changeText(getByTestId('home-topic-input'), '関係代名詞');
+    fireEvent.press(getByTestId('home-start-button'));
 
     expect(await findByText(/セッションの開始に失敗しました/)).toBeTruthy();
     expect(mockPush).not.toHaveBeenCalled();

--- a/mobile/src/features/session/types.ts
+++ b/mobile/src/features/session/types.ts
@@ -1,0 +1,36 @@
+/**
+ * セッション関連の共通型。
+ * backend の `src/domain/value_objects/session_status.py` および
+ * `src/presentation/schemas/session_schema.py` と対応する。
+ */
+
+export const SESSION_STATUSES = [
+  'input',
+  'output',
+  'judging',
+  'judged',
+  'cancelled',
+] as const;
+export type SessionStatus = (typeof SESSION_STATUSES)[number];
+
+export type Session = {
+  id: string;
+  user_id: string;
+  status: SessionStatus;
+  subject: string;
+  topic: string;
+  input_minutes: number;
+  output_minutes: number;
+  break_minutes: number;
+  started_at: string;
+  completed_at: string | null;
+  created_at: string;
+};
+
+export type CreateSessionInput = {
+  subject: string;
+  topic: string;
+  input_minutes: number;
+  output_minutes: number;
+  break_minutes: number;
+};

--- a/mobile/src/features/session/types.ts
+++ b/mobile/src/features/session/types.ts
@@ -4,13 +4,7 @@
  * `src/presentation/schemas/session_schema.py` と対応する。
  */
 
-export const SESSION_STATUSES = [
-  'input',
-  'output',
-  'judging',
-  'judged',
-  'cancelled',
-] as const;
+export const SESSION_STATUSES = ['input', 'output', 'judging', 'judged', 'cancelled'] as const;
 export type SessionStatus = (typeof SESSION_STATUSES)[number];
 
 export type Session = {

--- a/mobile/src/shared/components/__tests__/Button.test.tsx
+++ b/mobile/src/shared/components/__tests__/Button.test.tsx
@@ -2,19 +2,35 @@
  * Button が Tamagui の Provider 配下でレンダリングできることを確認する最低限のテスト。
  * 後続 Epic で variant / interaction のテストを追加する。
  */
-import { render } from '@testing-library/react-native';
+import { act, render } from '@testing-library/react-native';
 import { TamaguiProvider } from 'tamagui';
 
 import config from '../../../../tamagui.config';
 import { Button } from '../Button';
 
 describe('Button', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
   it('children を表示する', () => {
     const { getByText } = render(
       <TamaguiProvider config={config} defaultTheme="light">
         <Button testID="primary-button">送信</Button>
       </TamaguiProvider>,
     );
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     expect(getByText('送信')).toBeTruthy();
   });
 });

--- a/mobile/src/shared/lib/__tests__/api.test.ts
+++ b/mobile/src/shared/lib/__tests__/api.test.ts
@@ -100,6 +100,43 @@ describe('api', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('post は Content-Type: application/json と JSON 化した body を送る', async () => {
+    setTokenProvider(() => 'token-initial');
+    fetchMock.mockResolvedValueOnce(jsonResponse(201, { id: 'ses-1' }));
+
+    const result = await api.post<{ id: string }>('/sessions', {
+      subject: '英語',
+      input_minutes: 20,
+    });
+
+    expect(result.data).toEqual({ id: 'ses-1' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]![1]!;
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ subject: '英語', input_minutes: 20 }));
+    const headers = init.headers as Headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('Authorization')).toBe('Bearer token-initial');
+  });
+
+  it('post も 401 を受けたら tokenRefresher 経由で 1 回だけ再送する', async () => {
+    setTokenProvider(() => 'token-expired');
+    const refresher = jest.fn<Promise<string | null>, []>().mockResolvedValue('token-fresh');
+    setTokenRefresher(refresher);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }))
+      .mockResolvedValueOnce(jsonResponse(201, { id: 'ses-2' }));
+
+    const result = await api.post<{ id: string }>('/sessions', { subject: 's' });
+
+    expect(result.data).toEqual({ id: 'ses-2' });
+    expect(refresher).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getAuthHeader(fetchMock.mock.calls[0]!)).toBe('Bearer token-expired');
+    expect(getAuthHeader(fetchMock.mock.calls[1]!)).toBe('Bearer token-fresh');
+  });
+
   it('200 のときは tokenRefresher を呼ばない', async () => {
     setTokenProvider(() => 'token-initial');
     const refresher = jest.fn<Promise<string | null>, []>().mockResolvedValue('token-fresh');

--- a/mobile/src/shared/lib/api.ts
+++ b/mobile/src/shared/lib/api.ts
@@ -81,6 +81,14 @@ class ApiClient {
     return this.request<T>(path, { method: 'GET' });
   }
 
+  async post<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
+    return this.request<T>(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  }
+
   async patch<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
     return this.request<T>(path, {
       method: 'PATCH',


### PR DESCRIPTION
## Summary
- ホーム画面に subject / topic 入力欄と「おすすめ / カスタム」の時間設定フォームを実装し、`POST /api/v1/sessions` を呼んで `/session/{id}/input` に遷移するフローを完成させる
- 依存先の `POST /api/v1/sessions`（Issue #38）を最小実装として同梱。Session エンティティを subject / topic / timer / completed_at 込みに拡張し、Alembic で sessions テーブルを追加
- mobile の HTTP クライアントに `post` メソッドを追加（既存 fetch ラッパー方針を踏襲、axios 不使用）

## Closes
- Closes #38
- Closes #39

## 補足
- `SessionRepository.find_by_id` / `update` / `list_by_user` は Epic #3 後続 Task で実装するため `NotImplementedError` で残している
- `user_settings` API（Epic #5 / #6）は未実装のため、デフォルト時間は `mobile/src/features/session/config.ts` の `DEFAULT_TIMER` 定数で代替（要件書 4.3.2 の DEFAULT 値 20/5/5 に合わせる）
- 要件書 3.3.1 / 4.3.3 の subject / topic 追記は #70 で対応予定

## Test plan
- [x] backend: `cd backend && uv run pytest && uv run ruff check . && uv run ruff format --check .` 全部緑
- [x] mobile: `cd mobile && npm run typecheck && npm run lint && npm test` 全部緑（22 tests / 5 suites）
- [ ] 手動 E2E:
  - [ ] `cd backend && uv run alembic upgrade head` で sessions テーブル作成
  - [ ] `DEV_MOCK_AUTH_ENABLED=true uv run uvicorn src.main:app --reload --host 0.0.0.0 --port 8080` で起動
  - [ ] mobile を起動し、サインイン画面 → `[dev] テストユーザーでログイン` → 年代選択（初回のみ）→ ホーム画面
  - [ ] subject / topic 入力 + おすすめプリセットで「開始する」→ `/session/{id}/input` に遷移し、URL に UUID が乗ること
  - [ ] カスタムプリセットで input/output/break を 1〜120 範囲で変更 → 開始 → 同上の遷移
  - [ ] subject / topic 空欄 / 数値範囲外でバリデーションエラーが UI に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)