### PR TITLE
feat(mobile): 共通タイマー基盤 (timerStore / useTimer / Timer) を実装

### DIFF
--- a/mobile/src/features/session/components/Timer.tsx
+++ b/mobile/src/features/session/components/Timer.tsx
@@ -1,8 +1,27 @@
 /**
- * ポモドーロ風タイマー UI。Epic #3 で実装する。
+ * 画面共通の `MM:SS` タイマー表示コンポーネント。
+ *
+ * 表示に徹し、pause/resume 等の操作は呼び出し側 (画面) で `useTimer()` 経由で行う。
+ * 本コンポーネントは interval 駆動を持たず、`useTimerStore` の selector で
+ * `remainingSeconds` だけを購読するため、同一画面で `useTimer({ onComplete })` を
+ * 併用しても interval が二重に走らない。
  */
-import { Text } from 'tamagui';
+import type { ComponentProps } from 'react';
+import { SizableText } from 'tamagui';
 
-export function Timer() {
-  return <Text>00:00</Text>;
+import { formatMmSs } from '@/features/session/hooks/useTimer';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+export type TimerProps = {
+  size?: ComponentProps<typeof SizableText>['size'];
+  testID?: string;
+};
+
+export function Timer({ size = '$10', testID = 'timer-display' }: TimerProps) {
+  const remainingSeconds = useTimerStore((s) => s.remainingSeconds);
+  return (
+    <SizableText size={size} testID={testID} fontWeight="700">
+      {formatMmSs(remainingSeconds)}
+    </SizableText>
+  );
 }

--- a/mobile/src/features/session/components/__tests__/Timer.test.tsx
+++ b/mobile/src/features/session/components/__tests__/Timer.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * `Timer` コンポーネントが `timerStore` の `remainingSeconds` を購読し、
+ * `MM:SS` 形式で表示することを検証する。
+ *
+ * Tamagui の `SizableText` を使うため `TamaguiProvider` 配下でレンダする。
+ */
+import { act, render } from '@testing-library/react-native';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import { Timer } from '../Timer';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+function renderTimer(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>,
+  );
+}
+
+describe('Timer', () => {
+  beforeEach(() => {
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('初期状態は 00:00 を表示する', () => {
+    const { getByText } = renderTimer(<Timer />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByText('00:00')).toBeTruthy();
+  });
+
+  it('remainingSeconds=1200 のときに 20:00 を表示する', () => {
+    useTimerStore.setState({
+      phase: 'input',
+      status: 'paused',
+      totalSeconds: 1200,
+      remainingSeconds: 1200,
+    });
+    const { getByText } = renderTimer(<Timer />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByText('20:00')).toBeTruthy();
+  });
+
+  it('store の更新に追従して再レンダリングされる (ゼロパディング含む)', () => {
+    const { getByText } = renderTimer(<Timer />);
+    act(() => {
+      useTimerStore.setState({ remainingSeconds: 65 });
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByText('01:05')).toBeTruthy();
+
+    act(() => {
+      useTimerStore.setState({ remainingSeconds: 9 });
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByText('00:09')).toBeTruthy();
+  });
+
+  it('testID で取得できる (デフォルトは timer-display)', () => {
+    const { getByTestId } = renderTimer(<Timer />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByTestId('timer-display')).toBeTruthy();
+  });
+
+  it('testID を明示指定できる', () => {
+    const { getByTestId } = renderTimer(<Timer testID="custom-timer" />);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(getByTestId('custom-timer')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/session/hooks/__tests__/useTimer.test.tsx
+++ b/mobile/src/features/session/hooks/__tests__/useTimer.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * `useTimer` の挙動を fakeTimers ベースで検証する。
+ * - interval 駆動での remainingSeconds 減少
+ * - pause / resume
+ * - 完了時の onComplete が冪等に 1 度だけ呼ばれる
+ * - unmount 時の cleanup
+ * - onComplete の差し替えが反映される (ref 経由)
+ */
+import { act, renderHook } from '@testing-library/react-native';
+
+import { formatMmSs, useTimer } from '../useTimer';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+describe('formatMmSs', () => {
+  it.each([
+    [0, '00:00'],
+    [9, '00:09'],
+    [59, '00:59'],
+    [60, '01:00'],
+    [65, '01:05'],
+    [1200, '20:00'],
+    [3661, '61:01'],
+    [-5, '00:00'],
+  ])('%i 秒は "%s" にフォーマットされる', (input, expected) => {
+    expect(formatMmSs(input)).toBe(expected);
+  });
+});
+
+describe('useTimer', () => {
+  beforeEach(() => {
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('start 後に時間経過で remainingSeconds が減り、formatted も更新される', () => {
+    const { result } = renderHook(() => useTimer());
+    act(() => {
+      result.current.start('input', 5);
+    });
+    expect(result.current.remainingSeconds).toBe(5);
+    expect(result.current.formatted).toBe('00:05');
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(result.current.remainingSeconds).toBe(2);
+    expect(result.current.formatted).toBe('00:02');
+  });
+
+  it('pause 中は時間経過で減らず、resume 後に再開する', () => {
+    const { result } = renderHook(() => useTimer());
+    act(() => {
+      result.current.start('input', 10);
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.remainingSeconds).toBe(8);
+
+    act(() => {
+      result.current.pause();
+    });
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.remainingSeconds).toBe(8);
+
+    act(() => {
+      result.current.resume();
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.remainingSeconds).toBe(6);
+  });
+
+  it('0 秒到達で onComplete が phase 付きで 1 度だけ呼ばれる', () => {
+    const onComplete = jest.fn();
+    const { result } = renderHook(() => useTimer({ onComplete }));
+    act(() => {
+      result.current.start('input', 2);
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('input');
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmount で interval が解除され、その後は store の値が進まない', () => {
+    const { result, unmount } = renderHook(() => useTimer());
+    act(() => {
+      result.current.start('input', 10);
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(useTimerStore.getState().remainingSeconds).toBe(9);
+
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(useTimerStore.getState().remainingSeconds).toBe(9);
+  });
+
+  it('onComplete を差し替えると最新のコールバックが呼ばれる', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ cb }: { cb: (phase: 'idle' | 'input' | 'output' | 'break') => void }) =>
+        useTimer({ onComplete: cb }),
+      { initialProps: { cb: first } },
+    );
+    act(() => {
+      result.current.start('input', 2);
+    });
+    rerender({ cb: second });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledWith('input');
+  });
+
+  it('complete() を呼ぶと onComplete が発火し remainingSeconds が 0 になる', () => {
+    const onComplete = jest.fn();
+    const { result } = renderHook(() => useTimer({ onComplete }));
+    act(() => {
+      result.current.start('output', 30);
+    });
+    act(() => {
+      result.current.complete();
+    });
+    expect(result.current.status).toBe('completed');
+    expect(result.current.remainingSeconds).toBe(0);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('output');
+  });
+
+  it('reset で idle に戻り、再度 start して完了すると onComplete が再発火する', () => {
+    const onComplete = jest.fn();
+    const { result } = renderHook(() => useTimer({ onComplete }));
+    act(() => {
+      result.current.start('input', 1);
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe('idle');
+
+    act(() => {
+      result.current.start('break', 1);
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onComplete).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenLastCalledWith('break');
+  });
+});

--- a/mobile/src/features/session/hooks/useTimer.ts
+++ b/mobile/src/features/session/hooks/useTimer.ts
@@ -1,8 +1,107 @@
 /**
- * タイマーロジック。Epic #3 で実装する。
+ * タイマー駆動ロジック。
+ *
+ * 責務:
+ * - `timerStore` の状態 (phase / status / 残秒数) を React 側に橋渡しする
+ * - `status === 'running'` の間だけ 1 秒ごとに `store.tick()` を呼ぶ interval を回す
+ * - フェーズ完了 (`completionToken` の増加) を検知して `onComplete` を 1 度だけ呼ぶ
+ *
+ * 運用上の注意:
+ * - 同一画面で `useTimer({ onComplete })` を呼ぶのは 1 箇所に絞ること。複数の hook
+ *   インスタンスが interval を個別に所有すると、1 秒に複数回 tick が走る可能性がある。
+ *   UI の時刻表示は `Timer` コンポーネントのように `useTimerStore` を直接購読する
+ *   形で実装する。
+ * - JS がバックグラウンドに入ると `setInterval` が止まる問題は本タスクのスコープ外。
+ *   後続タスクで `Date.now()` ベースの再計算を導入する想定。
  */
-import { useTimerStore } from '@/shared/stores/timerStore';
+import { useCallback, useEffect, useRef } from 'react';
 
-export function useTimer() {
-  return useTimerStore();
+import { useTimerStore, type TimerPhase, type TimerStatus } from '@/shared/stores/timerStore';
+
+export type UseTimerOptions = {
+  /**
+   * フェーズが完了した瞬間に呼ばれるコールバック。`completionToken` の変化に同期し、
+   * 1 つの hook インスタンスにつき完了 1 回ごとに 1 回だけ呼ばれる。
+   */
+  onComplete?: (phase: TimerPhase) => void;
+};
+
+export type UseTimerResult = {
+  phase: TimerPhase;
+  status: TimerStatus;
+  totalSeconds: number;
+  remainingSeconds: number;
+  /** `'MM:SS'` 形式のゼロパディング文字列。 */
+  formatted: string;
+  start: (phase: Exclude<TimerPhase, 'idle'>, seconds: number) => void;
+  pause: () => void;
+  resume: () => void;
+  complete: () => void;
+  reset: () => void;
+};
+
+/** 秒数を `'MM:SS'` 形式の文字列にフォーマットする。負数は `'00:00'` にクランプする。 */
+export function formatMmSs(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function useTimer(options: UseTimerOptions = {}): UseTimerResult {
+  const phase = useTimerStore((s) => s.phase);
+  const status = useTimerStore((s) => s.status);
+  const totalSeconds = useTimerStore((s) => s.totalSeconds);
+  const remainingSeconds = useTimerStore((s) => s.remainingSeconds);
+  const completionToken = useTimerStore((s) => s.completionToken);
+
+  const start = useTimerStore((s) => s.start);
+  const pause = useTimerStore((s) => s.pause);
+  const resume = useTimerStore((s) => s.resume);
+  const tick = useTimerStore((s) => s.tick);
+  const complete = useTimerStore((s) => s.complete);
+  const reset = useTimerStore((s) => s.reset);
+
+  const onCompleteRef = useRef(options.onComplete);
+  useEffect(() => {
+    onCompleteRef.current = options.onComplete;
+  }, [options.onComplete]);
+
+  useEffect(() => {
+    if (status !== 'running') return;
+    const id = setInterval(() => {
+      tick();
+    }, 1000);
+    return () => clearInterval(id);
+  }, [status, tick]);
+
+  const previousTokenRef = useRef(completionToken);
+  useEffect(() => {
+    if (completionToken !== previousTokenRef.current) {
+      previousTokenRef.current = completionToken;
+      onCompleteRef.current?.(phase);
+    }
+  }, [completionToken, phase]);
+
+  const startCb = useCallback(
+    (p: Exclude<TimerPhase, 'idle'>, seconds: number) => start(p, seconds),
+    [start],
+  );
+  const pauseCb = useCallback(() => pause(), [pause]);
+  const resumeCb = useCallback(() => resume(), [resume]);
+  const completeCb = useCallback(() => complete(), [complete]);
+  const resetCb = useCallback(() => reset(), [reset]);
+
+  return {
+    phase,
+    status,
+    totalSeconds,
+    remainingSeconds,
+    formatted: formatMmSs(remainingSeconds),
+    start: startCb,
+    pause: pauseCb,
+    resume: resumeCb,
+    complete: completeCb,
+    reset: resetCb,
+  };
 }

--- a/mobile/src/shared/stores/__tests__/timerStore.test.ts
+++ b/mobile/src/shared/stores/__tests__/timerStore.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `timerStore` を pure な状態機械としてテストする。React / Provider に依存せず、
+ * `getState()` / `setState()` を直接使って各アクションの遷移を検証する。
+ */
+import { useTimerStore } from '../timerStore';
+
+describe('timerStore', () => {
+  beforeEach(() => {
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+  });
+
+  it('初期状態は idle / 0 秒', () => {
+    const s = useTimerStore.getState();
+    expect(s.phase).toBe('idle');
+    expect(s.status).toBe('idle');
+    expect(s.totalSeconds).toBe(0);
+    expect(s.remainingSeconds).toBe(0);
+    expect(s.completionToken).toBe(0);
+  });
+
+  it('start で指定 phase / seconds の running 状態に遷移する', () => {
+    useTimerStore.getState().start('input', 1200);
+    const s = useTimerStore.getState();
+    expect(s.phase).toBe('input');
+    expect(s.status).toBe('running');
+    expect(s.totalSeconds).toBe(1200);
+    expect(s.remainingSeconds).toBe(1200);
+  });
+
+  it('start(phase, 0) は即 completed になり completionToken を +1 する', () => {
+    const before = useTimerStore.getState().completionToken;
+    useTimerStore.getState().start('input', 0);
+    const s = useTimerStore.getState();
+    expect(s.status).toBe('completed');
+    expect(s.remainingSeconds).toBe(0);
+    expect(s.completionToken).toBe(before + 1);
+  });
+
+  it('start は負数や小数の seconds を 0 以上の整数に丸める', () => {
+    useTimerStore.getState().start('input', 12.9);
+    expect(useTimerStore.getState().remainingSeconds).toBe(12);
+    useTimerStore.getState().start('input', -5);
+    // 負数は 0 扱いなので即 completed
+    expect(useTimerStore.getState().status).toBe('completed');
+  });
+
+  it('pause は running からのみ有効', () => {
+    useTimerStore.getState().pause();
+    expect(useTimerStore.getState().status).toBe('idle');
+
+    useTimerStore.getState().start('input', 10);
+    useTimerStore.getState().pause();
+    expect(useTimerStore.getState().status).toBe('paused');
+  });
+
+  it('resume は paused からのみ有効', () => {
+    useTimerStore.getState().resume();
+    expect(useTimerStore.getState().status).toBe('idle');
+
+    useTimerStore.getState().start('input', 10);
+    useTimerStore.getState().resume();
+    // 既に running なので変化なし
+    expect(useTimerStore.getState().status).toBe('running');
+
+    useTimerStore.getState().pause();
+    useTimerStore.getState().resume();
+    expect(useTimerStore.getState().status).toBe('running');
+  });
+
+  it('tick を N 回呼ぶと remainingSeconds が N 減る', () => {
+    useTimerStore.getState().start('input', 5);
+    useTimerStore.getState().tick();
+    useTimerStore.getState().tick();
+    useTimerStore.getState().tick();
+    expect(useTimerStore.getState().remainingSeconds).toBe(2);
+    expect(useTimerStore.getState().status).toBe('running');
+  });
+
+  it('paused / idle / completed 中の tick は no-op', () => {
+    useTimerStore.getState().start('input', 5);
+    useTimerStore.getState().pause();
+    useTimerStore.getState().tick();
+    expect(useTimerStore.getState().remainingSeconds).toBe(5);
+
+    useTimerStore.getState().reset();
+    useTimerStore.getState().tick();
+    expect(useTimerStore.getState().remainingSeconds).toBe(0);
+  });
+
+  it('残り 1 秒で tick すると completed へ遷移し completionToken が +1 される', () => {
+    useTimerStore.getState().start('input', 1);
+    const before = useTimerStore.getState().completionToken;
+    useTimerStore.getState().tick();
+    const s = useTimerStore.getState();
+    expect(s.status).toBe('completed');
+    expect(s.remainingSeconds).toBe(0);
+    expect(s.completionToken).toBe(before + 1);
+  });
+
+  it('complete を 2 回連続で呼んでも completionToken は 1 回しか増えない', () => {
+    useTimerStore.getState().start('input', 10);
+    const before = useTimerStore.getState().completionToken;
+    useTimerStore.getState().complete();
+    useTimerStore.getState().complete();
+    expect(useTimerStore.getState().completionToken).toBe(before + 1);
+    expect(useTimerStore.getState().status).toBe('completed');
+  });
+
+  it('reset は idle に戻すが completionToken は保持する', () => {
+    useTimerStore.getState().start('input', 1);
+    useTimerStore.getState().tick(); // completed, token +1
+    const tokenAfterComplete = useTimerStore.getState().completionToken;
+    useTimerStore.getState().reset();
+    const s = useTimerStore.getState();
+    expect(s.phase).toBe('idle');
+    expect(s.status).toBe('idle');
+    expect(s.totalSeconds).toBe(0);
+    expect(s.remainingSeconds).toBe(0);
+    expect(s.completionToken).toBe(tokenAfterComplete);
+  });
+
+  it('reset 後に再度フェーズを完走すると completionToken がさらに +1 される', () => {
+    useTimerStore.getState().start('input', 1);
+    useTimerStore.getState().tick();
+    const first = useTimerStore.getState().completionToken;
+    useTimerStore.getState().reset();
+    useTimerStore.getState().start('output', 1);
+    useTimerStore.getState().tick();
+    expect(useTimerStore.getState().completionToken).toBe(first + 1);
+    expect(useTimerStore.getState().phase).toBe('output');
+  });
+});

--- a/mobile/src/shared/stores/timerStore.ts
+++ b/mobile/src/shared/stores/timerStore.ts
@@ -1,22 +1,116 @@
 /**
- * Zustand のタイマーストア。Epic #3 でフェーズ遷移とカウントダウンを実装する。
+ * Zustand のタイマーストア。
+ *
+ * 学習サイクル (input -> output -> break -> ...) の残り時間と稼働状態を保持する。
+ *
+ * 設計メモ:
+ * - `phase` (ライフサイクル段階) と `status` (稼働状態) を分離し、
+ *   `'input-paused'` のような積表現を避ける。
+ * - 時間経過 (tick) は hook (`useTimer`) 側が所有する `setInterval` から呼び出され、
+ *   本 store 自体は時間に依存しない pure な状態機械として動作する。
+ * - フェーズ完了通知は `completionToken` の単調増加で表現する。hook はこの値の
+ *   変化を購読して `onComplete` を 1 回だけ発火することで、冪等性を担保する。
  */
 import { create } from 'zustand';
 
 export type TimerPhase = 'idle' | 'input' | 'output' | 'break';
+export type TimerStatus = 'idle' | 'running' | 'paused' | 'completed';
 
 export type TimerState = {
   phase: TimerPhase;
+  status: TimerStatus;
+  /** 現在のフェーズに割り当てられた合計秒数。進捗計算や表示に利用する。 */
+  totalSeconds: number;
+  /** 残り秒数。0 に達した瞬間に完了扱いになる。 */
   remainingSeconds: number;
-  setPhase: (phase: TimerPhase) => void;
-  setRemaining: (seconds: number) => void;
+  /**
+   * フェーズ完了イベントの単調増加カウンタ。`complete()` が呼ばれるたびに
+   * インクリメントされ、`useTimer` 側はこの値の変化を検知して `onComplete`
+   * を 1 回だけ発火する。
+   */
+  completionToken: number;
+
+  /** 指定 phase / 秒数で running 状態に遷移する。0 秒以下なら即 completed 扱い。 */
+  start: (phase: Exclude<TimerPhase, 'idle'>, seconds: number) => void;
+  /** running -> paused (それ以外は no-op)。 */
+  pause: () => void;
+  /** paused -> running (それ以外は no-op)。 */
+  resume: () => void;
+  /** running 中に 1 秒減らす。残り 1 秒で呼ぶと completed に遷移して token を増やす。 */
+  tick: () => void;
+  /** 強制的に完了状態へ遷移させる。既に completed の場合は token を増やさない。 */
+  complete: () => void;
+  /** idle へ戻す。`completionToken` は保持する (履歴リセットは行わない)。 */
   reset: () => void;
 };
 
-export const useTimerStore = create<TimerState>((set) => ({
+export const useTimerStore = create<TimerState>((set, get) => ({
   phase: 'idle',
+  status: 'idle',
+  totalSeconds: 0,
   remainingSeconds: 0,
-  setPhase: (phase) => set({ phase }),
-  setRemaining: (seconds) => set({ remainingSeconds: seconds }),
-  reset: () => set({ phase: 'idle', remainingSeconds: 0 }),
+  completionToken: 0,
+
+  start: (phase, seconds) => {
+    const safeSeconds = Math.max(0, Math.floor(seconds));
+    if (safeSeconds === 0) {
+      set((state) => ({
+        phase,
+        status: 'completed',
+        totalSeconds: 0,
+        remainingSeconds: 0,
+        completionToken: state.completionToken + 1,
+      }));
+      return;
+    }
+    set({
+      phase,
+      status: 'running',
+      totalSeconds: safeSeconds,
+      remainingSeconds: safeSeconds,
+    });
+  },
+
+  pause: () => {
+    if (get().status !== 'running') return;
+    set({ status: 'paused' });
+  },
+
+  resume: () => {
+    if (get().status !== 'paused') return;
+    set({ status: 'running' });
+  },
+
+  tick: () => {
+    const { status, remainingSeconds } = get();
+    if (status !== 'running') return;
+    const next = remainingSeconds - 1;
+    if (next <= 0) {
+      set((state) => ({
+        remainingSeconds: 0,
+        status: 'completed',
+        completionToken: state.completionToken + 1,
+      }));
+      return;
+    }
+    set({ remainingSeconds: next });
+  },
+
+  complete: () => {
+    if (get().status === 'completed') return;
+    set((state) => ({
+      remainingSeconds: 0,
+      status: 'completed',
+      completionToken: state.completionToken + 1,
+    }));
+  },
+
+  reset: () => {
+    set({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+    });
+  },
 }));


### PR DESCRIPTION
## Summary
- Issue #40 対応。各フェーズ画面で再利用できる Zustand ベースのタイマー基盤を本実装
- `timerStore` は `phase` と `status` を分離して保持し、`completionToken` の単調増加でフェーズ完了イベントを表現 (hook 側で onComplete を冪等に 1 度だけ発火)
- `useTimer` が setInterval を所有し `tick / pause / resume / complete / reset` と `onComplete(phase)` を提供。`formatMmSs` も export
- `Timer` コンポーネントは `useTimerStore` を直接購読して表示専用。同一画面で `useTimer({ onComplete })` と併用しても interval が二重起動しない設計
- 既存 API (`setPhase` / `setRemaining`) は利用箇所無しを確認済のため廃止

## Test plan
- [x] `task mobile:typecheck` が pass
- [x] `task mobile:lint` が pass
- [x] `task mobile:test` が pass (8 suites / 54 tests)
- [x] `timerStore` のユニットテスト (start / pause / resume / tick / complete / reset / completionToken の単調増加)
- [x] `useTimer` のユニットテスト (fakeTimers で tick・pause・resume・unmount・onComplete 冪等・ref 差し替え)
- [x] `Timer` コンポーネントのテスト (`TamaguiProvider` 配下で表示とストア追従)
- [ ] #41 でフェーズ画面に組み込んだ後の手動確認 (本 PR スコープ外)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)