### PR TITLE
Task #51 pending / error / rejected UX と Problem Details 応答を実装

### DIFF
--- a/backend/db/migrations/versions/2f8d9d3c0a61_create_outputs_and_judgments_tables.py
+++ b/backend/db/migrations/versions/2f8d9d3c0a61_create_outputs_and_judgments_tables.py
@@ -1,0 +1,73 @@
+"""create outputs and judgments tables
+
+Revision ID: 2f8d9d3c0a61
+Revises: a47617ee9c12
+Create Date: 2026-04-16 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "2f8d9d3c0a61"
+down_revision: str | None = "a47617ee9c12"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "outputs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("session_id", sa.Uuid(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            ["sessions.id"],
+            name="fk_outputs_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("session_id", name="uq_outputs_session_id"),
+    )
+    op.create_index("ix_outputs_session_id", "outputs", ["session_id"])
+
+    op.create_table(
+        "judgments",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("session_id", sa.Uuid(), nullable=False),
+        sa.Column("verdict", sa.String(length=16), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False),
+        sa.Column("advice", sa.Text(), nullable=False),
+        sa.Column(
+            "items",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("judged_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            ["sessions.id"],
+            name="fk_judgments_session_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("session_id", name="uq_judgments_session_id"),
+    )
+    op.create_index("ix_judgments_session_id", "judgments", ["session_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_judgments_session_id", table_name="judgments")
+    op.drop_table("judgments")
+    op.drop_index("ix_outputs_session_id", table_name="outputs")
+    op.drop_table("outputs")

--- a/backend/src/application/dto/judgment_dto.py
+++ b/backend/src/application/dto/judgment_dto.py
@@ -1,4 +1,36 @@
-"""判定関連ユースケースの入出力 DTO。
+"""判定関連ユースケースの入出力 DTO。"""
 
-実装は Epic #4 / Epic #5 で追加する。
-"""
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from src.common.models import FrozenModel
+from src.domain.value_objects.verdict import Verdict
+
+
+class JudgmentItemView(FrozenModel):
+    """判定結果の補足コメント。"""
+
+    label: str
+    comment: str
+
+
+class JudgmentView(FrozenModel):
+    """取得済み判定結果。"""
+
+    id: UUID
+    session_id: UUID
+    verdict: Verdict
+    score: int
+    advice: str
+    items: list[JudgmentItemView]
+    judged_at: datetime
+
+
+class JudgmentPendingView(FrozenModel):
+    """判定がまだ未完了であることを表すビュー。"""
+
+    status: Literal["pending"] = "pending"
+    detail: str
+    retry_after_seconds: int
+    estimated_ready_at: datetime

--- a/backend/src/application/dto/session_dto.py
+++ b/backend/src/application/dto/session_dto.py
@@ -2,6 +2,7 @@
 
 CQRS 的な命名で役割を明示する。
 - `CreateSessionCommand`: セッション作成の意図を表すコマンド
+- `SubmitOutputCommand`: アウトプット送信の意図を表すコマンド
 - `SessionView`: クライアントに返却する読み出し用ビュー
 """
 
@@ -29,6 +30,14 @@ class UpdateSessionStatusCommand(FrozenModel):
     new_status: SessionStatus
 
 
+class SubmitOutputCommand(FrozenModel):
+    """POST /sessions/{id}/output の入力コマンド。"""
+
+    session_id: UUID
+    content: str
+    submitted_at: datetime
+
+
 class SessionView(FrozenModel):
     """セッション情報のレスポンス元ビュー。"""
 
@@ -43,3 +52,19 @@ class SessionView(FrozenModel):
     started_at: datetime
     completed_at: datetime | None
     created_at: datetime
+
+
+class OutputView(FrozenModel):
+    """送信済みアウトプットのビュー。"""
+
+    id: UUID
+    session_id: UUID
+    content: str
+    submitted_at: datetime
+
+
+class SubmitOutputView(FrozenModel):
+    """アウトプット送信完了後のビュー。"""
+
+    output: OutputView
+    status: SessionStatus

--- a/backend/src/application/use_cases/get_judgment.py
+++ b/backend/src/application/use_cases/get_judgment.py
@@ -1,4 +1,181 @@
-"""判定結果取得のユースケース。
+"""判定結果取得のユースケース。"""
 
-実装は Epic #4 で追加する。
-"""
+from datetime import UTC, datetime, timedelta
+from math import ceil
+from uuid import UUID, uuid4
+
+from src.application.dto.judgment_dto import (
+    JudgmentItemView,
+    JudgmentPendingView,
+    JudgmentView,
+)
+from src.domain.entities.judgment import Judgment, JudgmentItem
+from src.domain.entities.output import Output
+from src.domain.entities.session import Session
+from src.domain.entities.user import User
+from src.domain.repositories.judgment_repository import JudgmentRepository
+from src.domain.repositories.output_repository import OutputRepository
+from src.domain.repositories.session_repository import SessionRepository
+from src.domain.value_objects.session_status import SessionStatus
+from src.domain.value_objects.verdict import Verdict
+
+_PENDING_BUFFER_SECONDS = 10
+_MIN_REJECTED_LENGTH = 20
+_MIN_PARTIAL_LENGTH = 60
+_MIN_CORRECT_LENGTH = 120
+
+
+class SessionNotFoundError(Exception):
+    """当該 session が存在しない、または別ユーザーのため参照できない。"""
+
+
+class JudgmentNotAvailableError(Exception):
+    """判定取得前のステータスであり、まだ結果取得フェーズではない。"""
+
+
+class OutputNotSubmittedError(Exception):
+    """判定対象のアウトプットがまだ保存されていない。"""
+
+
+class GetJudgment:
+    """判定結果を返す。未完了なら pending を返す。"""
+
+    def __init__(
+        self,
+        session_repository: SessionRepository,
+        output_repository: OutputRepository,
+        judgment_repository: JudgmentRepository,
+    ) -> None:
+        self._session_repository = session_repository
+        self._output_repository = output_repository
+        self._judgment_repository = judgment_repository
+
+    async def execute(
+        self,
+        current_user: User,
+        session_id: UUID,
+    ) -> JudgmentView | JudgmentPendingView:
+        session = await self._session_repository.find_by_id(session_id)
+        if session is None or session.user_id != current_user.id:
+            raise SessionNotFoundError("session not found")
+
+        if session.status in {SessionStatus.INPUT, SessionStatus.OUTPUT}:
+            raise JudgmentNotAvailableError(
+                f"cannot fetch judgment while session is {session.status.value}"
+            )
+
+        existing = await self._judgment_repository.find_by_session_id(session.id)
+        if existing is not None:
+            return _to_view(existing)
+
+        output = await self._output_repository.find_by_session_id(session.id)
+        if output is None:
+            raise OutputNotSubmittedError("output not submitted")
+
+        now = datetime.now(UTC)
+        ready_at = output.submitted_at + timedelta(
+            minutes=session.break_minutes,
+            seconds=_PENDING_BUFFER_SECONDS,
+        )
+        if now < ready_at:
+            return JudgmentPendingView(
+                detail="判定結果を準備しています。少し待ってから再確認してください。",
+                retry_after_seconds=max(1, ceil((ready_at - now).total_seconds())),
+                estimated_ready_at=ready_at,
+            )
+
+        judgment = _build_mock_judgment(session, output, now)
+        await self._judgment_repository.add(judgment)
+
+        if session.status is not SessionStatus.JUDGED:
+            await self._session_repository.update(
+                session.with_status(new_status=SessionStatus.JUDGED, completed_at=now)
+            )
+
+        return _to_view(judgment)
+
+
+def _build_mock_judgment(session: Session, output: Output, now: datetime) -> Judgment:
+    """LLM 実装前の暫定判定。
+
+    Issue #51 では pending / rejected / success の UX と API 契約を成立させることを優先し、
+    本番の LLM 判定の代わりに本文量ベースの簡易ルールで Verdict を決める。
+    """
+    content = output.content.strip()
+
+    if len(content) < _MIN_REJECTED_LENGTH:
+        verdict = Verdict.REJECTED
+        score = 0
+        advice = "学習内容をもう少し具体的に書いてから、あらためて送信してください。"
+        items = [
+            JudgmentItem(
+                label="入力内容の確認",
+                comment="学習内容として判定できるだけの説明量が不足しています。",
+            )
+        ]
+    elif len(content) >= _MIN_CORRECT_LENGTH:
+        verdict = Verdict.CORRECT
+        score = 90
+        advice = "要点を十分に説明できています。この調子で具体例も添えるとさらに安定します。"
+        items = [
+            JudgmentItem(
+                label=f"{session.topic} の理解",
+                comment="主題とポイントが具体的に書かれており、理解度が高く見えます。",
+            ),
+            JudgmentItem(
+                label="説明の具体性",
+                comment="理由や根拠まで触れられており、再現性のある説明になっています。",
+            ),
+        ]
+    elif len(content) >= _MIN_PARTIAL_LENGTH:
+        verdict = Verdict.PARTIAL
+        score = 72
+        advice = "要点は押さえられています。定義と具体例をもう一歩足すと理解が安定します。"
+        items = [
+            JudgmentItem(
+                label=f"{session.topic} の理解",
+                comment="学習内容の要旨は書けていますが、補足説明があるとより明確です。",
+            ),
+            JudgmentItem(
+                label="説明の具体性",
+                comment="具体例や言い換えが増えると、自分の理解としてより伝わります。",
+            ),
+        ]
+    else:
+        verdict = Verdict.INCORRECT
+        score = 45
+        advice = (
+            "説明が短く、理解の根拠がまだ見えにくい状態です。" "要点を整理して再挑戦してください。"
+        )
+        items = [
+            JudgmentItem(
+                label=f"{session.topic} の理解",
+                comment="キーワードはありますが、内容のつながりがまだ十分ではありません。",
+            ),
+            JudgmentItem(
+                label="説明の具体性",
+                comment="学んだことを自分の言葉で 2〜3 文にすると判定しやすくなります。",
+            ),
+        ]
+
+    return Judgment(
+        id=uuid4(),
+        session_id=session.id,
+        verdict=verdict,
+        score=score,
+        advice=advice,
+        items=items,
+        judged_at=now,
+    )
+
+
+def _to_view(judgment: Judgment) -> JudgmentView:
+    return JudgmentView(
+        id=judgment.id,
+        session_id=judgment.session_id,
+        verdict=judgment.verdict,
+        score=judgment.score,
+        advice=judgment.advice,
+        items=[JudgmentItemView(label=item.label, comment=item.comment) for item in judgment.items],
+        judged_at=judgment.judged_at,
+    )

