### PR TITLE
feat: フェーズ画面遷移と session status 更新 (#41)

### DIFF
--- a/backend/src/application/dto/session_dto.py
+++ b/backend/src/application/dto/session_dto.py
@@ -22,6 +22,13 @@ class CreateSessionCommand(FrozenModel):
     break_minutes: int
 
 
+class UpdateSessionStatusCommand(FrozenModel):
+    """PATCH /sessions/{id} の入力コマンド。"""
+
+    session_id: UUID
+    new_status: SessionStatus
+
+
 class SessionView(FrozenModel):
     """セッション情報のレスポンス元ビュー。"""
 

--- a/backend/src/application/use_cases/update_session_status.py
+++ b/backend/src/application/use_cases/update_session_status.py
@@ -1,0 +1,79 @@
+"""PATCH /sessions/{id} の UseCase。
+
+Session.status の遷移は有限状態機械として扱い、許可された遷移のみ通す。
+判定 (judging→judged) はダミー扱いで、本 Task では API が状態を進めるだけの
+役割に留める。LLM 判定の実呼び出しは Epic #4 のスコープ。
+"""
+
+from datetime import UTC, datetime
+
+from src.application.dto.session_dto import SessionView, UpdateSessionStatusCommand
+from src.domain.entities.session import Session
+from src.domain.entities.user import User
+from src.domain.repositories.session_repository import SessionRepository
+from src.domain.value_objects.session_status import SessionStatus
+
+
+class SessionNotFoundError(Exception):
+    """当該 session が存在しない、または別ユーザーの session のため参照できない。
+
+    enumeration 対策として「他ユーザー」と「存在しない」は呼び出し側で区別しない。
+    """
+
+
+class InvalidSessionStatusTransitionError(Exception):
+    """許可されていない status 遷移を要求された。"""
+
+
+_ALLOWED_TRANSITIONS: dict[SessionStatus, frozenset[SessionStatus]] = {
+    SessionStatus.INPUT: frozenset({SessionStatus.OUTPUT, SessionStatus.CANCELLED}),
+    SessionStatus.OUTPUT: frozenset({SessionStatus.JUDGING, SessionStatus.CANCELLED}),
+    SessionStatus.JUDGING: frozenset({SessionStatus.JUDGED, SessionStatus.CANCELLED}),
+    SessionStatus.JUDGED: frozenset(),
+    SessionStatus.CANCELLED: frozenset(),
+}
+
+_TERMINAL_STATUSES: frozenset[SessionStatus] = frozenset(
+    {SessionStatus.JUDGED, SessionStatus.CANCELLED}
+)
+
+
+class UpdateSessionStatus:
+    """Session の status を許可された遷移のみで更新する。"""
+
+    def __init__(self, session_repository: SessionRepository) -> None:
+        self._session_repository = session_repository
+
+    async def execute(self, current_user: User, command: UpdateSessionStatusCommand) -> SessionView:
+        session = await self._session_repository.find_by_id(command.session_id)
+        if session is None or session.user_id != current_user.id:
+            raise SessionNotFoundError("session not found")
+
+        if command.new_status not in _ALLOWED_TRANSITIONS[session.status]:
+            raise InvalidSessionStatusTransitionError(
+                f"cannot transition from {session.status.value} to {command.new_status.value}"
+            )
+
+        completed_at: datetime | None = None
+        if command.new_status in _TERMINAL_STATUSES:
+            completed_at = datetime.now(UTC)
+
+        updated = session.with_status(new_status=command.new_status, completed_at=completed_at)
+        await self._session_repository.update(updated)
+        return _to_view(updated)
+
+
+def _to_view(session: Session) -> SessionView:
+    return SessionView(
+        id=session.id,
+        user_id=session.user_id,
+        status=session.status,
+        subject=session.subject,
+        topic=session.topic,
+        input_minutes=session.input_minutes,
+        output_minutes=session.output_minutes,
+        break_minutes=session.break_minutes,
+        started_at=session.started_at,
+        completed_at=session.completed_at,
+        created_at=session.created_at,
+    )

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
 from src.domain.repositories.session_repository import SessionRepository
@@ -37,6 +38,7 @@ class Container(BaseModel):
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
     create_session: CreateSession
+    update_session_status: UpdateSessionStatus
 
 
 def build_container(settings: Settings) -> Container:
@@ -48,6 +50,7 @@ def build_container(settings: Settings) -> Container:
     get_user_profile = GetUserProfile()
     update_user_profile = UpdateUserProfile(user_repository=user_repository)
     create_session = CreateSession(session_repository=session_repository)
+    update_session_status = UpdateSessionStatus(session_repository=session_repository)
     return Container(
         settings=settings,
         database=database,
@@ -57,4 +60,5 @@ def build_container(settings: Settings) -> Container:
         get_user_profile=get_user_profile,
         update_user_profile=update_user_profile,
         create_session=create_session,
+        update_session_status=update_session_status,
     )

--- a/backend/src/domain/entities/session.py
+++ b/backend/src/domain/entities/session.py
@@ -26,3 +26,20 @@ class Session(FrozenModel):
     started_at: datetime
     completed_at: datetime | None
     created_at: datetime
+
+    def with_status(
+        self,
+        *,
+        new_status: SessionStatus,
+        completed_at: datetime | None = None,
+    ) -> "Session":
+        """status を更新した新しい Session を返す。
+
+        completed_at は judged / cancelled 等の終端遷移で呼び出し側から
+        明示的に渡す想定。None のときは現在値を保つ（後段で None に戻す
+        ケースは本ドメインでは発生しない想定）。
+        """
+        update: dict[str, object] = {"status": new_status}
+        if completed_at is not None:
+            update["completed_at"] = completed_at
+        return self.model_copy(update=update)

--- a/backend/src/infrastructure/persistence/repositories/pg_session_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_session_repository.py
@@ -1,14 +1,17 @@
 """Session リポジトリの PostgreSQL 実装。
 
-本 PR では Issue #38 / #39 のスコープに合わせて `add` のみ実装する。
-`find_by_id` / `update` / `list_by_user` は Epic #3 の後続 Task で実装するため、
-呼び出された時点で `NotImplementedError` を投げて気づけるようにしておく。
+Issue #41 で `find_by_id` / `update` を実装。`list_by_user` は履歴一覧 API を
+扱う別 Task で実装する想定のため、呼び出されたら `NotImplementedError` で
+気づけるようにしておく。
 """
 
 from uuid import UUID
 
+from sqlalchemy import select
+
 from src.domain.entities.session import Session
 from src.domain.repositories.session_repository import SessionRepository
+from src.domain.value_objects.session_status import SessionStatus
 from src.infrastructure.persistence.database import Database
 from src.infrastructure.persistence.models.session_model import SessionModel
 
@@ -39,10 +42,26 @@ class PgSessionRepository(SessionRepository):
             await db_session.commit()
 
     async def find_by_id(self, session_id: UUID) -> Session | None:
-        raise NotImplementedError("Epic #3 後続 Task で実装する")
+        async with self._database.session() as db_session:
+            stmt = select(SessionModel).where(SessionModel.id == session_id)
+            result = await db_session.execute(stmt)
+            row = result.scalar_one_or_none()
+            return _to_session(row) if row is not None else None
 
     async def update(self, session: Session) -> None:
-        raise NotImplementedError("Epic #3 後続 Task で実装する")
+        async with self._database.session() as db_session:
+            stmt = select(SessionModel).where(SessionModel.id == session.id)
+            result = await db_session.execute(stmt)
+            model = result.scalar_one()
+            model.status = session.status.value
+            model.subject = session.subject
+            model.topic = session.topic
+            model.input_minutes = session.input_minutes
+            model.output_minutes = session.output_minutes
+            model.break_minutes = session.break_minutes
+            model.started_at = session.started_at
+            model.completed_at = session.completed_at
+            await db_session.commit()
 
     async def list_by_user(
         self,
@@ -50,4 +69,21 @@ class PgSessionRepository(SessionRepository):
         cursor: str | None,
         limit: int,
     ) -> tuple[list[Session], str | None]:
-        raise NotImplementedError("Epic #3 後続 Task で実装する")
+        raise NotImplementedError("履歴一覧エンドポイントの Task で実装する")
+
+
+def _to_session(model: SessionModel) -> Session:
+    """ORM モデル → domain.Session の変換。"""
+    return Session(
+        id=model.id,
+        user_id=model.user_id,
+        status=SessionStatus(model.status),
+        subject=model.subject,
+        topic=model.topic,
+        input_minutes=model.input_minutes,
+        output_minutes=model.output_minutes,
+        break_minutes=model.break_minutes,
+        started_at=model.started_at,
+        completed_at=model.completed_at,
+        created_at=model.created_at,
+    )

--- a/backend/src/presentation/api/v1/sessions.py
+++ b/backend/src/presentation/api/v1/sessions.py
@@ -1,18 +1,31 @@
 """セッションエンドポイント。
 
-本 PR では Issue #38 / #39 のスコープに合わせて `POST /api/v1/sessions` のみ実装する。
-他エンドポイント（GET / PATCH / output / judgment）は Epic #3 後続 Task で追加する。
+- POST /api/v1/sessions: 新規セッション作成（Issue #39）
+- PATCH /api/v1/sessions/{id}: フェーズ遷移に伴うステータス更新（Issue #41）
+
+GET / 判定系は別 Task で追加する。
 """
 
-from fastapi import APIRouter, Depends, Request, status
+from uuid import UUID
 
-from src.application.dto.session_dto import CreateSessionCommand, SessionView
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+
+from src.application.dto.session_dto import (
+    CreateSessionCommand,
+    SessionView,
+    UpdateSessionStatusCommand,
+)
+from src.application.use_cases.update_session_status import (
+    InvalidSessionStatusTransitionError,
+    SessionNotFoundError,
+)
 from src.domain.entities.user import User
 from src.presentation.container_access import get_presentation_container
 from src.presentation.middleware.auth_middleware import get_current_user
 from src.presentation.schemas.session_schema import (
     CreateSessionRequest,
     SessionResponse,
+    UpdateSessionRequest,
 )
 
 sessions_router = APIRouter(prefix="/sessions", tags=["sessions"])
@@ -38,6 +51,34 @@ async def create_session(
         break_minutes=body.break_minutes,
     )
     view = await container.create_session.execute(current_user, command)
+    return _to_response(view)
+
+
+@sessions_router.patch("/{session_id}", response_model=SessionResponse)
+async def update_session(
+    body: UpdateSessionRequest,
+    request: Request,
+    session_id: UUID = Path(...),  # noqa: B008
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> SessionResponse:
+    """Session の status を遷移させる。
+
+    許可されない遷移は 400、存在しない / 他ユーザーの session は 404 を返す。
+    """
+    container = get_presentation_container(request)
+    command = UpdateSessionStatusCommand(session_id=session_id, new_status=body.status)
+    try:
+        view = await container.update_session_status.execute(current_user, command)
+    except SessionNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="session not found",
+        ) from exc
+    except InvalidSessionStatusTransitionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     return _to_response(view)
 
 

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -7,6 +7,7 @@ from fastapi import Request
 
 from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.domain.repositories.user_repository import UserRepository
 from src.domain.services.auth_verifier import AuthVerifier
@@ -29,6 +30,7 @@ class PresentationContainer(ABC):
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
     create_session: CreateSession
+    update_session_status: UpdateSessionStatus
 
 
 def get_presentation_container(request: Request) -> PresentationContainer:

--- a/backend/src/presentation/schemas/session_schema.py
+++ b/backend/src/presentation/schemas/session_schema.py
@@ -23,6 +23,16 @@ class CreateSessionRequest(StrictRequestModel):
     break_minutes: int = Field(ge=1, le=120)
 
 
+class UpdateSessionRequest(StrictRequestModel):
+    """PATCH /sessions/{id} の body。
+
+    本 Task ではフェーズ遷移のための status 更新のみをサポートする。
+    実際に許可される遷移は UseCase 側の遷移表で絞り込む。
+    """
+
+    status: SessionStatus
+
+
 class SessionResponse(FrozenModel):
     """POST /sessions / GET /sessions/{id} のレスポンス。"""
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
 from src.container import Container
@@ -71,6 +72,7 @@ def container(
         get_user_profile=GetUserProfile(),
         update_user_profile=UpdateUserProfile(user_repository=fake_user_repository),
         create_session=CreateSession(session_repository=fake_session_repository),
+        update_session_status=UpdateSessionStatus(session_repository=fake_session_repository),
     )
 
 

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -3,6 +3,8 @@
 FakeAuthVerifier + FakeSessionRepository 経由で、実 DB / Firebase 無しで経路を検証する。
 """
 
+from uuid import uuid4
+
 import pytest
 from httpx import AsyncClient
 
@@ -15,6 +17,34 @@ def _valid_body() -> dict[str, object]:
         "output_minutes": 5,
         "break_minutes": 5,
     }
+
+
+async def _create_session(client: AsyncClient, auth_uid: str) -> dict[str, object]:
+    """PATCH テストで使うための helper。POST で session を作って body を返す。
+
+    FakeAuthVerifier は Authorization 値をそのまま Firebase UID として解釈するため、
+    ここで渡す auth_uid がユーザー ID の代わりになる。
+    """
+    response = await client.post(
+        "/api/v1/sessions",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json=_valid_body(),
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _advance_status(
+    client: AsyncClient, auth_uid: str, session_id: str, new_status: str
+) -> dict[str, object]:
+    """テスト内で status を順送りするための helper。"""
+    response = await client.patch(
+        f"/api/v1/sessions/{session_id}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": new_status},
+    )
+    assert response.status_code == 200
+    return response.json()
 
 
 @pytest.mark.asyncio
@@ -98,4 +128,162 @@ async def test_create_session_forbids_extra_fields(client: AsyncClient):
     headers = {"Authorization": "Bearer user-007"}
     payload = _valid_body() | {"unknown": "x"}
     response = await client.post("/api/v1/sessions", headers=headers, json=payload)
+    assert response.status_code == 422
+
+
+# --- PATCH /sessions/{id} (Issue #41) ---
+
+
+@pytest.mark.asyncio
+async def test_update_session_requires_authorization_header(client: AsyncClient):
+    created = await _create_session(client, "patch-user-001")
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        json={"status": "output"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_invalid_token(client: AsyncClient):
+    created = await _create_session(client, "patch-user-002")
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": "Bearer invalid-token"},
+        json={"status": "output"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_update_session_returns_404_for_unknown_session(client: AsyncClient):
+    response = await client.patch(
+        f"/api/v1/sessions/{uuid4()}",
+        headers={"Authorization": "Bearer patch-user-003"},
+        json={"status": "output"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_session_returns_404_for_other_users_session(client: AsyncClient):
+    created = await _create_session(client, "patch-user-owner")
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": "Bearer patch-user-other"},
+        json={"status": "output"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_session_advances_input_to_output(client: AsyncClient):
+    auth_uid = "patch-user-flow-1"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "output"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "output"
+    # output 遷移時点では completed_at はセットされない
+    assert body["completed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_session_full_happy_path_sets_completed_at_on_judged(
+    client: AsyncClient,
+):
+    """input → output → judging → judged まで順送りする正常パス。"""
+    auth_uid = "patch-user-flow-2"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+
+    await _advance_status(client, auth_uid, session_id, "output")
+    await _advance_status(client, auth_uid, session_id, "judging")
+    judged = await _advance_status(client, auth_uid, session_id, "judged")
+
+    assert judged["status"] == "judged"
+    assert judged["completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_session_cancelled_sets_completed_at(client: AsyncClient):
+    auth_uid = "patch-user-flow-3"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "cancelled"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "cancelled"
+    assert body["completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_skip_transition(client: AsyncClient):
+    auth_uid = "patch-user-flow-4"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "judged"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_no_op_transition(client: AsyncClient):
+    auth_uid = "patch-user-flow-5"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "input"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_transition_after_judged(client: AsyncClient):
+    auth_uid = "patch-user-flow-6"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+    await _advance_status(client, auth_uid, session_id, "judging")
+    await _advance_status(client, auth_uid, session_id, "judged")
+
+    response = await client.patch(
+        f"/api/v1/sessions/{session_id}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "cancelled"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_unknown_status_value(client: AsyncClient):
+    auth_uid = "patch-user-flow-7"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "unknown"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_session_rejects_extra_fields(client: AsyncClient):
+    auth_uid = "patch-user-flow-8"
+    created = await _create_session(client, auth_uid)
+    response = await client.patch(
+        f"/api/v1/sessions/{created['id']}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"status": "output", "unknown": "x"},
+    )
     assert response.status_code == 422

--- a/backend/tests/unit/test_entities/test_session.py
+++ b/backend/tests/unit/test_entities/test_session.py
@@ -1,0 +1,64 @@
+"""Session entity の振る舞いを検証する。"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from src.domain.entities.session import Session
+from src.domain.value_objects.session_status import SessionStatus
+
+
+def _make_session(
+    *,
+    session_status: SessionStatus = SessionStatus.INPUT,
+    completed_at: datetime | None = None,
+) -> Session:
+    now = datetime.now(UTC)
+    return Session(
+        id=uuid4(),
+        user_id=uuid4(),
+        status=session_status,
+        subject="英語",
+        topic="関係代名詞",
+        input_minutes=20,
+        output_minutes=5,
+        break_minutes=5,
+        started_at=now,
+        completed_at=completed_at,
+        created_at=now,
+    )
+
+
+def test_with_status_returns_new_instance_with_updated_status():
+    original = _make_session(session_status=SessionStatus.INPUT)
+
+    updated = original.with_status(new_status=SessionStatus.OUTPUT)
+
+    assert updated.status is SessionStatus.OUTPUT
+    # 元のインスタンスは変更されない
+    assert original.status is SessionStatus.INPUT
+
+
+def test_with_status_applies_completed_at_when_passed():
+    original = _make_session(session_status=SessionStatus.JUDGING)
+    completed_at = datetime(2026, 4, 15, 10, 0, tzinfo=UTC)
+
+    updated = original.with_status(
+        new_status=SessionStatus.JUDGED,
+        completed_at=completed_at,
+    )
+
+    assert updated.status is SessionStatus.JUDGED
+    assert updated.completed_at == completed_at
+
+
+def test_with_status_keeps_existing_completed_at_when_none_passed():
+    existing_completed_at = datetime(2026, 4, 15, 9, 0, tzinfo=UTC)
+    original = _make_session(
+        session_status=SessionStatus.INPUT,
+        completed_at=existing_completed_at,
+    )
+
+    updated = original.with_status(new_status=SessionStatus.OUTPUT)
+
+    # completed_at を明示的に渡していないので保持される
+    assert updated.completed_at == existing_completed_at

--- a/backend/tests/unit/test_use_cases/test_update_session_status.py
+++ b/backend/tests/unit/test_use_cases/test_update_session_status.py
@@ -1,0 +1,238 @@
+"""UpdateSessionStatus UseCase の振る舞い。
+
+`_ALLOWED_TRANSITIONS` で許可された遷移のみが通り、
+終端 (judged / cancelled) 到達時は completed_at がセットされる。
+他ユーザーの session と存在しない session は区別せず 404 相当の例外を投げる。
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.application.dto.session_dto import UpdateSessionStatusCommand
+from src.application.use_cases.update_session_status import (
+    InvalidSessionStatusTransitionError,
+    SessionNotFoundError,
+    UpdateSessionStatus,
+)
+from src.domain.entities.session import Session
+from src.domain.entities.user import User
+from src.domain.value_objects.auth_provider import AuthProvider
+from src.domain.value_objects.session_status import SessionStatus
+from tests.fakes.fake_session_repository import FakeSessionRepository
+
+
+def _make_user(user_id: UUID | None = None) -> User:
+    now = datetime.now(UTC)
+    return User(
+        id=user_id if user_id is not None else uuid4(),
+        firebase_uid="uid-owner",
+        auth_provider=AuthProvider.GOOGLE,
+        display_name=None,
+        age_group=None,
+        onboarding_completed=False,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_session(
+    user_id: UUID,
+    *,
+    session_status: SessionStatus = SessionStatus.INPUT,
+) -> Session:
+    now = datetime.now(UTC)
+    return Session(
+        id=uuid4(),
+        user_id=user_id,
+        status=session_status,
+        subject="英語",
+        topic="関係代名詞",
+        input_minutes=20,
+        output_minutes=5,
+        break_minutes=5,
+        started_at=now,
+        completed_at=None,
+        created_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_updates_status_from_input_to_output():
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.INPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    view = await use_case.execute(
+        user,
+        UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.OUTPUT),
+    )
+
+    assert view.status is SessionStatus.OUTPUT
+    assert repo.sessions[session.id].status is SessionStatus.OUTPUT
+    # output 遷移では completed_at はセットされない
+    assert view.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_updates_status_from_output_to_judging():
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.OUTPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    view = await use_case.execute(
+        user,
+        UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.JUDGING),
+    )
+
+    assert view.status is SessionStatus.JUDGING
+    assert view.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_judged_transition_sets_completed_at():
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.JUDGING)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    view = await use_case.execute(
+        user,
+        UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.JUDGED),
+    )
+
+    assert view.status is SessionStatus.JUDGED
+    assert view.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_transition_sets_completed_at():
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.INPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    view = await use_case.execute(
+        user,
+        UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.CANCELLED),
+    )
+
+    assert view.status is SessionStatus.CANCELLED
+    assert view.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_skip_transition_is_rejected():
+    """input から judged に直接飛ぶ遷移は許可しない。"""
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.INPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(InvalidSessionStatusTransitionError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.JUDGED),
+        )
+
+
+@pytest.mark.asyncio
+async def test_backward_transition_is_rejected():
+    """output から input への戻り遷移は許可しない。"""
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.OUTPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(InvalidSessionStatusTransitionError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.INPUT),
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_op_transition_is_rejected():
+    """同一 status への遷移も許可しない（厳密モード）。"""
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.INPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(InvalidSessionStatusTransitionError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.INPUT),
+        )
+
+
+@pytest.mark.asyncio
+async def test_transition_from_judged_is_rejected():
+    """judged は終端。以降の遷移は許可しない。"""
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.JUDGED)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(InvalidSessionStatusTransitionError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.CANCELLED),
+        )
+
+
+@pytest.mark.asyncio
+async def test_transition_from_cancelled_is_rejected():
+    """cancelled も終端。以降の遷移は許可しない。"""
+    repo = FakeSessionRepository()
+    user = _make_user()
+    session = _make_session(user.id, session_status=SessionStatus.CANCELLED)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(InvalidSessionStatusTransitionError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.INPUT),
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_session_raises_not_found():
+    repo = FakeSessionRepository()
+    user = _make_user()
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(SessionNotFoundError):
+        await use_case.execute(
+            user,
+            UpdateSessionStatusCommand(session_id=uuid4(), new_status=SessionStatus.OUTPUT),
+        )
+
+
+@pytest.mark.asyncio
+async def test_other_users_session_raises_not_found():
+    """他人の session を enumerate 不能にするため、権限違反も NotFound で返す。"""
+    repo = FakeSessionRepository()
+    owner = _make_user()
+    other = _make_user()
+    session = _make_session(owner.id, session_status=SessionStatus.INPUT)
+    await repo.add(session)
+
+    use_case = UpdateSessionStatus(session_repository=repo)
+    with pytest.raises(SessionNotFoundError):
+        await use_case.execute(
+            other,
+            UpdateSessionStatusCommand(session_id=session.id, new_status=SessionStatus.OUTPUT),
+        )

--- a/mobile/src/features/session/api/sessionApi.ts
+++ b/mobile/src/features/session/api/sessionApi.ts
@@ -1,10 +1,22 @@
 /**
- * POST /api/v1/sessions の API 呼び出し。
+ * `/api/v1/sessions` 系の API 呼び出し。
  */
 import { api } from '@/shared/lib/api';
-import type { CreateSessionInput, Session } from '@/features/session/types';
+import type { CreateSessionInput, Session, SessionStatus } from '@/features/session/types';
 
 export async function createSession(input: CreateSessionInput): Promise<Session> {
   const { data } = await api.post<Session>('/sessions', input);
+  return data;
+}
+
+/**
+ * フェーズ遷移に伴い session.status を更新する。
+ * 許可される遷移はサーバ側の状態遷移表で絞り込まれる。
+ */
+export async function updateSessionStatus(
+  sessionId: string,
+  status: SessionStatus,
+): Promise<Session> {
+  const { data } = await api.patch<Session>(`/sessions/${sessionId}`, { status });
   return data;
 }

--- a/mobile/src/features/session/components/SessionHeader.tsx
+++ b/mobile/src/features/session/components/SessionHeader.tsx
@@ -1,0 +1,70 @@
+/**
+ * セッション画面 (input / output / break) 共通のヘッダー。
+ *
+ * 左端にフェーズ名を表示し、右端に「中断」ボタンを置く。
+ * 中断操作は Alert で確認を取り、承諾されたら `PATCH status=cancelled` を送って
+ * ホームタブ（`/(tabs)`）へ `router.replace` する。
+ *
+ * Result 画面は終端ステータス (judged) のため本コンポーネントを使わず、
+ * 独自のヘッダー + ホームへ戻るボタンを配置する想定。
+ */
+import { useRouter } from 'expo-router';
+import { Alert } from 'react-native';
+import { Button, H3, XStack } from 'tamagui';
+
+import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+
+export type SessionHeaderProps = {
+  sessionId: string;
+  title: string;
+  /**
+   * 中断前にタイマー停止などを呼びたい場合に使う。
+   * 例: 動作中の setInterval を解除するため `reset()` を渡す。
+   */
+  onBeforeCancel?: () => void;
+};
+
+export function SessionHeader({ sessionId, title, onBeforeCancel }: SessionHeaderProps) {
+  const router = useRouter();
+  const cancelMutation = useUpdateSessionStatus();
+
+  const handleCancel = () => {
+    Alert.alert('セッションを中断しますか？', '中断するとこのセッションは終了します。', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '中断する',
+        style: 'destructive',
+        onPress: () => {
+          onBeforeCancel?.();
+          cancelMutation.mutate(
+            { sessionId, status: 'cancelled' },
+            {
+              onSuccess: () => {
+                router.replace('/(tabs)');
+              },
+            },
+          );
+        },
+      },
+    ]);
+  };
+
+  return (
+    <XStack
+      justifyContent="space-between"
+      alignItems="center"
+      paddingHorizontal="$4"
+      paddingVertical="$3"
+    >
+      <H3>{title}</H3>
+      <Button
+        size="$3"
+        onPress={handleCancel}
+        disabled={cancelMutation.isPending}
+        testID="session-header-cancel"
+      >
+        中断
+      </Button>
+    </XStack>
+  );
+}

--- a/mobile/src/features/session/components/__tests__/SessionHeader.test.tsx
+++ b/mobile/src/features/session/components/__tests__/SessionHeader.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * SessionHeader の「中断」操作の振る舞いを検証する。
+ *
+ * Alert.alert は jest.spyOn で差し替え、「中断する」ボタンの onPress を
+ * 直接呼び出して、確認ダイアログを承諾した状態をシミュレートする。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { Alert } from 'react-native';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import { SessionHeader } from '@/features/session/components/SessionHeader';
+import * as sessionApi from '@/features/session/api/sessionApi';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+}));
+
+jest.mock('@/features/session/api/sessionApi');
+
+type AlertButton = {
+  text: string;
+  style?: 'default' | 'cancel' | 'destructive';
+  onPress?: () => void;
+};
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('SessionHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('中断ボタン押下 → 「中断する」承諾で onBeforeCancel → cancelled PATCH → ホームへ replace', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({ status: 'cancelled' });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_title, _message, buttons) => {
+      const confirm = (buttons as AlertButton[] | undefined)?.find(
+        (b) => b.style === 'destructive',
+      );
+      confirm?.onPress?.();
+    });
+    const onBeforeCancel = jest.fn();
+
+    const { getByTestId } = renderWithProviders(
+      <SessionHeader sessionId="ses-1" title="インプット" onBeforeCancel={onBeforeCancel} />,
+    );
+
+    fireEvent.press(getByTestId('session-header-cancel'));
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(onBeforeCancel).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-1', 'cancelled');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it('「キャンセル」選択時は PATCH も遷移も起きない', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_title, _message, buttons) => {
+      const cancel = (buttons as AlertButton[] | undefined)?.find((b) => b.style === 'cancel');
+      cancel?.onPress?.();
+    });
+
+    const { getByTestId } = renderWithProviders(
+      <SessionHeader sessionId="ses-1" title="インプット" />,
+    );
+    fireEvent.press(getByTestId('session-header-cancel'));
+
+    expect(sessionApi.updateSessionStatus).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+});

--- a/mobile/src/features/session/hooks/__tests__/useUpdateSessionStatus.test.tsx
+++ b/mobile/src/features/session/hooks/__tests__/useUpdateSessionStatus.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * useUpdateSessionStatus の振る舞いを検証する。
+ *
+ * mutation が `updateSessionStatus(sessionId, status)` を呼び、成功 / 失敗の
+ * 状態が mutation フラグに反映されることを確認する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+
+jest.mock('@/features/session/api/sessionApi');
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('useUpdateSessionStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mutate 呼び出しで updateSessionStatus が正しい引数で呼ばれる', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-1',
+      status: 'output',
+    });
+
+    const { result } = renderHook(() => useUpdateSessionStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ sessionId: 'ses-1', status: 'output' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-1', 'output');
+  });
+
+  it('updateSessionStatus が失敗すると isError が true になる', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockRejectedValue(new Error('HTTP 400'));
+
+    const { result } = renderHook(() => useUpdateSessionStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ sessionId: 'ses-1', status: 'judged' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/mobile/src/features/session/hooks/useCreateSession.ts
+++ b/mobile/src/features/session/hooks/useCreateSession.ts
@@ -1,6 +1,10 @@
 /**
  * POST /sessions のための useMutation hook。
- * 成功時はそのまま `/session/{id}/input` に push 遷移する。
+ *
+ * 成功時は作成された session のタイマー分数を URL クエリに積んで、
+ * `/session/{id}/input` に push 遷移する。
+ * 各フェーズ画面は URL クエリから分数を復元して `useTimer.start()` する。
+ * （将来 GET /sessions/{id} を実装したらそちらに差し替える想定）
  */
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
@@ -13,7 +17,15 @@ export function useCreateSession() {
   return useMutation<Session, Error, CreateSessionInput>({
     mutationFn: (input) => createSession(input),
     onSuccess: (session) => {
-      router.push(`/session/${session.id}/input`);
+      router.push({
+        pathname: '/session/[id]/input',
+        params: {
+          id: session.id,
+          input: String(session.input_minutes),
+          output: String(session.output_minutes),
+          break: String(session.break_minutes),
+        },
+      });
     },
   });
 }

--- a/mobile/src/features/session/hooks/useUpdateSessionStatus.ts
+++ b/mobile/src/features/session/hooks/useUpdateSessionStatus.ts
@@ -1,0 +1,21 @@
+/**
+ * PATCH /sessions/{id} のための useMutation hook。
+ *
+ * 成功時のナビゲーションは呼び出し側 (Screen) の `onSuccess` オプションで扱う。
+ * この hook 自体は API 呼び出しと mutation 状態の提供だけに徹し、責務を単純化する。
+ */
+import { useMutation } from '@tanstack/react-query';
+
+import { updateSessionStatus } from '@/features/session/api/sessionApi';
+import type { Session, SessionStatus } from '@/features/session/types';
+
+export type UpdateSessionStatusInput = {
+  sessionId: string;
+  status: SessionStatus;
+};
+
+export function useUpdateSessionStatus() {
+  return useMutation<Session, Error, UpdateSessionStatusInput>({
+    mutationFn: ({ sessionId, status }) => updateSessionStatus(sessionId, status),
+  });
+}

--- a/mobile/src/features/session/screens/BreakScreen.tsx
+++ b/mobile/src/features/session/screens/BreakScreen.tsx
@@ -1,9 +1,72 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * 休憩フェーズ画面。
+ *
+ * 状態機械上は `judging` に相当（判定待ちの期間を UI 上は「休憩」として扱う）。
+ * タイマー完了時に `PATCH status=judged` を送って結果画面に遷移する。
+ * 実 LLM 判定は Epic #4 で追加予定で、本 Task ではダミー判定（遷移のみ）で終端する。
+ */
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Paragraph, SizableText, YStack } from 'tamagui';
+
+import { SessionHeader } from '@/features/session/components/SessionHeader';
+import { Timer } from '@/features/session/components/Timer';
+import { DEFAULT_TIMER } from '@/features/session/config';
+import { useTimer } from '@/features/session/hooks/useTimer';
+import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+
+type SessionRouteParams = {
+  id?: string;
+  break?: string;
+};
 
 export function BreakScreen() {
+  const params = useLocalSearchParams<SessionRouteParams>();
+  const sessionId = params.id ?? '';
+  const breakMinutes = Number(params.break) || DEFAULT_TIMER.break_minutes;
+
+  const router = useRouter();
+  const updateStatus = useUpdateSessionStatus();
+
+  const { start, reset } = useTimer({
+    onComplete: () => {
+      updateStatus.mutate(
+        { sessionId, status: 'judged' },
+        {
+          onSuccess: () => {
+            router.replace({
+              pathname: '/session/[id]/result',
+              params: { id: sessionId },
+            });
+          },
+        },
+      );
+    },
+  });
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    start('break', breakMinutes * 60);
+    return () => {
+      reset();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>休憩 (placeholder)</H1>
+    <YStack flex={1}>
+      <SessionHeader sessionId={sessionId} title="休憩" onBeforeCancel={reset} />
+      <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+        <Paragraph>休憩中です（判定結果を準備しています）</Paragraph>
+        <Timer />
+        {updateStatus.isError ? (
+          <SizableText color="$red10" size="$2" testID="break-screen-error">
+            通信エラーが発生しました。時間をおいて再度お試しください。
+          </SizableText>
+        ) : null}
+      </YStack>
     </YStack>
   );
 }

--- a/mobile/src/features/session/screens/InputScreen.tsx
+++ b/mobile/src/features/session/screens/InputScreen.tsx
@@ -1,9 +1,84 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * インプットフェーズ画面。
+ *
+ * マウント時に `useTimer.start('input', input_minutes * 60)` でカウントダウンを開始し、
+ * タイマー完了時に `PATCH status=output` を送る。成功後に `/session/{id}/output` へ
+ * `router.replace` で遷移する（history に残さない方針）。
+ *
+ * 学習素材の表示やノート機能は本 Task のスコープ外。
+ */
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Paragraph, SizableText, YStack } from 'tamagui';
+
+import { SessionHeader } from '@/features/session/components/SessionHeader';
+import { Timer } from '@/features/session/components/Timer';
+import { DEFAULT_TIMER } from '@/features/session/config';
+import { useTimer } from '@/features/session/hooks/useTimer';
+import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+
+type SessionRouteParams = {
+  id?: string;
+  input?: string;
+  output?: string;
+  break?: string;
+};
 
 export function InputScreen() {
+  const params = useLocalSearchParams<SessionRouteParams>();
+  const sessionId = params.id ?? '';
+  const inputMinutes = Number(params.input) || DEFAULT_TIMER.input_minutes;
+  const outputMinutes = Number(params.output) || DEFAULT_TIMER.output_minutes;
+  const breakMinutes = Number(params.break) || DEFAULT_TIMER.break_minutes;
+
+  const router = useRouter();
+  const updateStatus = useUpdateSessionStatus();
+
+  const { start, reset } = useTimer({
+    onComplete: () => {
+      updateStatus.mutate(
+        { sessionId, status: 'output' },
+        {
+          onSuccess: () => {
+            router.replace({
+              pathname: '/session/[id]/output',
+              params: {
+                id: sessionId,
+                output: String(outputMinutes),
+                break: String(breakMinutes),
+              },
+            });
+          },
+        },
+      );
+    },
+  });
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    start('input', inputMinutes * 60);
+    return () => {
+      reset();
+    };
+    // 依存を意図的に空にしている: start/reset が参照として安定しているうえ、
+    // startedRef で二重 start を防いでいるため再実行は不要。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>インプット (placeholder)</H1>
+    <YStack flex={1}>
+      <SessionHeader sessionId={sessionId} title="インプット" onBeforeCancel={reset} />
+      <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+        <Paragraph>インプットを進めてください</Paragraph>
+        <Timer />
+        {updateStatus.isError ? (
+          <SizableText color="$red10" size="$2" testID="input-screen-error">
+            通信エラーが発生しました。時間をおいて再度お試しください。
+          </SizableText>
+        ) : null}
+      </YStack>
     </YStack>
   );
 }

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -1,9 +1,73 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * アウトプットフェーズ画面。
+ *
+ * タイマー完了時に `PATCH status=judging` を送って `/session/{id}/break` に遷移する。
+ * アウトプット本体 (入力 UI の本格実装) は本 Task のスコープ外。
+ */
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Paragraph, SizableText, YStack } from 'tamagui';
+
+import { SessionHeader } from '@/features/session/components/SessionHeader';
+import { Timer } from '@/features/session/components/Timer';
+import { DEFAULT_TIMER } from '@/features/session/config';
+import { useTimer } from '@/features/session/hooks/useTimer';
+import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+
+type SessionRouteParams = {
+  id?: string;
+  output?: string;
+  break?: string;
+};
 
 export function OutputScreen() {
+  const params = useLocalSearchParams<SessionRouteParams>();
+  const sessionId = params.id ?? '';
+  const outputMinutes = Number(params.output) || DEFAULT_TIMER.output_minutes;
+  const breakMinutes = Number(params.break) || DEFAULT_TIMER.break_minutes;
+
+  const router = useRouter();
+  const updateStatus = useUpdateSessionStatus();
+
+  const { start, reset } = useTimer({
+    onComplete: () => {
+      updateStatus.mutate(
+        { sessionId, status: 'judging' },
+        {
+          onSuccess: () => {
+            router.replace({
+              pathname: '/session/[id]/break',
+              params: { id: sessionId, break: String(breakMinutes) },
+            });
+          },
+        },
+      );
+    },
+  });
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    start('output', outputMinutes * 60);
+    return () => {
+      reset();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>アウトプット (placeholder)</H1>
+    <YStack flex={1}>
+      <SessionHeader sessionId={sessionId} title="アウトプット" onBeforeCancel={reset} />
+      <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+        <Paragraph>アウトプットを記入してください</Paragraph>
+        <Timer />
+        {updateStatus.isError ? (
+          <SizableText color="$red10" size="$2" testID="output-screen-error">
+            通信エラーが発生しました。時間をおいて再度お試しください。
+          </SizableText>
+        ) : null}
+      </YStack>
     </YStack>
   );
 }

--- a/mobile/src/features/session/screens/ResultScreen.tsx
+++ b/mobile/src/features/session/screens/ResultScreen.tsx
@@ -1,9 +1,29 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * 判定結果画面。
+ *
+ * Issue #41 の時点では `JudgmentCard` は Epic #4 で実装される placeholder 表示のみ。
+ * 本画面は session が `judged` に到達した後に表示される終端画面で、中断操作は不要。
+ */
+import { useRouter } from 'expo-router';
+import { Button, H2, Paragraph, YStack } from 'tamagui';
+
+import { JudgmentCard } from '@/features/session/components/JudgmentCard';
 
 export function ResultScreen() {
+  const router = useRouter();
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>判定結果 (placeholder)</H1>
+    <YStack flex={1}>
+      <YStack paddingHorizontal="$4" paddingVertical="$3">
+        <H2>判定結果</H2>
+      </YStack>
+      <YStack flex={1} padding="$4" gap="$4">
+        <Paragraph>セッションお疲れさまでした。</Paragraph>
+        <JudgmentCard />
+        <Button themeInverse onPress={() => router.replace('/(tabs)')} testID="result-back-home">
+          ホームへ戻る
+        </Button>
+      </YStack>
     </YStack>
   );
 }

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * BreakScreen の振る舞いを検証する。
+ * タイマー完了で status=judged に PATCH → result 画面へ replace する（ダミー判定）。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { BreakScreen } from '@/features/session/screens/BreakScreen';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+  useLocalSearchParams: () => ({
+    id: 'ses-123',
+    break: '1',
+  }),
+}));
+
+jest.mock('@/features/session/api/sessionApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('BreakScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('マウントで phase=break のタイマーが開始され、タイトルが表示される', () => {
+    const { getByText } = renderWithProviders(<BreakScreen />);
+    expect(getByText('休憩')).toBeTruthy();
+    expect(useTimerStore.getState().phase).toBe('break');
+    expect(useTimerStore.getState().totalSeconds).toBe(60);
+  });
+
+  it('タイマー完了で PATCH status=judged が送られ、result 画面へ replace する', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      status: 'judged',
+    });
+
+    renderWithProviders(<BreakScreen />);
+
+    act(() => {
+      jest.advanceTimersByTime(60 * 1000);
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judged');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/session/[id]/result',
+        params: { id: 'ses-123' },
+      });
+    });
+  });
+});

--- a/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
@@ -96,7 +96,15 @@ describe('HomeScreen', () => {
       });
     });
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/session/ses-123/input');
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: '/session/[id]/input',
+        params: {
+          id: 'ses-123',
+          input: '20',
+          output: '5',
+          break: '5',
+        },
+      });
     });
   });
 

--- a/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * InputScreen の振る舞いを検証する。
+ *
+ * マウント時にタイマーが start され、0 秒到達で status=output に PATCH → output 画面へ
+ * replace 遷移することを fakeTimers + mock API で確認する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { InputScreen } from '@/features/session/screens/InputScreen';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+  useLocalSearchParams: () => ({
+    id: 'ses-123',
+    input: '1',
+    output: '5',
+    break: '5',
+  }),
+}));
+
+jest.mock('@/features/session/api/sessionApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('InputScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('マウント時にタイマーが start され、ヘッダーとタイマー表示がレンダリングされる', () => {
+    const { getByText, getByTestId } = renderWithProviders(<InputScreen />);
+    expect(getByText('インプット')).toBeTruthy();
+    expect(getByTestId('timer-display')).toBeTruthy();
+    expect(useTimerStore.getState().phase).toBe('input');
+    expect(useTimerStore.getState().totalSeconds).toBe(60);
+  });
+
+  it('タイマー完了で PATCH status=output が送られ、output 画面へ replace する', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      status: 'output',
+    });
+
+    renderWithProviders(<InputScreen />);
+
+    act(() => {
+      jest.advanceTimersByTime(60 * 1000);
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'output');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/session/[id]/output',
+        params: { id: 'ses-123', output: '5', break: '5' },
+      });
+    });
+  });
+});

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * OutputScreen の振る舞いを検証する。
+ * タイマー完了で status=judging に PATCH → break 画面へ replace する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { OutputScreen } from '@/features/session/screens/OutputScreen';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+  useLocalSearchParams: () => ({
+    id: 'ses-123',
+    output: '1',
+    break: '5',
+  }),
+}));
+
+jest.mock('@/features/session/api/sessionApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('OutputScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('マウントで phase=output のタイマーが開始され、タイトルが表示される', () => {
+    const { getByText } = renderWithProviders(<OutputScreen />);
+    expect(getByText('アウトプット')).toBeTruthy();
+    expect(useTimerStore.getState().phase).toBe('output');
+    expect(useTimerStore.getState().totalSeconds).toBe(60);
+  });
+
+  it('タイマー完了で PATCH status=judging が送られ、break 画面へ replace する', async () => {
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      status: 'judging',
+    });
+
+    renderWithProviders(<OutputScreen />);
+
+    act(() => {
+      jest.advanceTimersByTime(60 * 1000);
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judging');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/session/[id]/break',
+        params: { id: 'ses-123', break: '5' },
+      });
+    });
+  });
+});

--- a/mobile/src/features/session/screens/__tests__/ResultScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/ResultScreen.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * ResultScreen の振る舞いを検証する。
+ * JudgmentCard が表示され、「ホームへ戻る」ボタンで `/(tabs)` に replace 遷移する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import { ResultScreen } from '@/features/session/screens/ResultScreen';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+}));
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('ResultScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('判定結果カードと「ホームへ戻る」ボタンがレンダリングされる', () => {
+    const { getByText, getByTestId } = renderWithProviders(<ResultScreen />);
+    expect(getByText('判定結果')).toBeTruthy();
+    expect(getByTestId('result-back-home')).toBeTruthy();
+  });
+
+  it('「ホームへ戻る」押下で `/(tabs)` に replace 遷移する', () => {
+    const { getByTestId } = renderWithProviders(<ResultScreen />);
+    fireEvent.press(getByTestId('result-back-home'));
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #41 の実装。input → output → break → result のフェーズ切替と backend の `session.status` 更新を接続する。
- Backend: `Session.with_status` / `UpdateSessionStatus` UseCase / `PATCH /api/v1/sessions/{id}` / `PgSessionRepository.find_by_id` / `update` を追加。状態遷移は表で管理し、終端 (judged/cancelled) で `completed_at` を記録する。
- Mobile: `useUpdateSessionStatus` hook と `SessionHeader` (中断ダイアログ → cancelled PATCH) を追加し、各 Screen を `useTimer.onComplete` + `PATCH` + `router.replace` で配線。break 完了時に直接 `judged` を送ってダミー判定で終端させる。実 LLM 判定は Epic #4 のスコープ。

## 主な変更点
- 状態遷移: `input → {output, cancelled}` / `output → {judging, cancelled}` / `judging → {judged, cancelled}` / `judged`・`cancelled` は終端（不正遷移は 400、他ユーザー/未存在は 404）
- URL パラメータ: `useCreateSession` で作成直後の session のタイマー分数を `pathname + params` 形式で input 画面に引き継ぎ、以降 output → break で必要な分数だけ引き回す（GET `/sessions/{id}` を今回は実装しない方針）
- 判定結果: `ResultScreen` は既存 placeholder の `JudgmentCard` を表示し「ホームへ戻る」のみ

## Test plan
- [x] backend: `task ci` (ruff / format:check / import-linter / ty / pytest 49 tests) が通る
- [x] mobile: `npx jest` (66 tests) / `npx eslint .` / `npx tsc --noEmit` / `npx prettier --check .` が通る
- [ ] 実機 e2e: HomeScreen でカスタム 1/1/1 分にしてセッション開始し、input → output → break → result が自動遷移して各フェーズで PATCH が走ることを確認
- [ ] 中断: input / output / break の各画面で「中断」→ Alert 承諾 → ホームへ戻り、DB で status=cancelled / completed_at が埋まっていることを確認
- [ ] 異常系: 未知 session / 他ユーザーの PATCH → 404、スキップ遷移 → 400 を curl で確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)