### PR TITLE
feat(mobile): OutputEditor と入力バリデーション UX を実装

### DIFF
--- a/mobile/src/features/session/api/sessionApi.ts
+++ b/mobile/src/features/session/api/sessionApi.ts
@@ -2,7 +2,12 @@
  * `/api/v1/sessions` 系の API 呼び出し。
  */
 import { api } from '@/shared/lib/api';
-import type { CreateSessionInput, Session, SessionStatus } from '@/features/session/types';
+import type {
+  CreateSessionInput,
+  Session,
+  SessionStatus,
+  SubmitOutputInput,
+} from '@/features/session/types';
 
 export async function createSession(input: CreateSessionInput): Promise<Session> {
   const { data } = await api.post<Session>('/sessions', input);
@@ -19,4 +24,12 @@ export async function updateSessionStatus(
 ): Promise<Session> {
   const { data } = await api.patch<Session>(`/sessions/${sessionId}`, { status });
   return data;
+}
+
+/**
+ * アウトプット本文と送信時刻を backend に送る。
+ * backend 側のレスポンス型が未確定のため、成功/失敗のみをハンドリングする。
+ */
+export async function submitOutput(sessionId: string, input: SubmitOutputInput): Promise<void> {
+  await api.post<unknown>(`/sessions/${sessionId}/output`, input);
 }

--- a/mobile/src/features/session/components/OutputEditor.tsx
+++ b/mobile/src/features/session/components/OutputEditor.tsx
@@ -1,8 +1,125 @@
 /**
- * アウトプット入力エディター。Epic #3 で実装する。
+ * アウトプット入力エディター。
+ *
+ * セッションのアウトプットフェーズで、ユーザーが理解した内容を自由記述する UI。
+ * 制御コンポーネントとして `value` / `onChange` / `onSubmit` を受け取り、
+ * 親 (OutputScreen) が送信状態・エラー状態を管理する。
+ *
+ * UX 要件 (Issue #42):
+ * - 空送信を防ぐ: `content.trim()` が空のときは送信ボタンを disabled にする
+ * - 送信中の二重送信防止: `isSubmitting` で disabled + Spinner 表示
+ * - 連打抑止: 「送信する」ボタンは 1 度押すと disable のままになる。
+ *   失敗時に表示される「再送する」ボタンを明示的に押した場合のみ再送する。
+ *   (送信成功時は親が画面遷移するため自動リセットは不要)
+ * - 文字数カウンタを表示し、上限 (`maxLength`) に近づくと視覚で分かる
  */
-import { TextArea } from 'tamagui';
+import { useRef, useState } from 'react';
+import { Spinner, Button, SizableText, TextArea, XStack, YStack } from 'tamagui';
 
-export function OutputEditor() {
-  return <TextArea placeholder="アウトプットを入力 (placeholder)" />;
+export type OutputEditorSubmitPayload = {
+  content: string;
+  submitted_at: string;
+};
+
+export type OutputEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (payload: OutputEditorSubmitPayload) => void;
+  isSubmitting: boolean;
+  errorMessage?: string | null;
+  disabled?: boolean;
+  maxLength?: number;
+};
+
+const DEFAULT_MAX_LENGTH = 2000;
+
+export function OutputEditor({
+  value,
+  onChange,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+  disabled = false,
+  maxLength = DEFAULT_MAX_LENGTH,
+}: OutputEditorProps) {
+  // 「送信する」を一度押したら true。連打抑止のため、その後の自動再有効化は行わず、
+  // 失敗時は別途表示される「再送する」ボタンの明示操作のみで再送する。
+  // ref と state を併用しているのは、ref で同一 tick 内の連打を同期的にガードしつつ、
+  // state でボタンの disabled 表示を再レンダリングへ反映するため。
+  const hasAttemptedRef = useRef(false);
+  const [hasAttempted, setHasAttempted] = useState(false);
+
+  const trimmed = value.trim();
+  const isEmpty = trimmed.length === 0;
+  const isOverMax = value.length > maxLength;
+  const cannotSubmit = isEmpty || isOverMax || isSubmitting || disabled;
+  const submitDisabled = cannotSubmit || hasAttempted;
+  const showRetryButton = Boolean(errorMessage) && !isSubmitting;
+
+  const buildPayload = (): OutputEditorSubmitPayload => ({
+    content: trimmed,
+    submitted_at: new Date().toISOString(),
+  });
+
+  const handleSubmit = () => {
+    if (cannotSubmit || hasAttemptedRef.current) return;
+    hasAttemptedRef.current = true;
+    setHasAttempted(true);
+    onSubmit(buildPayload());
+  };
+
+  const handleRetry = () => {
+    if (cannotSubmit) return;
+    onSubmit(buildPayload());
+  };
+
+  return (
+    <YStack gap="$2" width="100%">
+      <TextArea
+        testID="output-editor-textarea"
+        placeholder="学んだ内容を自分の言葉で書いてください"
+        value={value}
+        onChangeText={onChange}
+        maxLength={maxLength}
+        editable={!isSubmitting && !disabled}
+        minHeight={160}
+      />
+
+      <XStack justifyContent="space-between" alignItems="center">
+        <SizableText
+          testID="output-editor-count"
+          size="$2"
+          color={isOverMax ? '$red10' : '$color10'}
+        >
+          {value.length} / {maxLength}
+        </SizableText>
+        {errorMessage ? (
+          <SizableText
+            testID="output-editor-error"
+            color="$red10"
+            size="$2"
+            flex={1}
+            marginLeft="$3"
+          >
+            {errorMessage}
+          </SizableText>
+        ) : null}
+      </XStack>
+
+      <Button
+        testID="output-editor-submit"
+        onPress={handleSubmit}
+        disabled={submitDisabled}
+        themeInverse
+      >
+        {isSubmitting ? <Spinner /> : '送信する'}
+      </Button>
+
+      {showRetryButton ? (
+        <Button testID="output-editor-retry" onPress={handleRetry} disabled={cannotSubmit}>
+          再送する
+        </Button>
+      ) : null}
+    </YStack>
+  );
 }

--- a/mobile/src/features/session/components/__tests__/OutputEditor.test.tsx
+++ b/mobile/src/features/session/components/__tests__/OutputEditor.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * OutputEditor の入力バリデーションと送信 UX を検証する。
+ *
+ * - 空 / 空白のみのときは送信ボタンを押しても onSubmit が呼ばれない (空送信防止)
+ * - 送信中は onSubmit が呼ばれない (二重送信防止)
+ * - 送信ボタンは 1 度押すと自動では再有効化されない (連打抑止)
+ * - errorMessage を渡すと再送を促すメッセージと「再送する」ボタンが表示され、
+ *   明示的な押下のみで再送される
+ * - onSubmit は `content: 前後空白を除いた文字列` と `submitted_at: ISO8601` を渡す
+ */
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import { OutputEditor } from '../OutputEditor';
+
+function renderEditor(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      {ui}
+    </TamaguiProvider>,
+  );
+}
+
+describe('OutputEditor', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-10T15:25:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('初期表示で文字数 0 / 上限を示す', () => {
+    const { getByTestId } = renderEditor(
+      <OutputEditor value="" onChange={jest.fn()} onSubmit={jest.fn()} isSubmitting={false} />,
+    );
+    expect(getByTestId('output-editor-count').props.children).toEqual([0, ' / ', 2000]);
+  });
+
+  it('value の長さに応じて文字数カウンタが更新される', () => {
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value="こんにちは"
+        onChange={jest.fn()}
+        onSubmit={jest.fn()}
+        isSubmitting={false}
+      />,
+    );
+    expect(getByTestId('output-editor-count').props.children).toEqual([5, ' / ', 2000]);
+  });
+
+  it('value が空のとき送信ボタンを押しても onSubmit は呼ばれない', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor value="" onChange={jest.fn()} onSubmit={onSubmit} isSubmitting={false} />,
+    );
+
+    fireEvent.press(getByTestId('output-editor-submit'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('空白のみの入力でも送信は発火しない', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value={'   \n  \n'}
+        onChange={jest.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    );
+
+    fireEvent.press(getByTestId('output-editor-submit'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('送信ボタン押下で trim 済み content と ISO8601 の submitted_at が渡される', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value="   本文の内容   "
+        onChange={jest.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    );
+
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      content: '本文の内容',
+      submitted_at: '2026-04-10T15:25:00.000Z',
+    });
+  });
+
+  it('送信ボタンを連打しても onSubmit は 1 度しか呼ばれない (連打抑止)', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor value="本文" onChange={jest.fn()} onSubmit={onSubmit} isSubmitting={false} />,
+    );
+    const button = getByTestId('output-editor-submit');
+
+    act(() => {
+      fireEvent.press(button);
+      fireEvent.press(button);
+      fireEvent.press(button);
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('isSubmitting=true のときは onSubmit が呼ばれず、Spinner が表示される (ラベル非表示)', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId, queryByText } = renderEditor(
+      <OutputEditor value="本文" onChange={jest.fn()} onSubmit={onSubmit} isSubmitting />,
+    );
+
+    expect(queryByText('送信する')).toBeNull();
+
+    fireEvent.press(getByTestId('output-editor-submit'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('errorMessage を渡すとエラー文と「再送する」ボタンが表示される', () => {
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value="本文"
+        onChange={jest.fn()}
+        onSubmit={jest.fn()}
+        isSubmitting={false}
+        errorMessage="送信に失敗しました。時間をおいて再度お試しください。"
+      />,
+    );
+    expect(getByTestId('output-editor-error').props.children).toBe(
+      '送信に失敗しました。時間をおいて再度お試しください。',
+    );
+    expect(getByTestId('output-editor-retry')).toBeTruthy();
+  });
+
+  it('errorMessage が無いときは「再送する」ボタンは表示されない', () => {
+    const { queryByTestId } = renderEditor(
+      <OutputEditor value="本文" onChange={jest.fn()} onSubmit={jest.fn()} isSubmitting={false} />,
+    );
+    expect(queryByTestId('output-editor-retry')).toBeNull();
+  });
+
+  it('「再送する」ボタンの押下で onSubmit が呼ばれる', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value="本文"
+        onChange={jest.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+        errorMessage="送信に失敗しました。"
+      />,
+    );
+
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-retry'));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      content: '本文',
+      submitted_at: '2026-04-10T15:25:00.000Z',
+    });
+  });
+
+  it('送信中は「再送する」ボタンが表示されない', () => {
+    const { queryByTestId } = renderEditor(
+      <OutputEditor
+        value="本文"
+        onChange={jest.fn()}
+        onSubmit={jest.fn()}
+        isSubmitting
+        errorMessage="送信に失敗しました。"
+      />,
+    );
+    expect(queryByTestId('output-editor-retry')).toBeNull();
+  });
+
+  it('「送信する」を押した後は連打しても onSubmit は呼ばれず、「再送する」のみで再送できる', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId, rerender } = renderEditor(
+      <OutputEditor value="本文" onChange={jest.fn()} onSubmit={onSubmit} isSubmitting={false} />,
+    );
+
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // 親が「失敗」状態を反映してエラーメッセージを渡してくる
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="light">
+        <OutputEditor
+          value="本文"
+          onChange={jest.fn()}
+          onSubmit={onSubmit}
+          isSubmitting={false}
+          errorMessage="送信に失敗しました。"
+        />
+      </TamaguiProvider>,
+    );
+
+    // 「送信する」ボタンを再度押しても発火しない
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // 「再送する」ボタンの明示操作のみ再送される
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-retry'));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('TextArea の onChangeText で onChange prop が呼ばれる', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor value="" onChange={onChange} onSubmit={jest.fn()} isSubmitting={false} />,
+    );
+    const textarea = getByTestId('output-editor-textarea');
+
+    fireEvent.changeText(textarea, '追記');
+    expect(onChange).toHaveBeenCalledWith('追記');
+  });
+
+  it('disabled=true のときは送信が発火しない', () => {
+    const onSubmit = jest.fn();
+    const { getByTestId } = renderEditor(
+      <OutputEditor
+        value="本文"
+        onChange={jest.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+        disabled
+      />,
+    );
+
+    fireEvent.press(getByTestId('output-editor-submit'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/features/session/hooks/__tests__/useSubmitOutput.test.tsx
+++ b/mobile/src/features/session/hooks/__tests__/useSubmitOutput.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * useSubmitOutput の振る舞いを検証する。
+ *
+ * mutation が `submitOutput(sessionId, { content, submitted_at })` を呼ぶこと、
+ * 成功 / 失敗が mutation フラグ (isSuccess / isError / isPending) に反映されることを確認する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import * as sessionApi from '@/features/session/api/sessionApi';
+import { useSubmitOutput } from '@/features/session/hooks/useSubmitOutput';
+
+jest.mock('@/features/session/api/sessionApi');
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('useSubmitOutput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mutate 呼び出しで submitOutput が正しい引数で呼ばれる', async () => {
+    (sessionApi.submitOutput as jest.Mock).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSubmitOutput(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        sessionId: 'ses-1',
+        content: '本文',
+        submitted_at: '2026-04-10T15:25:00.000Z',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(sessionApi.submitOutput).toHaveBeenCalledWith('ses-1', {
+      content: '本文',
+      submitted_at: '2026-04-10T15:25:00.000Z',
+    });
+  });
+
+  it('submitOutput が失敗すると isError が true になる', async () => {
+    (sessionApi.submitOutput as jest.Mock).mockRejectedValue(new Error('HTTP 500'));
+
+    const { result } = renderHook(() => useSubmitOutput(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        sessionId: 'ses-1',
+        content: '本文',
+        submitted_at: '2026-04-10T15:25:00.000Z',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/mobile/src/features/session/hooks/useSubmitOutput.ts
+++ b/mobile/src/features/session/hooks/useSubmitOutput.ts
@@ -1,0 +1,22 @@
+/**
+ * POST /sessions/{id}/output のための useMutation hook。
+ *
+ * - アウトプット本文と送信時刻を backend に送るだけの責務に絞る
+ * - 送信成功後の PATCH status=judging や画面遷移は呼び出し側 (Screen) で扱う
+ * - mutation の `isPending` を使って二重送信防止に利用する
+ */
+import { useMutation } from '@tanstack/react-query';
+
+import { submitOutput } from '@/features/session/api/sessionApi';
+import type { SubmitOutputInput } from '@/features/session/types';
+
+export type UseSubmitOutputInput = SubmitOutputInput & {
+  sessionId: string;
+};
+
+export function useSubmitOutput() {
+  return useMutation<void, Error, UseSubmitOutputInput>({
+    mutationFn: ({ sessionId, content, submitted_at }) =>
+      submitOutput(sessionId, { content, submitted_at }),
+  });
+}

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -1,16 +1,22 @@
 /**
  * アウトプットフェーズ画面。
  *
- * タイマー完了時に `PATCH status=judging` を送って `/session/{id}/break` に遷移する。
- * アウトプット本体 (入力 UI の本格実装) は本 Task のスコープ外。
+ * - `OutputEditor` でアウトプット本文を入力し、「送信する」で POST /sessions/{id}/output
+ * - 送信成功時は `PATCH status=judging` を送り `/session/{id}/break` へ遷移
+ * - タイマー完了時は（本文の有無に関わらず）`PATCH status=judging` を送り break へ遷移
+ *   （自動送信は行わず、ユーザーの明示的な送信操作のみで submit する方針）
  */
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { Paragraph, SizableText, YStack } from 'tamagui';
 
+import { OutputEditor } from '@/features/session/components/OutputEditor';
+import type { OutputEditorSubmitPayload } from '@/features/session/components/OutputEditor';
 import { SessionHeader } from '@/features/session/components/SessionHeader';
 import { Timer } from '@/features/session/components/Timer';
 import { DEFAULT_TIMER } from '@/features/session/config';
+import { useSubmitOutput } from '@/features/session/hooks/useSubmitOutput';
 import { useTimer } from '@/features/session/hooks/useTimer';
 import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
 
@@ -27,21 +33,42 @@ export function OutputScreen() {
   const breakMinutes = Number(params.break) || DEFAULT_TIMER.break_minutes;
 
   const router = useRouter();
+  const submit = useSubmitOutput();
   const updateStatus = useUpdateSessionStatus();
+
+  const [content, setContent] = useState('');
+
+  const navigateToBreak = useCallback(() => {
+    router.replace({
+      pathname: '/session/[id]/break',
+      params: { id: sessionId, break: String(breakMinutes) },
+    });
+  }, [router, sessionId, breakMinutes]);
+
+  const advanceToJudging = useCallback(() => {
+    updateStatus.mutate(
+      { sessionId, status: 'judging' },
+      {
+        onSuccess: navigateToBreak,
+      },
+    );
+  }, [updateStatus, sessionId, navigateToBreak]);
+
+  const handleEditorSubmit = useCallback(
+    ({ content: nextContent, submitted_at }: OutputEditorSubmitPayload) => {
+      submit.mutate(
+        { sessionId, content: nextContent, submitted_at },
+        {
+          onSuccess: advanceToJudging,
+        },
+      );
+    },
+    [submit, sessionId, advanceToJudging],
+  );
 
   const { start, reset } = useTimer({
     onComplete: () => {
-      updateStatus.mutate(
-        { sessionId, status: 'judging' },
-        {
-          onSuccess: () => {
-            router.replace({
-              pathname: '/session/[id]/break',
-              params: { id: sessionId, break: String(breakMinutes) },
-            });
-          },
-        },
-      );
+      advanceToJudging();
     },
   });
 
@@ -53,21 +80,41 @@ export function OutputScreen() {
     return () => {
       reset();
     };
+    // 依存を意図的に空にしている: start/reset が参照として安定しているうえ、
+    // startedRef で二重 start を防いでいるため再実行は不要。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const submitErrorMessage = submit.isError
+    ? '送信に失敗しました。時間をおいて再度お試しください。'
+    : null;
 
   return (
     <YStack flex={1}>
       <SessionHeader sessionId={sessionId} title="アウトプット" onBeforeCancel={reset} />
-      <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
-        <Paragraph>アウトプットを記入してください</Paragraph>
-        <Timer />
-        {updateStatus.isError ? (
-          <SizableText color="$red10" size="$2" testID="output-screen-error">
-            通信エラーが発生しました。時間をおいて再度お試しください。
-          </SizableText>
-        ) : null}
-      </YStack>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps="handled">
+          <YStack flex={1} padding="$4" gap="$4">
+            <Paragraph>学んだ内容をまとめて送信してください。</Paragraph>
+            <Timer />
+            <OutputEditor
+              value={content}
+              onChange={setContent}
+              onSubmit={handleEditorSubmit}
+              isSubmitting={submit.isPending || updateStatus.isPending}
+              errorMessage={submitErrorMessage}
+            />
+            {updateStatus.isError ? (
+              <SizableText color="$red10" size="$2" testID="output-screen-error">
+                通信エラーが発生しました。時間をおいて再度お試しください。
+              </SizableText>
+            ) : null}
+          </YStack>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </YStack>
   );
 }

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -1,9 +1,13 @@
 /**
  * OutputScreen の振る舞いを検証する。
- * タイマー完了で status=judging に PATCH → break 画面へ replace する。
+ *
+ * - マウント時に phase=output のタイマーが start される
+ * - タイマー完了で PATCH status=judging → break 画面へ replace する
+ * - OutputEditor で本文を入力 → 送信すると submitOutput → PATCH status=judging → break へ replace
+ * - submitOutput が失敗するとエラーメッセージが表示され、再度送信できる (二重送信防止の挙動含む)
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
@@ -49,6 +53,7 @@ describe('OutputScreen', () => {
       completionToken: 0,
     });
     jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-10T15:25:00.000Z'));
   });
 
   afterEach(() => {
@@ -79,6 +84,84 @@ describe('OutputScreen', () => {
 
     await waitFor(() => {
       expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judging');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/session/[id]/break',
+        params: { id: 'ses-123', break: '5' },
+      });
+    });
+    expect(sessionApi.submitOutput).not.toHaveBeenCalled();
+  });
+
+  it('本文入力 → 送信で submitOutput → PATCH judging → break 画面へ replace する', async () => {
+    (sessionApi.submitOutput as jest.Mock).mockResolvedValue(undefined);
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      status: 'judging',
+    });
+
+    const { getByTestId } = renderWithProviders(<OutputScreen />);
+
+    fireEvent.changeText(getByTestId('output-editor-textarea'), '関係代名詞は先行詞を修飾する');
+
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.submitOutput).toHaveBeenCalledWith('ses-123', {
+        content: '関係代名詞は先行詞を修飾する',
+        submitted_at: '2026-04-10T15:25:00.000Z',
+      });
+    });
+    await waitFor(() => {
+      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judging');
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/session/[id]/break',
+        params: { id: 'ses-123', break: '5' },
+      });
+    });
+  });
+
+  it('submitOutput 失敗時はエラーメッセージと「再送する」ボタンが現れ、明示操作で再送できる', async () => {
+    (sessionApi.submitOutput as jest.Mock)
+      .mockRejectedValueOnce(new Error('HTTP 500'))
+      .mockResolvedValueOnce(undefined);
+    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
+      id: 'ses-123',
+      status: 'judging',
+    });
+
+    const { getByTestId } = renderWithProviders(<OutputScreen />);
+
+    fireEvent.changeText(getByTestId('output-editor-textarea'), '本文');
+
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('output-editor-error')).toBeTruthy();
+    });
+    expect(sessionApi.updateSessionStatus).not.toHaveBeenCalled();
+
+    // 失敗後「送信する」ボタンを連打しても再送されない (連打抑止)
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-submit'));
+      fireEvent.press(getByTestId('output-editor-submit'));
+    });
+    expect(sessionApi.submitOutput).toHaveBeenCalledTimes(1);
+
+    // 「再送する」ボタンの明示操作のみ再送される
+    act(() => {
+      fireEvent.press(getByTestId('output-editor-retry'));
+    });
+
+    await waitFor(() => {
+      expect(sessionApi.submitOutput).toHaveBeenCalledTimes(2);
     });
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith({

--- a/mobile/src/features/session/types.ts
+++ b/mobile/src/features/session/types.ts
@@ -28,3 +28,13 @@ export type CreateSessionInput = {
   output_minutes: number;
   break_minutes: number;
 };
+
+/**
+ * アウトプット送信リクエスト。
+ * backend の `POST /api/v1/sessions/{id}/output` と対応する。
+ * `submitted_at` は ISO8601 (JST) のタイムスタンプ文字列。
+ */
+export type SubmitOutputInput = {
+  content: string;
+  submitted_at: string;
+};


### PR DESCRIPTION
## Summary

- アウトプット入力エディター (OutputEditor) を制御コンポーネントへ書き換え、文字数カウンタ・空送信防止・送信中の Spinner / disabled 制御・エラー時の再送 UX を実装した。
- 「送信する」ボタンは 1 度押すと `useRef` で同期ロックされ、ローカル環境で 404 が即時に返っても連打されない。失敗時のみ表示される「再送する」ボタンの明示操作だけで再送する。
- mobile 側の API クライアントとして `sessionApi.submitOutput` と `useSubmitOutput` フックを新設 (POST `/sessions/{id}/output` 仕様)。backend 実装は別 Issue で対応する想定。
- `OutputScreen` にエディタを統合し、送信成功 → `PATCH status=judging` → `/session/[id]/break` 遷移のフローを通せるようにした。タイマー満了時は既存どおり `PATCH judging` のみで遷移する。

Closes #42

## Test plan

自動テスト (CI で実行):

- [x] `task mobile:lint`
- [x] `task mobile:format:check`
- [x] `task mobile:typecheck`
- [x] `task mobile:test`（16 suites / 84 tests pass）
  - 新規: `OutputEditor.test.tsx`（13 ケース、空送信防止・連打抑止・再送 UX を網羅）
  - 新規: `useSubmitOutput.test.tsx`（mutation の成功/失敗）
  - 更新: `OutputScreen.test.tsx`（手動送信成功・失敗→再送フロー）

実機での手動確認:

- [x] 本文未入力で送信ボタンを押下しても何も起きない
- [x] 本文入力後に送信を押下し、404 が返って「送信に失敗しました…」と「再送する」ボタンが表示される
- [x] 「送信する」ボタンを連打しても POST は 1 回しか走らない（uvicorn ログで確認）
- [x] 「再送する」ボタンの明示操作のみ POST が再度走る
- [ ] backend に POST `/sessions/{id}/output` が実装された後、送信成功 → break 画面遷移の通し確認（別 Issue で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)