--- a/backend/src/application/use_cases/submit_output.py
+++ b/backend/src/application/use_cases/submit_output.py
@@ -1,4 +1,68 @@
-"""アウトプット送信と判定キューイングのユースケース。
+"""アウトプット送信と判定キューイングのユースケース。"""
 
-実装は Epic #3 / Epic #4 で追加する。
-"""
+from uuid import uuid4
+
+from src.application.dto.session_dto import OutputView, SubmitOutputCommand, SubmitOutputView
+from src.domain.entities.output import Output
+from src.domain.entities.user import User
+from src.domain.repositories.output_repository import OutputRepository
+from src.domain.repositories.session_repository import SessionRepository
+from src.domain.value_objects.session_status import SessionStatus
+
+
+class SessionNotFoundError(Exception):
+    """当該 session が存在しない、または別ユーザーのため参照できない。"""
+
+
+class InvalidSessionStatusError(Exception):
+    """アウトプット送信が許可されていないセッション状態。"""
+
+
+_ALLOWED_OUTPUT_STATUSES = frozenset({SessionStatus.OUTPUT, SessionStatus.JUDGING})
+
+
+class SubmitOutput:
+    """アウトプット本文を保存し、セッションを judging に進める。"""
+
+    def __init__(
+        self,
+        session_repository: SessionRepository,
+        output_repository: OutputRepository,
+    ) -> None:
+        self._session_repository = session_repository
+        self._output_repository = output_repository
+
+    async def execute(self, current_user: User, command: SubmitOutputCommand) -> SubmitOutputView:
+        session = await self._session_repository.find_by_id(command.session_id)
+        if session is None or session.user_id != current_user.id:
+            raise SessionNotFoundError("session not found")
+
+        if session.status not in _ALLOWED_OUTPUT_STATUSES:
+            raise InvalidSessionStatusError(
+                f"cannot submit output while session is {session.status.value}"
+            )
+
+        existing_output = await self._output_repository.find_by_session_id(session.id)
+        output = Output(
+            id=existing_output.id if existing_output is not None else uuid4(),
+            session_id=session.id,
+            content=command.content,
+            submitted_at=command.submitted_at,
+        )
+        await self._output_repository.upsert(output)
+
+        if session.status is SessionStatus.OUTPUT:
+            updated_session = session.with_status(new_status=SessionStatus.JUDGING)
+            await self._session_repository.update(updated_session)
+        else:
+            updated_session = session
+
+        return SubmitOutputView(
+            output=OutputView(
+                id=output.id,
+                session_id=output.session_id,
+                content=output.content,
+                submitted_at=output.submitted_at,
+            ),
+            status=updated_session.status,
+        )

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -7,15 +7,23 @@ presentation からは `request.app.state.container` 経由で参照する。
 from pydantic import BaseModel, ConfigDict
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
+from src.domain.repositories.judgment_repository import JudgmentRepository
+from src.domain.repositories.output_repository import OutputRepository
 from src.domain.repositories.session_repository import SessionRepository
 from src.domain.repositories.user_repository import UserRepository
 from src.domain.services.auth_verifier import AuthVerifier
 from src.infrastructure.auth.firebase_auth import FirebaseAuthVerifier
 from src.infrastructure.persistence.database import Database
+from src.infrastructure.persistence.repositories.pg_judgment_repository import (
+    PgJudgmentRepository,
+)
+from src.infrastructure.persistence.repositories.pg_output_repository import PgOutputRepository
 from src.infrastructure.persistence.repositories.pg_session_repository import (
     PgSessionRepository,
 )
@@ -35,10 +43,14 @@ class Container(BaseModel):
     auth_verifier: AuthVerifier
     user_repository: UserRepository
     session_repository: SessionRepository
+    output_repository: OutputRepository
+    judgment_repository: JudgmentRepository
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
     create_session: CreateSession
     update_session_status: UpdateSessionStatus
+    submit_output: SubmitOutput
+    get_judgment: GetJudgment
 
 
 def build_container(settings: Settings) -> Container:
@@ -47,18 +59,33 @@ def build_container(settings: Settings) -> Container:
     auth_verifier: AuthVerifier = FirebaseAuthVerifier(settings=settings)
     user_repository: UserRepository = PgUserRepository(database=database)
     session_repository: SessionRepository = PgSessionRepository(database=database)
+    output_repository: OutputRepository = PgOutputRepository(database=database)
+    judgment_repository: JudgmentRepository = PgJudgmentRepository(database=database)
     get_user_profile = GetUserProfile()
     update_user_profile = UpdateUserProfile(user_repository=user_repository)
     create_session = CreateSession(session_repository=session_repository)
     update_session_status = UpdateSessionStatus(session_repository=session_repository)
+    submit_output = SubmitOutput(
+        session_repository=session_repository,
+        output_repository=output_repository,
+    )
+    get_judgment = GetJudgment(
+        session_repository=session_repository,
+        output_repository=output_repository,
+        judgment_repository=judgment_repository,
+    )
     return Container(
         settings=settings,
         database=database,
         auth_verifier=auth_verifier,
         user_repository=user_repository,
         session_repository=session_repository,
+        output_repository=output_repository,
+        judgment_repository=judgment_repository,
         get_user_profile=get_user_profile,
         update_user_profile=update_user_profile,
         create_session=create_session,
         update_session_status=update_session_status,
+        submit_output=submit_output,
+        get_judgment=get_judgment,
     )

--- a/backend/src/domain/entities/judgment.py
+++ b/backend/src/domain/entities/judgment.py
@@ -3,18 +3,26 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
 
+from src.common.models import FrozenModel
 from src.domain.value_objects.verdict import Verdict
 
 
-class Judgment(BaseModel):
-    """判定結果を表現するエンティティ。詳細スコアや項目別フィードバックは Epic #4 で追加する。"""
+class JudgmentItem(FrozenModel):
+    """判定結果カードに表示する補足コメント。"""
 
-    model_config = ConfigDict(frozen=True)
+    label: str
+    comment: str
+
+
+class Judgment(FrozenModel):
+    """判定結果を表現するエンティティ。"""
 
     id: UUID
     session_id: UUID
     verdict: Verdict
     score: int = Field(ge=0, le=100)
+    advice: str
+    items: list[JudgmentItem]
     judged_at: datetime

--- a/backend/src/domain/repositories/output_repository.py
+++ b/backend/src/domain/repositories/output_repository.py
@@ -1,0 +1,18 @@
+"""Output リポジトリの抽象 IF。"""
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from src.domain.entities.output import Output
+
+
+class OutputRepository(ABC):
+    """Output の永続化に対する抽象 IF。"""
+
+    @abstractmethod
+    async def upsert(self, output: Output) -> None:
+        """セッションに紐づくアウトプットを保存または更新する。"""
+
+    @abstractmethod
+    async def find_by_session_id(self, session_id: UUID) -> Output | None:
+        """セッション ID からアウトプットを取得する。"""

--- a/backend/src/infrastructure/persistence/models/__init__.py
+++ b/backend/src/infrastructure/persistence/models/__init__.py
@@ -5,7 +5,17 @@
 """
 
 from src.infrastructure.persistence.models.base import Base
+from src.infrastructure.persistence.models.judgment_model import JudgmentModel
+from src.infrastructure.persistence.models.output_model import OutputModel
+from src.infrastructure.persistence.models.session_model import SessionModel
 from src.infrastructure.persistence.models.user_model import UserModel
 from src.infrastructure.persistence.models.user_settings_model import UserSettingsModel
 
-__all__ = ["Base", "UserModel", "UserSettingsModel"]
+__all__ = [
+    "Base",
+    "JudgmentModel",
+    "OutputModel",
+    "SessionModel",
+    "UserModel",
+    "UserSettingsModel",
+]

--- a/backend/src/infrastructure/persistence/models/judgment_model.py
+++ b/backend/src/infrastructure/persistence/models/judgment_model.py
@@ -1,1 +1,30 @@
-"""Judgment の SQLAlchemy ORM モデル。Epic #4 で実装する。"""
+"""judgments テーブルの SQLAlchemy モデル。"""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.models.base import Base
+
+
+class JudgmentModel(Base):
+    """セッションごとの判定結果。"""
+
+    __tablename__ = "judgments"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    session_id: Mapped[UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    verdict: Mapped[str] = mapped_column(String(16), nullable=False)
+    score: Mapped[int] = mapped_column(Integer(), nullable=False)
+    advice: Mapped[str] = mapped_column(Text(), nullable=False)
+    items: Mapped[list[dict[str, str]]] = mapped_column(JSONB(), nullable=False)
+    judged_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/src/infrastructure/persistence/models/output_model.py
+++ b/backend/src/infrastructure/persistence/models/output_model.py
@@ -1,1 +1,31 @@
-"""Output の SQLAlchemy ORM モデル。Epic #3 / Epic #4 で実装する。"""
+"""outputs テーブルの SQLAlchemy モデル。"""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Text, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.models.base import Base
+
+
+class OutputModel(Base):
+    """1 セッション 1 件のアウトプット本文。"""
+
+    __tablename__ = "outputs"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    session_id: Mapped[UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    content: Mapped[str] = mapped_column(Text(), nullable=False)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/src/infrastructure/persistence/repositories/pg_judgment_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_judgment_repository.py
@@ -1,1 +1,70 @@
-"""Judgment リポジトリの PostgreSQL 実装。Epic #4 で実装する。"""
+"""Judgment リポジトリの PostgreSQL 実装。"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from src.domain.entities.judgment import Judgment, JudgmentItem
+from src.domain.repositories.judgment_repository import JudgmentRepository
+from src.domain.value_objects.verdict import Verdict
+from src.infrastructure.persistence.database import Database
+from src.infrastructure.persistence.models.judgment_model import JudgmentModel
+
+
+class PgJudgmentRepository(JudgmentRepository):
+    """PostgreSQL 実装。"""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    async def add(self, judgment: Judgment) -> None:
+        async with self._database.session() as db_session:
+            db_session.add(
+                JudgmentModel(
+                    id=judgment.id,
+                    session_id=judgment.session_id,
+                    verdict=judgment.verdict.value,
+                    score=judgment.score,
+                    advice=judgment.advice,
+                    items=[
+                        {"label": item.label, "comment": item.comment} for item in judgment.items
+                    ],
+                    judged_at=judgment.judged_at,
+                )
+            )
+            await db_session.commit()
+
+    async def find_by_id(self, judgment_id: UUID) -> Judgment | None:
+        async with self._database.session() as db_session:
+            stmt = select(JudgmentModel).where(JudgmentModel.id == judgment_id)
+            result = await db_session.execute(stmt)
+            model = result.scalar_one_or_none()
+            return _to_judgment(model) if model is not None else None
+
+    async def find_by_session_id(self, session_id: UUID) -> Judgment | None:
+        async with self._database.session() as db_session:
+            stmt = select(JudgmentModel).where(JudgmentModel.session_id == session_id)
+            result = await db_session.execute(stmt)
+            model = result.scalar_one_or_none()
+            return _to_judgment(model) if model is not None else None
+
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        cursor: str | None,
+        limit: int,
+    ) -> tuple[list[Judgment], str | None]:
+        del user_id, cursor, limit
+        raise NotImplementedError("履歴一覧エンドポイントの Task で実装する")
+
+
+def _to_judgment(model: JudgmentModel) -> Judgment:
+    return Judgment(
+        id=model.id,
+        session_id=model.session_id,
+        verdict=Verdict(model.verdict),
+        score=model.score,
+        advice=model.advice,
+        items=[JudgmentItem(label=item["label"], comment=item["comment"]) for item in model.items],
+        judged_at=model.judged_at,
+    )

--- a/backend/src/infrastructure/persistence/repositories/pg_output_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_output_repository.py
@@ -1,0 +1,55 @@
+"""Output リポジトリの PostgreSQL 実装。"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from src.domain.entities.output import Output
+from src.domain.repositories.output_repository import OutputRepository
+from src.infrastructure.persistence.database import Database
+from src.infrastructure.persistence.models.output_model import OutputModel
+
+
+class PgOutputRepository(OutputRepository):
+    """PostgreSQL 実装。"""
+
+    def __init__(self, database: Database) -> None:
+        self._database = database
+
+    async def upsert(self, output: Output) -> None:
+        async with self._database.session() as db_session:
+            stmt = select(OutputModel).where(OutputModel.session_id == output.session_id)
+            result = await db_session.execute(stmt)
+            model = result.scalar_one_or_none()
+
+            if model is None:
+                db_session.add(
+                    OutputModel(
+                        id=output.id,
+                        session_id=output.session_id,
+                        content=output.content,
+                        submitted_at=output.submitted_at,
+                    )
+                )
+            else:
+                model.id = output.id
+                model.content = output.content
+                model.submitted_at = output.submitted_at
+
+            await db_session.commit()
+
+    async def find_by_session_id(self, session_id: UUID) -> Output | None:
+        async with self._database.session() as db_session:
+            stmt = select(OutputModel).where(OutputModel.session_id == session_id)
+            result = await db_session.execute(stmt)
+            model = result.scalar_one_or_none()
+            return _to_output(model) if model is not None else None
+
+
+def _to_output(model: OutputModel) -> Output:
+    return Output(
+        id=model.id,
+        session_id=model.session_id,
+        content=model.content,
+        submitted_at=model.submitted_at,
+    )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -7,12 +7,20 @@ Composition Root でコンテナを組み立て、ルーターを束ねる。
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 
 from src.config import Settings, get_settings
 from src.container import Container, build_container
 from src.presentation.api.v1.router import api_v1_router
 from src.presentation.health import health_router
+from src.presentation.problem_details import (
+    ProblemDetailsError,
+    http_exception_handler,
+    problem_details_exception_handler,
+    unexpected_exception_handler,
+    validation_exception_handler,
+)
 
 
 def create_app(
@@ -36,6 +44,10 @@ def create_app(
         version="0.1.0",
         lifespan=lifespan,
     )
+    app.add_exception_handler(ProblemDetailsError, problem_details_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unexpected_exception_handler)
 
     app.include_router(health_router)
     app.include_router(api_v1_router, prefix="/api/v1")

--- a/backend/src/presentation/api/v1/sessions.py
+++ b/backend/src/presentation/api/v1/sessions.py
@@ -2,18 +2,35 @@
 
 - POST /api/v1/sessions: 新規セッション作成（Issue #39）
 - PATCH /api/v1/sessions/{id}: フェーズ遷移に伴うステータス更新（Issue #41）
-
-GET / 判定系は別 Task で追加する。
+- POST /api/v1/sessions/{id}/output: アウトプット送信（Issue #51）
+- GET /api/v1/sessions/{id}/judgment: 判定結果取得（Issue #51）
 """
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+from fastapi import APIRouter, Depends, Path, Request, status
+from fastapi.responses import JSONResponse
 
+from src.application.dto.judgment_dto import JudgmentPendingView
 from src.application.dto.session_dto import (
     CreateSessionCommand,
     SessionView,
+    SubmitOutputCommand,
+    SubmitOutputView,
     UpdateSessionStatusCommand,
+)
+from src.application.use_cases.get_judgment import (
+    JudgmentNotAvailableError,
+    OutputNotSubmittedError,
+)
+from src.application.use_cases.get_judgment import (
+    SessionNotFoundError as JudgmentSessionNotFoundError,
+)
+from src.application.use_cases.submit_output import (
+    InvalidSessionStatusError as SubmitOutputInvalidSessionStatusError,
+)
+from src.application.use_cases.submit_output import (
+    SessionNotFoundError as SubmitOutputSessionNotFoundError,
 )
 from src.application.use_cases.update_session_status import (
     InvalidSessionStatusTransitionError,
@@ -22,9 +39,18 @@ from src.application.use_cases.update_session_status import (
 from src.domain.entities.user import User
 from src.presentation.container_access import get_presentation_container
 from src.presentation.middleware.auth_middleware import get_current_user
+from src.presentation.problem_details import ProblemDetailsError
+from src.presentation.schemas.judgment_schema import (
+    JudgmentItemResponse,
+    JudgmentPendingResponse,
+    JudgmentResponse,
+)
 from src.presentation.schemas.session_schema import (
     CreateSessionRequest,
+    OutputResponse,
     SessionResponse,
+    SubmitOutputRequest,
+    SubmitOutputResponse,
     UpdateSessionRequest,
 )
 
@@ -70,16 +96,116 @@ async def update_session(
     try:
         view = await container.update_session_status.execute(current_user, command)
     except SessionNotFoundError as exc:
-        raise HTTPException(
+        raise ProblemDetailsError(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="session not found",
+            problem_type="session_not_found",
+            title="Session Not Found",
+            detail="指定されたセッションが見つかりません。",
         ) from exc
     except InvalidSessionStatusTransitionError as exc:
-        raise HTTPException(
+        raise ProblemDetailsError(
             status_code=status.HTTP_400_BAD_REQUEST,
+            problem_type="invalid_session_transition",
+            title="Invalid Session Transition",
             detail=str(exc),
         ) from exc
     return _to_response(view)
+
+
+@sessions_router.post(
+    "/{session_id}/output",
+    response_model=SubmitOutputResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_output(
+    body: SubmitOutputRequest,
+    request: Request,
+    session_id: UUID = Path(...),  # noqa: B008
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> SubmitOutputResponse:
+    """アウトプット本文を保存し、判定待ち状態に進める。"""
+    container = get_presentation_container(request)
+    command = SubmitOutputCommand(
+        session_id=session_id,
+        content=body.content,
+        submitted_at=body.submitted_at,
+    )
+    try:
+        view = await container.submit_output.execute(current_user, command)
+    except SubmitOutputSessionNotFoundError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            problem_type="session_not_found",
+            title="Session Not Found",
+            detail="指定されたセッションが見つかりません。",
+        ) from exc
+    except SubmitOutputInvalidSessionStatusError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_409_CONFLICT,
+            problem_type="invalid_session_state",
+            title="Invalid Session State",
+            detail=str(exc),
+        ) from exc
+    return _to_submit_output_response(view)
+
+
+@sessions_router.get(
+    "/{session_id}/judgment",
+    response_model=JudgmentResponse | JudgmentPendingResponse,
+)
+async def get_judgment(
+    request: Request,
+    session_id: UUID = Path(...),  # noqa: B008
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> JudgmentResponse | JSONResponse:
+    """判定結果を取得する。未完了なら 202 pending を返す。"""
+    container = get_presentation_container(request)
+    try:
+        view = await container.get_judgment.execute(current_user, session_id)
+    except JudgmentSessionNotFoundError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            problem_type="session_not_found",
+            title="Session Not Found",
+            detail="指定されたセッションが見つかりません。",
+        ) from exc
+    except JudgmentNotAvailableError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_409_CONFLICT,
+            problem_type="judgment_not_available",
+            title="Judgment Not Available",
+            detail=str(exc),
+        ) from exc
+    except OutputNotSubmittedError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_409_CONFLICT,
+            problem_type="output_not_submitted",
+            title="Output Not Submitted",
+            detail=str(exc),
+        ) from exc
+
+    if isinstance(view, JudgmentPendingView):
+        pending = JudgmentPendingResponse(
+            status=view.status,
+            detail=view.detail,
+            retry_after_seconds=view.retry_after_seconds,
+            estimated_ready_at=view.estimated_ready_at,
+        )
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content=pending.model_dump(mode="json"),
+            headers={"Retry-After": str(view.retry_after_seconds)},
+        )
+
+    return JudgmentResponse(
+        id=view.id,
+        session_id=view.session_id,
+        verdict=view.verdict,
+        score=view.score,
+        advice=view.advice,
+        items=[JudgmentItemResponse(label=item.label, comment=item.comment) for item in view.items],
+        judged_at=view.judged_at,
+    )
 
 
 def _to_response(view: SessionView) -> SessionResponse:
@@ -95,4 +221,16 @@ def _to_response(view: SessionView) -> SessionResponse:
         started_at=view.started_at,
         completed_at=view.completed_at,
         created_at=view.created_at,
+    )
+
+
+def _to_submit_output_response(view: SubmitOutputView) -> SubmitOutputResponse:
+    return SubmitOutputResponse(
+        output=OutputResponse(
+            id=view.output.id,
+            session_id=view.output.session_id,
+            content=view.output.content,
+            submitted_at=view.output.submitted_at,
+        ),
+        status=view.status,
     )

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -6,7 +6,9 @@ from typing import cast
 from fastapi import Request
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.domain.repositories.user_repository import UserRepository
@@ -31,6 +33,8 @@ class PresentationContainer(ABC):
     update_user_profile: UpdateUserProfile
     create_session: CreateSession
     update_session_status: UpdateSessionStatus
+    submit_output: SubmitOutput
+    get_judgment: GetJudgment
 
 
 def get_presentation_container(request: Request) -> PresentationContainer:

--- a/backend/src/presentation/middleware/auth_middleware.py
+++ b/backend/src/presentation/middleware/auth_middleware.py
@@ -8,7 +8,7 @@ users / user_settings を自動作成してから domain.User を返す。
 from datetime import UTC, datetime
 from uuid import uuid4
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.domain.entities.user import User
@@ -23,6 +23,7 @@ from src.presentation.container_access import (
     PresentationContainer,
     get_presentation_container,
 )
+from src.presentation.problem_details import ProblemDetailsError
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -33,9 +34,11 @@ async def get_current_user(
 ) -> User:
     """Authorization ヘッダを検証し、対応する内部ユーザを返す。"""
     if credentials is None or not credentials.credentials:
-        raise HTTPException(
+        raise ProblemDetailsError(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="認証トークンが指定されていません",
+            problem_type="authentication_required",
+            title="Authentication Required",
+            detail="認証トークンが指定されていません。",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -44,9 +47,11 @@ async def get_current_user(
     try:
         verified = verifier.verify_id_token(credentials.credentials)
     except InvalidTokenError as exc:
-        raise HTTPException(
+        raise ProblemDetailsError(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="認証トークンが無効です",
+            problem_type="authentication_error",
+            title="Authentication Error",
+            detail="認証トークンが無効です。",
             headers={"WWW-Authenticate": "Bearer"},
         ) from exc
 

--- a/backend/src/presentation/problem_details.py
+++ b/backend/src/presentation/problem_details.py
@@ -1,0 +1,133 @@
+"""Problem Details 例外と FastAPI ハンドラー。"""
+
+from collections.abc import Mapping, Sequence
+from http import HTTPStatus
+from typing import Any
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from src.presentation.schemas.problem_schema import ProblemDetails
+
+_DEFAULT_PROBLEM_TYPES: dict[int, str] = {
+    400: "bad_request",
+    401: "authentication_error",
+    404: "not_found",
+    409: "conflict",
+    422: "validation_error",
+    500: "internal_server_error",
+}
+
+
+class ProblemDetailsError(Exception):
+    """Problem Details を返すためのアプリ内例外。"""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        problem_type: str,
+        title: str | None = None,
+        detail: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        errors: Sequence[Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.problem_type = problem_type
+        self.title = title or _default_title(status_code)
+        self.detail = detail
+        self.headers = dict(headers or {})
+        self.errors = errors
+        super().__init__(detail or self.title)
+
+
+async def problem_details_exception_handler(
+    request: Request,
+    exc: ProblemDetailsError,
+) -> JSONResponse:
+    return _build_response(
+        request=request,
+        status_code=exc.status_code,
+        problem_type=exc.problem_type,
+        title=exc.title,
+        detail=exc.detail,
+        headers=exc.headers,
+        errors=exc.errors,
+    )
+
+
+async def http_exception_handler(
+    request: Request,
+    exc: StarletteHTTPException,
+) -> JSONResponse:
+    detail = exc.detail if isinstance(exc.detail, str) else None
+    return _build_response(
+        request=request,
+        status_code=exc.status_code,
+        problem_type=_DEFAULT_PROBLEM_TYPES.get(exc.status_code, "http_error"),
+        title=_default_title(exc.status_code),
+        detail=detail,
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def validation_exception_handler(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    return _build_response(
+        request=request,
+        status_code=422,
+        problem_type="validation_error",
+        title="Validation Error",
+        detail="リクエスト内容を確認してください。",
+        errors=exc.errors(),
+    )
+
+
+async def unexpected_exception_handler(
+    request: Request,
+    exc: Exception,  # noqa: ARG001
+) -> JSONResponse:
+    return _build_response(
+        request=request,
+        status_code=500,
+        problem_type="internal_server_error",
+        title="Internal Server Error",
+        detail="予期しないエラーが発生しました。",
+    )
+
+
+def _build_response(
+    *,
+    request: Request,
+    status_code: int,
+    problem_type: str,
+    title: str,
+    detail: str | None,
+    headers: Mapping[str, str] | None = None,
+    errors: Sequence[Any] | None = None,
+) -> JSONResponse:
+    problem = ProblemDetails(
+        type=problem_type,
+        title=title,
+        status=status_code,
+        detail=detail,
+        instance=request.url.path,
+        errors=errors,
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=problem.model_dump(exclude_none=True, mode="json"),
+        headers=dict(headers or {}),
+        media_type="application/problem+json",
+    )
+
+
+def _default_title(status_code: int) -> str:
+    try:
+        return HTTPStatus(status_code).phrase
+    except ValueError:
+        return "Error"

--- a/backend/src/presentation/schemas/judgment_schema.py
+++ b/backend/src/presentation/schemas/judgment_schema.py
@@ -1,1 +1,36 @@
-"""判定 API の Pydantic スキーマ。Epic #4 / Epic #5 で実装する。"""
+"""判定 API の Pydantic スキーマ。"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from src.common.models import FrozenModel
+from src.domain.value_objects.verdict import Verdict
+
+
+class JudgmentItemResponse(FrozenModel):
+    """判定結果の補足コメント。"""
+
+    label: str
+    comment: str
+
+
+class JudgmentResponse(FrozenModel):
+    """判定結果レスポンス。"""
+
+    id: UUID
+    session_id: UUID
+    verdict: Verdict
+    score: int
+    advice: str
+    items: list[JudgmentItemResponse]
+    judged_at: datetime
+
+
+class JudgmentPendingResponse(FrozenModel):
+    """判定未完了レスポンス。"""
+
+    status: Literal["pending"] = "pending"
+    detail: str
+    retry_after_seconds: int
+    estimated_ready_at: datetime

--- a/backend/src/presentation/schemas/problem_schema.py
+++ b/backend/src/presentation/schemas/problem_schema.py
@@ -1,0 +1,17 @@
+"""RFC 7807 Problem Details の共通スキーマ。"""
+
+from collections.abc import Sequence
+from typing import Any
+
+from src.common.models import FrozenModel
+
+
+class ProblemDetails(FrozenModel):
+    """HTTP エラーを統一表現する Problem Details。"""
+
+    type: str
+    title: str
+    status: int
+    detail: str | None = None
+    instance: str | None = None
+    errors: Sequence[Any] | None = None

--- a/backend/src/presentation/schemas/session_schema.py
+++ b/backend/src/presentation/schemas/session_schema.py
@@ -1,12 +1,18 @@
 """/api/v1/sessions 系の Pydantic スキーマ。"""
 
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, StringConstraints
 
 from src.common.models import FrozenModel, StrictRequestModel
 from src.domain.value_objects.session_status import SessionStatus
+
+NonEmptyOutputContent = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
+]
 
 
 class CreateSessionRequest(StrictRequestModel):
@@ -33,6 +39,13 @@ class UpdateSessionRequest(StrictRequestModel):
     status: SessionStatus
 
 
+class SubmitOutputRequest(StrictRequestModel):
+    """POST /sessions/{id}/output の body。"""
+
+    content: NonEmptyOutputContent
+    submitted_at: datetime
+
+
 class SessionResponse(FrozenModel):
     """POST /sessions / GET /sessions/{id} のレスポンス。"""
 
@@ -47,3 +60,19 @@ class SessionResponse(FrozenModel):
     started_at: datetime
     completed_at: datetime | None
     created_at: datetime
+
+
+class OutputResponse(FrozenModel):
+    """送信済みアウトプット。"""
+
+    id: UUID
+    session_id: UUID
+    content: str
+    submitted_at: datetime
+
+
+class SubmitOutputResponse(FrozenModel):
+    """アウトプット送信完了レスポンス。"""
+
+    output: OutputResponse
+    status: SessionStatus

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,7 +15,9 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
 from src.config import Settings
@@ -23,6 +25,8 @@ from src.container import Container
 from src.infrastructure.persistence.database import Database
 from src.main import create_app
 from tests.fakes.fake_auth_verifier import FakeAuthVerifier
+from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
+from tests.fakes.fake_output_repository import FakeOutputRepository
 from tests.fakes.fake_session_repository import FakeSessionRepository
 from tests.fakes.fake_user_repository import FakeUserRepository
 
@@ -50,6 +54,16 @@ def fake_session_repository() -> FakeSessionRepository:
 
 
 @pytest.fixture
+def fake_output_repository() -> FakeOutputRepository:
+    return FakeOutputRepository()
+
+
+@pytest.fixture
+def fake_judgment_repository() -> FakeJudgmentRepository:
+    return FakeJudgmentRepository()
+
+
+@pytest.fixture
 def fake_auth_verifier() -> FakeAuthVerifier:
     return FakeAuthVerifier()
 
@@ -59,6 +73,8 @@ def container(
     settings: Settings,
     fake_user_repository: FakeUserRepository,
     fake_session_repository: FakeSessionRepository,
+    fake_output_repository: FakeOutputRepository,
+    fake_judgment_repository: FakeJudgmentRepository,
     fake_auth_verifier: FakeAuthVerifier,
 ) -> Container:
     """fake 実装を差し込んだ Container。"""
@@ -69,10 +85,21 @@ def container(
         auth_verifier=fake_auth_verifier,
         user_repository=fake_user_repository,
         session_repository=fake_session_repository,
+        output_repository=fake_output_repository,
+        judgment_repository=fake_judgment_repository,
         get_user_profile=GetUserProfile(),
         update_user_profile=UpdateUserProfile(user_repository=fake_user_repository),
         create_session=CreateSession(session_repository=fake_session_repository),
         update_session_status=UpdateSessionStatus(session_repository=fake_session_repository),
+        submit_output=SubmitOutput(
+            session_repository=fake_session_repository,
+            output_repository=fake_output_repository,
+        ),
+        get_judgment=GetJudgment(
+            session_repository=fake_session_repository,
+            output_repository=fake_output_repository,
+            judgment_repository=fake_judgment_repository,
+        ),
     )
 
 

--- a/backend/tests/fakes/fake_judgment_repository.py
+++ b/backend/tests/fakes/fake_judgment_repository.py
@@ -1,0 +1,33 @@
+"""インメモリな JudgmentRepository 実装。"""
+
+from uuid import UUID
+
+from src.domain.entities.judgment import Judgment
+from src.domain.repositories.judgment_repository import JudgmentRepository
+
+
+class FakeJudgmentRepository(JudgmentRepository):
+    """in-memory な JudgmentRepository。テスト以外で使用しない。"""
+
+    def __init__(self) -> None:
+        self.judgments_by_id: dict[UUID, Judgment] = {}
+        self.judgments_by_session_id: dict[UUID, Judgment] = {}
+
+    async def add(self, judgment: Judgment) -> None:
+        self.judgments_by_id[judgment.id] = judgment
+        self.judgments_by_session_id[judgment.session_id] = judgment
+
+    async def find_by_id(self, judgment_id: UUID) -> Judgment | None:
+        return self.judgments_by_id.get(judgment_id)
+
+    async def find_by_session_id(self, session_id: UUID) -> Judgment | None:
+        return self.judgments_by_session_id.get(session_id)
+
+    async def list_by_user(
+        self,
+        user_id: UUID,  # noqa: ARG002
+        cursor: str | None,  # noqa: ARG002
+        limit: int,
+    ) -> tuple[list[Judgment], str | None]:
+        items = list(self.judgments_by_id.values())
+        return items[:limit], None

--- a/backend/tests/fakes/fake_output_repository.py
+++ b/backend/tests/fakes/fake_output_repository.py
@@ -1,0 +1,19 @@
+"""インメモリな OutputRepository 実装。"""
+
+from uuid import UUID
+
+from src.domain.entities.output import Output
+from src.domain.repositories.output_repository import OutputRepository
+
+
+class FakeOutputRepository(OutputRepository):
+    """in-memory な OutputRepository。テスト以外で使用しない。"""
+
+    def __init__(self) -> None:
+        self.outputs_by_session_id: dict[UUID, Output] = {}
+
+    async def upsert(self, output: Output) -> None:
+        self.outputs_by_session_id[output.session_id] = output
+
+    async def find_by_session_id(self, session_id: UUID) -> Output | None:
+        return self.outputs_by_session_id.get(session_id)

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -47,6 +47,33 @@ async def _advance_status(
     return response.json()
 
 
+async def _submit_output(
+    client: AsyncClient,
+    auth_uid: str,
+    session_id: str,
+    *,
+    content: str = "関係代名詞は先行詞を修飾し、文中の名詞を詳しく説明する表現です。",
+    submitted_at: str = "2026-04-10T15:25:00Z",
+):
+    return await client.post(
+        f"/api/v1/sessions/{session_id}/output",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={"content": content, "submitted_at": submitted_at},
+    )
+
+
+def _assert_problem_details(
+    body: dict[str, object],
+    *,
+    expected_status: int,
+    expected_type: str,
+) -> None:
+    assert body["status"] == expected_status
+    assert body["type"] == expected_type
+    assert body["title"]
+    assert body["instance"]
+
+
 @pytest.mark.asyncio
 async def test_create_session_requires_authorization_header(client: AsyncClient):
     response = await client.post("/api/v1/sessions", json=_valid_body())
@@ -61,6 +88,11 @@ async def test_create_session_rejects_invalid_token(client: AsyncClient):
         json=_valid_body(),
     )
     assert response.status_code == 401
+    _assert_problem_details(
+        response.json(),
+        expected_status=401,
+        expected_type="authentication_error",
+    )
 
 
 @pytest.mark.asyncio
@@ -129,6 +161,11 @@ async def test_create_session_forbids_extra_fields(client: AsyncClient):
     payload = _valid_body() | {"unknown": "x"}
     response = await client.post("/api/v1/sessions", headers=headers, json=payload)
     assert response.status_code == 422
+    _assert_problem_details(
+        response.json(),
+        expected_status=422,
+        expected_type="validation_error",
+    )
 
 
 # --- PATCH /sessions/{id} (Issue #41) ---
@@ -163,6 +200,11 @@ async def test_update_session_returns_404_for_unknown_session(client: AsyncClien
         json={"status": "output"},
     )
     assert response.status_code == 404
+    _assert_problem_details(
+        response.json(),
+        expected_status=404,
+        expected_type="session_not_found",
+    )
 
 
 @pytest.mark.asyncio
@@ -287,3 +329,199 @@ async def test_update_session_rejects_extra_fields(client: AsyncClient):
         json={"status": "output", "unknown": "x"},
     )
     assert response.status_code == 422
+
+
+# --- POST /sessions/{id}/output (Issue #51) ---
+
+
+@pytest.mark.asyncio
+async def test_submit_output_requires_authorization_header(client: AsyncClient):
+    created = await _create_session(client, "submit-user-001")
+    await _advance_status(client, "submit-user-001", created["id"], "output")
+
+    response = await client.post(
+        f"/api/v1/sessions/{created['id']}/output",
+        json={
+            "content": "本文です",
+            "submitted_at": "2026-04-10T15:25:00Z",
+        },
+    )
+
+    assert response.status_code == 401
+    _assert_problem_details(
+        response.json(),
+        expected_status=401,
+        expected_type="authentication_required",
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_output_returns_202_and_updates_status_to_judging(client: AsyncClient):
+    auth_uid = "submit-user-002"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+
+    response = await _submit_output(client, auth_uid, session_id)
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "judging"
+    assert body["output"]["session_id"] == session_id
+    assert body["output"]["content"].startswith("関係代名詞")
+
+
+@pytest.mark.asyncio
+async def test_submit_output_returns_404_for_other_users_session(client: AsyncClient):
+    created = await _create_session(client, "submit-user-owner")
+    await _advance_status(client, "submit-user-owner", created["id"], "output")
+
+    response = await _submit_output(client, "submit-user-other", created["id"])
+
+    assert response.status_code == 404
+    _assert_problem_details(
+        response.json(),
+        expected_status=404,
+        expected_type="session_not_found",
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_output_rejects_invalid_session_state(client: AsyncClient):
+    created = await _create_session(client, "submit-user-003")
+
+    response = await _submit_output(client, "submit-user-003", created["id"])
+
+    assert response.status_code == 409
+    _assert_problem_details(
+        response.json(),
+        expected_status=409,
+        expected_type="invalid_session_state",
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_output_rejects_blank_content_with_problem_details(client: AsyncClient):
+    auth_uid = "submit-user-004"
+    created = await _create_session(client, auth_uid)
+    await _advance_status(client, auth_uid, created["id"], "output")
+
+    response = await client.post(
+        f"/api/v1/sessions/{created['id']}/output",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json={
+            "content": "   ",
+            "submitted_at": "2026-04-10T15:25:00Z",
+        },
+    )
+
+    assert response.status_code == 422
+    _assert_problem_details(
+        response.json(),
+        expected_status=422,
+        expected_type="validation_error",
+    )
+
+
+# --- GET /sessions/{id}/judgment (Issue #51) ---
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_returns_202_while_pending(client: AsyncClient):
+    auth_uid = "judgment-user-001"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+    await _submit_output(
+        client,
+        auth_uid,
+        session_id,
+        submitted_at="2099-04-10T15:25:00Z",
+    )
+
+    response = await client.get(
+        f"/api/v1/sessions/{session_id}/judgment",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "pending"
+    assert body["retry_after_seconds"] >= 1
+    assert response.headers["Retry-After"]
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_returns_rejected_verdict_for_short_content(client: AsyncClient):
+    auth_uid = "judgment-user-002"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+    await _submit_output(
+        client,
+        auth_uid,
+        session_id,
+        content="短いです",
+        submitted_at="2020-04-10T15:25:00Z",
+    )
+
+    response = await client.get(
+        f"/api/v1/sessions/{session_id}/judgment",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["verdict"] == "rejected"
+    assert body["score"] == 0
+    assert "学習内容" in body["advice"]
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_returns_ready_judgment_for_past_submission(client: AsyncClient):
+    auth_uid = "judgment-user-003"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+    await _submit_output(
+        client,
+        auth_uid,
+        session_id,
+        content=(
+            "関係代名詞は先行詞を詳しく説明する節を作るために使います。"
+            "who は人、which は物に使い、that はどちらにも使えることがあります。"
+            "主節と従属節の関係を意識すると理解しやすいです。"
+        ),
+        submitted_at="2020-04-10T15:25:00Z",
+    )
+
+    response = await client.get(
+        f"/api/v1/sessions/{session_id}/judgment",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["verdict"] in {"correct", "partial"}
+    assert body["items"]
+    assert body["judged_at"]
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_returns_409_when_output_not_submitted(client: AsyncClient):
+    auth_uid = "judgment-user-004"
+    created = await _create_session(client, auth_uid)
+    await _advance_status(client, auth_uid, created["id"], "output")
+    await _advance_status(client, auth_uid, created["id"], "judging")
+
+    response = await client.get(
+        f"/api/v1/sessions/{created['id']}/judgment",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 409
+    _assert_problem_details(
+        response.json(),
+        expected_status=409,
+        expected_type="output_not_submitted",
+    )

--- a/mobile/src/features/session/api/sessionApi.ts
+++ b/mobile/src/features/session/api/sessionApi.ts
@@ -4,9 +4,13 @@
 import { api } from '@/shared/lib/api';
 import type {
   CreateSessionInput,
+  Judgment,
+  JudgmentFetchResult,
+  JudgmentPending,
   Session,
   SessionStatus,
   SubmitOutputInput,
+  SubmitOutputResponse,
 } from '@/features/session/types';
 
 export async function createSession(input: CreateSessionInput): Promise<Session> {
@@ -28,8 +32,24 @@ export async function updateSessionStatus(
 
 /**
  * アウトプット本文と送信時刻を backend に送る。
- * backend 側のレスポンス型が未確定のため、成功/失敗のみをハンドリングする。
  */
-export async function submitOutput(sessionId: string, input: SubmitOutputInput): Promise<void> {
-  await api.post<unknown>(`/sessions/${sessionId}/output`, input);
+export async function submitOutput(
+  sessionId: string,
+  input: SubmitOutputInput,
+): Promise<SubmitOutputResponse> {
+  const { data } = await api.post<SubmitOutputResponse>(`/sessions/${sessionId}/output`, input);
+  return data;
+}
+
+/**
+ * 判定結果を取得する。未完了の場合は 202 pending を返す。
+ */
+export async function getJudgment(sessionId: string): Promise<JudgmentFetchResult> {
+  const response = await api.get<Judgment | JudgmentPending>(`/sessions/${sessionId}/judgment`);
+
+  if (response.status === 202) {
+    return { kind: 'pending', pending: response.data as JudgmentPending };
+  }
+
+  return { kind: 'ready', judgment: response.data as Judgment };
 }

--- a/mobile/src/features/session/components/JudgmentCard.tsx
+++ b/mobile/src/features/session/components/JudgmentCard.tsx
@@ -1,14 +1,50 @@
 /**
- * 判定結果カード。Epic #4 で実装する。
+ * 判定結果カード。
  */
-import { Text } from 'tamagui';
+import { H3, Paragraph, SizableText, XStack, YStack } from 'tamagui';
 
+import type { Judgment } from '@/features/session/types';
 import { Card } from '@/shared/components/Card';
 
-export function JudgmentCard() {
+type JudgmentCardProps = {
+  judgment: Judgment;
+};
+
+const VERDICT_LABELS: Record<Judgment['verdict'], string> = {
+  correct: 'Good',
+  partial: 'Partial',
+  incorrect: 'Needs Work',
+  rejected: 'Rejected',
+};
+
+const VERDICT_COLORS: Record<Judgment['verdict'], string> = {
+  correct: '$green10',
+  partial: '$orange10',
+  incorrect: '$red10',
+  rejected: '$red10',
+};
+
+export function JudgmentCard({ judgment }: JudgmentCardProps) {
   return (
-    <Card>
-      <Text>判定結果 (placeholder)</Text>
+    <Card testID="judgment-card">
+      <YStack gap="$3">
+        <XStack alignItems="center" justifyContent="space-between">
+          <H3>今回の判定</H3>
+          <SizableText color={VERDICT_COLORS[judgment.verdict]} fontWeight="700" size="$3">
+            {VERDICT_LABELS[judgment.verdict]}
+          </SizableText>
+        </XStack>
+        <Paragraph testID="judgment-score">スコア: {judgment.score}</Paragraph>
+        <Paragraph>{judgment.advice}</Paragraph>
+        <YStack gap="$2">
+          {judgment.items.map((item) => (
+            <YStack key={item.label} gap="$1">
+              <SizableText fontWeight="700">{item.label}</SizableText>
+              <Paragraph>{item.comment}</Paragraph>
+            </YStack>
+          ))}
+        </YStack>
+      </YStack>
     </Card>
   );
 }

--- a/mobile/src/features/session/hooks/__tests__/useSubmitOutput.test.tsx
+++ b/mobile/src/features/session/hooks/__tests__/useSubmitOutput.test.tsx
@@ -29,7 +29,15 @@ describe('useSubmitOutput', () => {
   });
 
   it('mutate 呼び出しで submitOutput が正しい引数で呼ばれる', async () => {
-    (sessionApi.submitOutput as jest.Mock).mockResolvedValue(undefined);
+    (sessionApi.submitOutput as jest.Mock).mockResolvedValue({
+      status: 'judging',
+      output: {
+        id: 'out-1',
+        session_id: 'ses-1',
+        content: '本文',
+        submitted_at: '2026-04-10T15:25:00.000Z',
+      },
+    });
 
     const { result } = renderHook(() => useSubmitOutput(), { wrapper });
 

--- a/mobile/src/features/session/hooks/useJudgment.ts
+++ b/mobile/src/features/session/hooks/useJudgment.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getJudgment } from '@/features/session/api/sessionApi';
+import type { JudgmentFetchResult } from '@/features/session/types';
+import type { ApiError } from '@/shared/lib/api';
+
+const JUDGMENT_POLLING_INTERVAL_MS = 5_000;
+
+export function useJudgment(sessionId: string, autoRefetch = true) {
+  return useQuery<JudgmentFetchResult, ApiError>({
+    queryKey: ['sessions', sessionId, 'judgment'],
+    queryFn: () => getJudgment(sessionId),
+    enabled: sessionId.length > 0,
+    retry: false,
+    refetchInterval: (query) =>
+      autoRefetch && query.state.data?.kind === 'pending' ? JUDGMENT_POLLING_INTERVAL_MS : false,
+  });
+}

--- a/mobile/src/features/session/hooks/useSubmitOutput.ts
+++ b/mobile/src/features/session/hooks/useSubmitOutput.ts
@@ -8,14 +8,14 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { submitOutput } from '@/features/session/api/sessionApi';
-import type { SubmitOutputInput } from '@/features/session/types';
+import type { SubmitOutputInput, SubmitOutputResponse } from '@/features/session/types';
 
 export type UseSubmitOutputInput = SubmitOutputInput & {
   sessionId: string;
 };
 
 export function useSubmitOutput() {
-  return useMutation<void, Error, UseSubmitOutputInput>({
+  return useMutation<SubmitOutputResponse, Error, UseSubmitOutputInput>({
     mutationFn: ({ sessionId, content, submitted_at }) =>
       submitOutput(sessionId, { content, submitted_at }),
   });

--- a/mobile/src/features/session/screens/BreakScreen.tsx
+++ b/mobile/src/features/session/screens/BreakScreen.tsx
@@ -2,18 +2,16 @@
  * 休憩フェーズ画面。
  *
  * 状態機械上は `judging` に相当（判定待ちの期間を UI 上は「休憩」として扱う）。
- * タイマー完了時に `PATCH status=judged` を送って結果画面に遷移する。
- * 実 LLM 判定は Epic #4 で追加予定で、本 Task ではダミー判定（遷移のみ）で終端する。
+ * タイマー完了後に結果画面へ遷移し、実際の判定取得は ResultScreen で行う。
  */
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useRef } from 'react';
-import { Paragraph, SizableText, YStack } from 'tamagui';
+import { Paragraph, YStack } from 'tamagui';
 
 import { SessionHeader } from '@/features/session/components/SessionHeader';
 import { Timer } from '@/features/session/components/Timer';
 import { DEFAULT_TIMER } from '@/features/session/config';
 import { useTimer } from '@/features/session/hooks/useTimer';
-import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
 
 type SessionRouteParams = {
   id?: string;
@@ -26,21 +24,13 @@ export function BreakScreen() {
   const breakMinutes = Number(params.break) || DEFAULT_TIMER.break_minutes;
 
   const router = useRouter();
-  const updateStatus = useUpdateSessionStatus();
 
   const { start, reset } = useTimer({
     onComplete: () => {
-      updateStatus.mutate(
-        { sessionId, status: 'judged' },
-        {
-          onSuccess: () => {
-            router.replace({
-              pathname: '/session/[id]/result',
-              params: { id: sessionId },
-            });
-          },
-        },
-      );
+      router.replace({
+        pathname: '/session/[id]/result',
+        params: { id: sessionId },
+      });
     },
   });
 
@@ -59,13 +49,8 @@ export function BreakScreen() {
     <YStack flex={1}>
       <SessionHeader sessionId={sessionId} title="休憩" onBeforeCancel={reset} />
       <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
-        <Paragraph>休憩中です（判定結果を準備しています）</Paragraph>
+        <Paragraph>休憩中です。終了後に判定結果を確認します。</Paragraph>
         <Timer />
-        {updateStatus.isError ? (
-          <SizableText color="$red10" size="$2" testID="break-screen-error">
-            通信エラーが発生しました。時間をおいて再度お試しください。
-          </SizableText>
-        ) : null}
       </YStack>
     </YStack>
   );

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -2,14 +2,13 @@
  * アウトプットフェーズ画面。
  *
  * - `OutputEditor` でアウトプット本文を入力し、「送信する」で POST /sessions/{id}/output
- * - 送信成功時は `PATCH status=judging` を送り `/session/{id}/break` へ遷移
- * - タイマー完了時は（本文の有無に関わらず）`PATCH status=judging` を送り break へ遷移
- *   （自動送信は行わず、ユーザーの明示的な送信操作のみで submit する方針）
+ * - 送信成功時は `/session/{id}/break` へ遷移
+ * - タイマー完了時は自動送信せず、ユーザーに明示的な送信を促す
  */
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
-import { Paragraph, SizableText, YStack } from 'tamagui';
+import { Paragraph, YStack } from 'tamagui';
 
 import { OutputEditor } from '@/features/session/components/OutputEditor';
 import type { OutputEditorSubmitPayload } from '@/features/session/components/OutputEditor';
@@ -18,7 +17,7 @@ import { Timer } from '@/features/session/components/Timer';
 import { DEFAULT_TIMER } from '@/features/session/config';
 import { useSubmitOutput } from '@/features/session/hooks/useSubmitOutput';
 import { useTimer } from '@/features/session/hooks/useTimer';
-import { useUpdateSessionStatus } from '@/features/session/hooks/useUpdateSessionStatus';
+import { isApiError } from '@/shared/lib/api';
 
 type SessionRouteParams = {
   id?: string;
@@ -34,9 +33,9 @@ export function OutputScreen() {
 
   const router = useRouter();
   const submit = useSubmitOutput();
-  const updateStatus = useUpdateSessionStatus();
 
   const [content, setContent] = useState('');
+  const [localErrorMessage, setLocalErrorMessage] = useState<string | null>(null);
 
   const navigateToBreak = useCallback(() => {
     router.replace({
@@ -45,30 +44,28 @@ export function OutputScreen() {
     });
   }, [router, sessionId, breakMinutes]);
 
-  const advanceToJudging = useCallback(() => {
-    updateStatus.mutate(
-      { sessionId, status: 'judging' },
-      {
-        onSuccess: navigateToBreak,
-      },
-    );
-  }, [updateStatus, sessionId, navigateToBreak]);
-
   const handleEditorSubmit = useCallback(
     ({ content: nextContent, submitted_at }: OutputEditorSubmitPayload) => {
+      setLocalErrorMessage(null);
+      submit.reset();
       submit.mutate(
         { sessionId, content: nextContent, submitted_at },
         {
-          onSuccess: advanceToJudging,
+          onSuccess: navigateToBreak,
         },
       );
     },
-    [submit, sessionId, advanceToJudging],
+    [submit, sessionId, navigateToBreak],
   );
 
   const { start, reset } = useTimer({
     onComplete: () => {
-      advanceToJudging();
+      const trimmed = content.trim();
+      if (trimmed.length === 0) {
+        setLocalErrorMessage('時間になりました。学習内容を入力してから送信してください。');
+        return;
+      }
+      setLocalErrorMessage('時間になりました。内容を確認して送信してください。');
     },
   });
 
@@ -85,9 +82,13 @@ export function OutputScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const submitErrorMessage = submit.isError
-    ? '送信に失敗しました。時間をおいて再度お試しください。'
-    : null;
+  const submitErrorMessage =
+    localErrorMessage ??
+    (submit.isError
+      ? isApiError(submit.error)
+        ? (submit.error.problem?.detail ?? '送信に失敗しました。時間をおいて再度お試しください。')
+        : '送信に失敗しました。時間をおいて再度お試しください。'
+      : null);
 
   return (
     <YStack flex={1}>
@@ -102,16 +103,19 @@ export function OutputScreen() {
             <Timer />
             <OutputEditor
               value={content}
-              onChange={setContent}
+              onChange={(nextValue) => {
+                setContent(nextValue);
+                if (localErrorMessage !== null) {
+                  setLocalErrorMessage(null);
+                }
+                if (submit.isError) {
+                  submit.reset();
+                }
+              }}
               onSubmit={handleEditorSubmit}
-              isSubmitting={submit.isPending || updateStatus.isPending}
+              isSubmitting={submit.isPending}
               errorMessage={submitErrorMessage}
             />
-            {updateStatus.isError ? (
-              <SizableText color="$red10" size="$2" testID="output-screen-error">
-                通信エラーが発生しました。時間をおいて再度お試しください。
-              </SizableText>
-            ) : null}
           </YStack>
         </ScrollView>
       </KeyboardAvoidingView>

--- a/mobile/src/features/session/screens/ResultScreen.tsx
+++ b/mobile/src/features/session/screens/ResultScreen.tsx
@@ -1,16 +1,103 @@
 /**
- * 判定結果画面。
- *
- * Issue #41 の時点では `JudgmentCard` は Epic #4 で実装される placeholder 表示のみ。
- * 本画面は session が `judged` に到達した後に表示される終端画面で、中断操作は不要。
+ * 判定結果画面。pending / error / rejected の出し分けを行う。
  */
-import { useRouter } from 'expo-router';
-import { Button, H2, Paragraph, YStack } from 'tamagui';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Button, H2, Paragraph, Spinner, YStack } from 'tamagui';
 
 import { JudgmentCard } from '@/features/session/components/JudgmentCard';
+import { useJudgment } from '@/features/session/hooks/useJudgment';
+import { isApiError } from '@/shared/lib/api';
+
+type ResultRouteParams = {
+  id?: string;
+};
 
 export function ResultScreen() {
+  const params = useLocalSearchParams<ResultRouteParams>();
+  const sessionId = params.id ?? '';
   const router = useRouter();
+  const judgmentQuery = useJudgment(sessionId);
+
+  const problemMessage = judgmentQuery.isError
+    ? isApiError(judgmentQuery.error)
+      ? (judgmentQuery.error.problem?.detail ??
+        judgmentQuery.error.problem?.title ??
+        '判定結果の取得に失敗しました。')
+      : '判定結果の取得に失敗しました。'
+    : null;
+
+  if (judgmentQuery.isPending) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3">
+          <H2>判定結果</H2>
+        </YStack>
+        <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+          <Spinner testID="result-loading" />
+          <Paragraph>判定結果を確認しています。</Paragraph>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentQuery.isError || judgmentQuery.data === undefined) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3">
+          <H2>判定結果</H2>
+        </YStack>
+        <YStack flex={1} padding="$4" gap="$4" justifyContent="center">
+          <Paragraph testID="result-error-message">
+            {problemMessage ?? '判定結果の取得に失敗しました。'}
+          </Paragraph>
+          <Button themeInverse onPress={() => void judgmentQuery.refetch()} testID="result-retry">
+            再試行する
+          </Button>
+          <Button onPress={() => router.replace('/(tabs)')} testID="result-back-home">
+            ホームへ戻る
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentQuery.data.kind === 'pending') {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3">
+          <H2>判定結果</H2>
+        </YStack>
+        <YStack flex={1} padding="$4" gap="$4" justifyContent="center">
+          <Paragraph testID="result-pending-detail">{judgmentQuery.data.pending.detail}</Paragraph>
+          <Paragraph>このまま待つと自動で再確認します。</Paragraph>
+          <Button themeInverse onPress={() => void judgmentQuery.refetch()} testID="result-refetch">
+            今すぐ再確認
+          </Button>
+          <Button onPress={() => router.replace('/(tabs)')} testID="result-back-home">
+            ホームへ戻る
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentQuery.data.judgment.verdict === 'rejected') {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3">
+          <H2>判定結果</H2>
+        </YStack>
+        <YStack flex={1} padding="$4" gap="$4" justifyContent="center">
+          <Paragraph testID="result-rejected-message">
+            {judgmentQuery.data.judgment.advice}
+          </Paragraph>
+          <Button themeInverse onPress={() => router.replace('/(tabs)')} testID="result-back-home">
+            ホームへ戻る
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
 
   return (
     <YStack flex={1}>
@@ -19,7 +106,7 @@ export function ResultScreen() {
       </YStack>
       <YStack flex={1} padding="$4" gap="$4">
         <Paragraph>セッションお疲れさまでした。</Paragraph>
-        <JudgmentCard />
+        <JudgmentCard judgment={judgmentQuery.data.judgment} />
         <Button themeInverse onPress={() => router.replace('/(tabs)')} testID="result-back-home">
           ホームへ戻る
         </Button>

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -1,6 +1,6 @@
 /**
  * BreakScreen の振る舞いを検証する。
- * タイマー完了で status=judged に PATCH → result 画面へ replace する（ダミー判定）。
+ * タイマー完了で result 画面へ replace する。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, waitFor } from '@testing-library/react-native';
@@ -8,7 +8,6 @@ import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
 import config from '../../../../../tamagui.config';
-import * as sessionApi from '@/features/session/api/sessionApi';
 import { BreakScreen } from '@/features/session/screens/BreakScreen';
 import { useTimerStore } from '@/shared/stores/timerStore';
 
@@ -20,8 +19,6 @@ jest.mock('expo-router', () => ({
     break: '1',
   }),
 }));
-
-jest.mock('@/features/session/api/sessionApi');
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
@@ -64,21 +61,13 @@ describe('BreakScreen', () => {
     expect(useTimerStore.getState().totalSeconds).toBe(60);
   });
 
-  it('タイマー完了で PATCH status=judged が送られ、result 画面へ replace する', async () => {
-    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
-      id: 'ses-123',
-      status: 'judged',
-    });
-
+  it('タイマー完了で result 画面へ replace する', async () => {
     renderWithProviders(<BreakScreen />);
 
     act(() => {
       jest.advanceTimersByTime(60 * 1000);
     });
 
-    await waitFor(() => {
-      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judged');
-    });
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith({
         pathname: '/session/[id]/result',

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -2,9 +2,10 @@
  * OutputScreen の振る舞いを検証する。
  *
  * - マウント時に phase=output のタイマーが start される
- * - タイマー完了で PATCH status=judging → break 画面へ replace する
- * - OutputEditor で本文を入力 → 送信すると submitOutput → PATCH status=judging → break へ replace
- * - submitOutput が失敗するとエラーメッセージが表示され、再度送信できる (二重送信防止の挙動含む)
+ * - タイマー完了で本文が空ならエラーメッセージを表示する
+ * - タイマー完了で本文があれば送信を促すメッセージを表示し、自動送信しない
+ * - OutputEditor で本文を入力 → 送信すると submitOutput → break 画面へ replace する
+ * - submitOutput が失敗するとエラーメッセージが表示され、再度送信できる
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
@@ -42,6 +43,16 @@ function renderWithProviders(ui: ReactNode) {
   );
 }
 
+const submitSuccessResponse = {
+  status: 'judging',
+  output: {
+    id: 'out-1',
+    session_id: 'ses-123',
+    content: '関係代名詞は先行詞を修飾する',
+    submitted_at: '2026-04-10T15:25:00.000Z',
+  },
+} as const;
+
 describe('OutputScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -70,36 +81,37 @@ describe('OutputScreen', () => {
     expect(useTimerStore.getState().totalSeconds).toBe(60);
   });
 
-  it('タイマー完了で PATCH status=judging が送られ、break 画面へ replace する', async () => {
-    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
-      id: 'ses-123',
-      status: 'judging',
-    });
-
-    renderWithProviders(<OutputScreen />);
+  it('タイマー完了で本文が空ならエラーメッセージを表示し、送信しない', async () => {
+    const { getByTestId } = renderWithProviders(<OutputScreen />);
 
     act(() => {
       jest.advanceTimersByTime(60 * 1000);
     });
 
     await waitFor(() => {
-      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judging');
-    });
-    await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith({
-        pathname: '/session/[id]/break',
-        params: { id: 'ses-123', break: '5' },
-      });
+      expect(getByTestId('output-editor-error')).toBeTruthy();
     });
     expect(sessionApi.submitOutput).not.toHaveBeenCalled();
   });
 
-  it('本文入力 → 送信で submitOutput → PATCH judging → break 画面へ replace する', async () => {
-    (sessionApi.submitOutput as jest.Mock).mockResolvedValue(undefined);
-    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
-      id: 'ses-123',
-      status: 'judging',
+  it('タイマー完了で本文があれば送信を促すメッセージを表示し、自動送信しない', async () => {
+    const { getByTestId } = renderWithProviders(<OutputScreen />);
+
+    fireEvent.changeText(getByTestId('output-editor-textarea'), '関係代名詞は先行詞を修飾する');
+
+    act(() => {
+      jest.advanceTimersByTime(60 * 1000);
     });
+
+    await waitFor(() => {
+      expect(getByTestId('output-editor-error')).toBeTruthy();
+    });
+    expect(sessionApi.submitOutput).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('本文入力 → 送信で submitOutput → break 画面へ replace する', async () => {
+    (sessionApi.submitOutput as jest.Mock).mockResolvedValue(submitSuccessResponse);
 
     const { getByTestId } = renderWithProviders(<OutputScreen />);
 
@@ -116,9 +128,6 @@ describe('OutputScreen', () => {
       });
     });
     await waitFor(() => {
-      expect(sessionApi.updateSessionStatus).toHaveBeenCalledWith('ses-123', 'judging');
-    });
-    await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith({
         pathname: '/session/[id]/break',
         params: { id: 'ses-123', break: '5' },
@@ -129,11 +138,7 @@ describe('OutputScreen', () => {
   it('submitOutput 失敗時はエラーメッセージと「再送する」ボタンが現れ、明示操作で再送できる', async () => {
     (sessionApi.submitOutput as jest.Mock)
       .mockRejectedValueOnce(new Error('HTTP 500'))
-      .mockResolvedValueOnce(undefined);
-    (sessionApi.updateSessionStatus as jest.Mock).mockResolvedValue({
-      id: 'ses-123',
-      status: 'judging',
-    });
+      .mockResolvedValueOnce(submitSuccessResponse);
 
     const { getByTestId } = renderWithProviders(<OutputScreen />);
 
@@ -146,16 +151,13 @@ describe('OutputScreen', () => {
     await waitFor(() => {
       expect(getByTestId('output-editor-error')).toBeTruthy();
     });
-    expect(sessionApi.updateSessionStatus).not.toHaveBeenCalled();
 
-    // 失敗後「送信する」ボタンを連打しても再送されない (連打抑止)
     act(() => {
       fireEvent.press(getByTestId('output-editor-submit'));
       fireEvent.press(getByTestId('output-editor-submit'));
     });
     expect(sessionApi.submitOutput).toHaveBeenCalledTimes(1);
 
-    // 「再送する」ボタンの明示操作のみ再送される
     act(() => {
       fireEvent.press(getByTestId('output-editor-retry'));
     });

--- a/mobile/src/features/session/screens/__tests__/ResultScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/ResultScreen.test.tsx
@@ -1,19 +1,24 @@
 /**
  * ResultScreen の振る舞いを検証する。
- * JudgmentCard が表示され、「ホームへ戻る」ボタンで `/(tabs)` に replace 遷移する。
+ * ready / pending / error / rejected を出し分ける。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
 import config from '../../../../../tamagui.config';
+import * as sessionApi from '@/features/session/api/sessionApi';
 import { ResultScreen } from '@/features/session/screens/ResultScreen';
+import { ApiError } from '@/shared/lib/api';
 
 const mockReplace = jest.fn();
 jest.mock('expo-router', () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'ses-123' }),
 }));
+
+jest.mock('@/features/session/api/sessionApi');
 
 function renderWithProviders(ui: ReactNode) {
   const queryClient = new QueryClient({
@@ -34,14 +39,106 @@ describe('ResultScreen', () => {
     jest.clearAllMocks();
   });
 
-  it('判定結果カードと「ホームへ戻る」ボタンがレンダリングされる', () => {
-    const { getByText, getByTestId } = renderWithProviders(<ResultScreen />);
+  it('ready 判定では JudgmentCard と「ホームへ戻る」ボタンが表示される', async () => {
+    (sessionApi.getJudgment as jest.Mock).mockResolvedValue({
+      kind: 'ready',
+      judgment: {
+        id: 'jdg-1',
+        session_id: 'ses-123',
+        verdict: 'partial',
+        score: 72,
+        advice: 'もう少し具体例を増やすと安定します。',
+        items: [{ label: '理解度', comment: '要点は押さえられています。' }],
+        judged_at: '2026-04-10T15:30:00.000Z',
+      },
+    });
+
+    const { getByTestId, getByText } = renderWithProviders(<ResultScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('judgment-card')).toBeTruthy();
+    });
     expect(getByText('判定結果')).toBeTruthy();
     expect(getByTestId('result-back-home')).toBeTruthy();
   });
 
-  it('「ホームへ戻る」押下で `/(tabs)` に replace 遷移する', () => {
+  it('pending 判定では待機メッセージと再確認ボタンが表示される', async () => {
+    (sessionApi.getJudgment as jest.Mock).mockResolvedValue({
+      kind: 'pending',
+      pending: {
+        status: 'pending',
+        detail: '判定結果を準備しています。',
+        retry_after_seconds: 5,
+        estimated_ready_at: '2026-04-10T15:30:00.000Z',
+      },
+    });
+
     const { getByTestId } = renderWithProviders(<ResultScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('result-pending-detail')).toBeTruthy();
+    });
+    expect(getByTestId('result-refetch')).toBeTruthy();
+  });
+
+  it('error では Problem Details の detail と再試行ボタンが表示される', async () => {
+    (sessionApi.getJudgment as jest.Mock).mockRejectedValue(
+      new ApiError(409, {
+        type: 'output_not_submitted',
+        title: 'Output Not Submitted',
+        status: 409,
+        detail: 'output not submitted',
+      }),
+    );
+
+    const { getByTestId } = renderWithProviders(<ResultScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('result-error-message')).toBeTruthy();
+    });
+    expect(getByTestId('result-retry')).toBeTruthy();
+  });
+
+  it('rejected 判定では専用メッセージを表示する', async () => {
+    (sessionApi.getJudgment as jest.Mock).mockResolvedValue({
+      kind: 'ready',
+      judgment: {
+        id: 'jdg-2',
+        session_id: 'ses-123',
+        verdict: 'rejected',
+        score: 0,
+        advice: '学習内容をもう少し具体的に書いてください。',
+        items: [{ label: '入力内容の確認', comment: '説明量が不足しています。' }],
+        judged_at: '2026-04-10T15:30:00.000Z',
+      },
+    });
+
+    const { getByTestId } = renderWithProviders(<ResultScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('result-rejected-message')).toBeTruthy();
+    });
+  });
+
+  it('「ホームへ戻る」押下で `/(tabs)` に replace 遷移する', async () => {
+    (sessionApi.getJudgment as jest.Mock).mockResolvedValue({
+      kind: 'ready',
+      judgment: {
+        id: 'jdg-1',
+        session_id: 'ses-123',
+        verdict: 'partial',
+        score: 72,
+        advice: 'もう少し具体例を増やすと安定します。',
+        items: [{ label: '理解度', comment: '要点は押さえられています。' }],
+        judged_at: '2026-04-10T15:30:00.000Z',
+      },
+    });
+
+    const { getByTestId } = renderWithProviders(<ResultScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('result-back-home')).toBeTruthy();
+    });
     fireEvent.press(getByTestId('result-back-home'));
     expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
   });

--- a/mobile/src/features/session/types.ts
+++ b/mobile/src/features/session/types.ts
@@ -6,6 +6,8 @@
 
 export const SESSION_STATUSES = ['input', 'output', 'judging', 'judged', 'cancelled'] as const;
 export type SessionStatus = (typeof SESSION_STATUSES)[number];
+export const JUDGMENT_VERDICTS = ['correct', 'partial', 'incorrect', 'rejected'] as const;
+export type JudgmentVerdict = (typeof JUDGMENT_VERDICTS)[number];
 
 export type Session = {
   id: string;
@@ -29,6 +31,18 @@ export type CreateSessionInput = {
   break_minutes: number;
 };
 
+export type Output = {
+  id: string;
+  session_id: string;
+  content: string;
+  submitted_at: string;
+};
+
+export type SubmitOutputResponse = {
+  output: Output;
+  status: SessionStatus;
+};
+
 /**
  * アウトプット送信リクエスト。
  * backend の `POST /api/v1/sessions/{id}/output` と対応する。
@@ -38,3 +52,29 @@ export type SubmitOutputInput = {
   content: string;
   submitted_at: string;
 };
+
+export type JudgmentItem = {
+  label: string;
+  comment: string;
+};
+
+export type Judgment = {
+  id: string;
+  session_id: string;
+  verdict: JudgmentVerdict;
+  score: number;
+  advice: string;
+  items: JudgmentItem[];
+  judged_at: string;
+};
+
+export type JudgmentPending = {
+  status: 'pending';
+  detail: string;
+  retry_after_seconds: number;
+  estimated_ready_at: string;
+};
+
+export type JudgmentFetchResult =
+  | { kind: 'ready'; judgment: Judgment }
+  | { kind: 'pending'; pending: JudgmentPending };

--- a/mobile/src/shared/lib/api.ts
+++ b/mobile/src/shared/lib/api.ts
@@ -10,10 +10,13 @@
  */
 import Constants from 'expo-constants';
 
+import type { ProblemDetails } from '@/shared/types/api';
+
 type TokenProvider = () => Promise<string | null> | string | null;
 type TokenRefresher = () => Promise<string | null>;
 type ApiResponse<T> = {
   data: T;
+  status: number;
 };
 
 let tokenProvider: TokenProvider = () => null;
@@ -76,6 +79,33 @@ async function parseResponseBody<T>(response: Response): Promise<T> {
   return (await response.text()) as T;
 }
 
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const maybeProblem = value as Partial<ProblemDetails>;
+  return (
+    typeof maybeProblem.type === 'string' &&
+    typeof maybeProblem.title === 'string' &&
+    typeof maybeProblem.status === 'number'
+  );
+}
+
+export class ApiError extends Error {
+  status: number;
+  problem?: ProblemDetails;
+
+  constructor(status: number, problem?: ProblemDetails) {
+    super(`HTTP ${status}`);
+    this.name = 'ApiError';
+    this.status = status;
+    this.problem = problem;
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
 class ApiClient {
   async get<T>(path: string): Promise<ApiResponse<T>> {
     return this.request<T>(path, { method: 'GET' });
@@ -99,13 +129,13 @@ class ApiClient {
 
   private async request<T>(path: string, init: RequestInit): Promise<ApiResponse<T>> {
     const response = await this.fetchWithAuth(path, init);
-    const data = await parseResponseBody<T>(response);
+    const data = await parseResponseBody<T | ProblemDetails>(response);
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+      throw new ApiError(response.status, isProblemDetails(data) ? data : undefined);
     }
 
-    return { data };
+    return { data: data as T, status: response.status };
   }
 
   /**

--- a/mobile/src/shared/types/api.ts
+++ b/mobile/src/shared/types/api.ts
@@ -11,6 +11,7 @@ export type ProblemDetails = {
   status: number;
   detail?: string;
   instance?: string;
+  errors?: unknown[];
 };
 
 export type Cursor = string | null;


### PR DESCRIPTION
## 概要

Task #51 に対応し、backend では Problem Details と判定取得 API を整備し、mobile では pending / error / rejected を出し分ける結果 UX を追加しました。
アウトプット送信後の break/result フローを API ベースに寄せ、ユーザーが現在の判定状態を把握できるようにしています。

## 関連 Issue

- Closes #51
- Refs #19
- Refs #4

## 変更内容

- backend に `POST /api/v1/sessions/{id}/output` と `GET /api/v1/sessions/{id}/judgment` を追加
- backend の 4xx/5xx を RFC 7807 Problem Details 形式で統一
- `outputs` / `judgments` テーブルと関連リポジトリ、テスト、マイグレーションを追加
- mobile で pending / error / rejected / ready を出し分ける Result UX を追加
- output 画面の送信導線を見直し、時間切れ時は自動送信せず明示送信を促す形に変更

## スコープ外 / 残課題

- 判定ロジックはまだ worker / LLM 連携ではなく、Issue #51 の UX 検証用の暫定ルール
- mobile の画面キャプチャ自動化基盤が無く、PR 添付用スクリーンショットは未取得

## 動作確認

```bash
task backend:db:upgrade
task backend:ci
task mobile:ci
```

- output 送信後、result 画面で `pending` から結果表示へ遷移すること
- 20 文字未満の本文で `rejected` 専用メッセージが表示されること
- Problem Details の `401 / 409 / 422` が `type / title / status / detail / instance` を返すこと

### スクリーンショット / 動画

- 未添付（Expo ローカル画面のため手元確認ベース）

## チェックリスト

- [x] `task backend:ci` と `task mobile:ci` がローカルで通る
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と大きく矛盾しない範囲で実装している
- [ ] 破壊的変更はない
