### PR TITLE
[Task] 履歴一覧 / 詳細 UI を実装する

### DIFF
--- a/mobile/app/history/[id].tsx
+++ b/mobile/app/history/[id].tsx
@@ -1,0 +1,5 @@
+import { HistoryDetailScreen } from '@/features/history/screens/HistoryDetailScreen';
+
+export default function HistoryDetailRoute() {
+  return <HistoryDetailScreen />;
+}

--- a/mobile/src/features/history/api/judgmentApi.ts
+++ b/mobile/src/features/history/api/judgmentApi.ts
@@ -1,3 +1,30 @@
 /**
- * 判定履歴 API。Epic #5 で実装する。
+ * 判定履歴 API。
  */
+import type { Judgment } from '@/features/session/types';
+import { api } from '@/shared/lib/api';
+import type { Cursor, Paginated } from '@/shared/types/api';
+
+type JudgmentListResponse = {
+  judgments: Judgment[];
+  next_cursor: Cursor;
+};
+
+type JudgmentDetailResponse = {
+  judgment: Judgment;
+};
+
+export async function listJudgments(cursor?: Cursor): Promise<Paginated<Judgment>> {
+  const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+  const { data } = await api.get<JudgmentListResponse>(`/judgments${query}`);
+
+  return {
+    items: data.judgments,
+    next_cursor: data.next_cursor,
+  };
+}
+
+export async function getJudgmentDetail(judgmentId: string): Promise<Judgment> {
+  const { data } = await api.get<JudgmentDetailResponse>(`/judgments/${judgmentId}`);
+  return data.judgment;
+}

--- a/mobile/src/features/history/components/JudgmentListItem.tsx
+++ b/mobile/src/features/history/components/JudgmentListItem.tsx
@@ -1,11 +1,41 @@
-import { Text } from 'tamagui';
+import { Pressable } from 'react-native';
+import { Paragraph, SizableText, XStack, YStack } from 'tamagui';
 
+import type { Judgment } from '@/features/session/types';
 import { Card } from '@/shared/components/Card';
+import {
+  formatJudgedAt,
+  JUDGMENT_VERDICT_COLORS,
+  JUDGMENT_VERDICT_LABELS,
+} from '@/shared/lib/judgmentPresentation';
 
-export function JudgmentListItem() {
+type JudgmentListItemProps = {
+  judgment: Judgment;
+  onPress: () => void;
+};
+
+export function JudgmentListItem({ judgment, onPress }: JudgmentListItemProps) {
   return (
-    <Card>
-      <Text>履歴アイテム (placeholder)</Text>
-    </Card>
+    <Pressable onPress={onPress} testID={`history-item-${judgment.id}`}>
+      <Card>
+        <YStack gap="$3">
+          <XStack alignItems="center" justifyContent="space-between" gap="$3">
+            <SizableText fontWeight="700">{formatJudgedAt(judgment.judged_at)}</SizableText>
+            <SizableText
+              color={JUDGMENT_VERDICT_COLORS[judgment.verdict]}
+              fontWeight="700"
+              size="$3"
+            >
+              {JUDGMENT_VERDICT_LABELS[judgment.verdict]}
+            </SizableText>
+          </XStack>
+          <Paragraph>スコア: {judgment.score}</Paragraph>
+          <Paragraph numberOfLines={2}>{judgment.advice}</Paragraph>
+          <SizableText color="$gray10" size="$2">
+            評価項目 {judgment.items.length} 件
+          </SizableText>
+        </YStack>
+      </Card>
+    </Pressable>
   );
 }

--- a/mobile/src/features/history/hooks/useJudgmentDetail.ts
+++ b/mobile/src/features/history/hooks/useJudgmentDetail.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getJudgmentDetail } from '@/features/history/api/judgmentApi';
+import type { Judgment } from '@/features/session/types';
+import type { ApiError } from '@/shared/lib/api';
+
+export function useJudgmentDetail(judgmentId: string) {
+  return useQuery<Judgment, ApiError>({
+    queryKey: ['judgments', judgmentId],
+    queryFn: () => getJudgmentDetail(judgmentId),
+    enabled: judgmentId.length > 0,
+    retry: false,
+  });
+}

--- a/mobile/src/features/history/hooks/useJudgments.ts
+++ b/mobile/src/features/history/hooks/useJudgments.ts
@@ -1,6 +1,17 @@
 /**
- * 履歴データ取得フック。Epic #5 で実装する。
+ * 判定履歴一覧を取得する。
  */
+import { useQuery } from '@tanstack/react-query';
+
+import { listJudgments } from '@/features/history/api/judgmentApi';
+import type { Judgment } from '@/features/session/types';
+import type { ApiError } from '@/shared/lib/api';
+import type { Paginated } from '@/shared/types/api';
+
 export function useJudgments() {
-  return { items: [], isLoading: false };
+  return useQuery<Paginated<Judgment>, ApiError>({
+    queryKey: ['judgments'],
+    queryFn: () => listJudgments(),
+    retry: false,
+  });
 }

--- a/mobile/src/features/history/screens/HistoryDetailScreen.tsx
+++ b/mobile/src/features/history/screens/HistoryDetailScreen.tsx
@@ -1,0 +1,132 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ScrollView } from 'react-native';
+import { Button, H2, H3, Paragraph, Spinner, SizableText, XStack, YStack } from 'tamagui';
+
+import { useJudgmentDetail } from '@/features/history/hooks/useJudgmentDetail';
+import { JudgmentCard } from '@/features/session/components/JudgmentCard';
+import { Card } from '@/shared/components/Card';
+import { isApiError } from '@/shared/lib/api';
+import {
+  formatJudgedAt,
+  JUDGMENT_VERDICT_COLORS,
+  JUDGMENT_VERDICT_LABELS,
+} from '@/shared/lib/judgmentPresentation';
+
+type HistoryDetailRouteParams = {
+  id?: string;
+};
+
+export function HistoryDetailScreen() {
+  const params = useLocalSearchParams<HistoryDetailRouteParams>();
+  const judgmentId = params.id ?? '';
+  const router = useRouter();
+  const judgmentQuery = useJudgmentDetail(judgmentId);
+
+  const problemMessage = judgmentQuery.isError
+    ? isApiError(judgmentQuery.error)
+      ? (judgmentQuery.error.problem?.detail ??
+        judgmentQuery.error.problem?.title ??
+        '判定詳細の取得に失敗しました。')
+      : '判定詳細の取得に失敗しました。'
+    : null;
+
+  if (judgmentId.length === 0) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3">
+          <H2>判定詳細</H2>
+        </YStack>
+        <YStack flex={1} justifyContent="center" gap="$4" padding="$4">
+          <Paragraph testID="history-detail-invalid">
+            判定 ID が指定されていないため詳細を表示できません。
+          </Paragraph>
+          <Button onPress={() => router.back()} testID="history-detail-back">
+            一覧へ戻る
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentQuery.isPending) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+          <H2>判定詳細</H2>
+          <Paragraph theme="alt2">選択した判定内容を再確認できます。</Paragraph>
+        </YStack>
+        <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+          <Spinner testID="history-detail-loading" />
+          <Paragraph>判定内容を読み込んでいます。</Paragraph>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentQuery.isError || judgmentQuery.data === undefined) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+          <H2>判定詳細</H2>
+          <Paragraph theme="alt2">選択した判定内容を再確認できます。</Paragraph>
+        </YStack>
+        <YStack flex={1} justifyContent="center" gap="$4" padding="$4">
+          <Paragraph testID="history-detail-error-message">
+            {problemMessage ?? '判定詳細の取得に失敗しました。'}
+          </Paragraph>
+          <Button
+            themeInverse
+            onPress={() => void judgmentQuery.refetch()}
+            testID="history-detail-retry"
+          >
+            再取得する
+          </Button>
+          <Button onPress={() => router.back()} testID="history-detail-back">
+            一覧へ戻る
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack flex={1}>
+      <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+        <H2>判定詳細</H2>
+        <Paragraph theme="alt2">選択した判定内容を再確認できます。</Paragraph>
+      </YStack>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <YStack gap="$4">
+          <Card testID="history-detail-summary">
+            <YStack gap="$3">
+              <XStack alignItems="center" justifyContent="space-between" gap="$3">
+                <H3>判定概要</H3>
+                <SizableText
+                  color={JUDGMENT_VERDICT_COLORS[judgmentQuery.data.verdict]}
+                  fontWeight="700"
+                  size="$3"
+                >
+                  {JUDGMENT_VERDICT_LABELS[judgmentQuery.data.verdict]}
+                </SizableText>
+              </XStack>
+              <Paragraph>判定日時: {formatJudgedAt(judgmentQuery.data.judged_at)}</Paragraph>
+            </YStack>
+          </Card>
+
+          <JudgmentCard judgment={judgmentQuery.data} title="判定内容" />
+
+          <Button
+            themeInverse
+            onPress={() => void judgmentQuery.refetch()}
+            testID="history-detail-refetch"
+          >
+            再取得する
+          </Button>
+          <Button onPress={() => router.back()} testID="history-detail-back">
+            一覧へ戻る
+          </Button>
+        </YStack>
+      </ScrollView>
+    </YStack>
+  );
+}

--- a/mobile/src/features/history/screens/HistoryScreen.tsx
+++ b/mobile/src/features/history/screens/HistoryScreen.tsx
@@ -1,9 +1,105 @@
-import { H1, YStack } from 'tamagui';
+import { type RelativePathString, useRouter } from 'expo-router';
+import { ScrollView } from 'react-native';
+import { Button, H2, Paragraph, Spinner, YStack } from 'tamagui';
+
+import { JudgmentListItem } from '@/features/history/components/JudgmentListItem';
+import { useJudgments } from '@/features/history/hooks/useJudgments';
+import { isApiError } from '@/shared/lib/api';
 
 export function HistoryScreen() {
+  const router = useRouter();
+  const judgmentsQuery = useJudgments();
+
+  const problemMessage = judgmentsQuery.isError
+    ? isApiError(judgmentsQuery.error)
+      ? (judgmentsQuery.error.problem?.detail ??
+        judgmentsQuery.error.problem?.title ??
+        '履歴の取得に失敗しました。')
+      : '履歴の取得に失敗しました。'
+    : null;
+
+  if (judgmentsQuery.isPending) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+          <H2>判定履歴</H2>
+          <Paragraph theme="alt2">これまでの判定結果を確認できます。</Paragraph>
+        </YStack>
+        <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
+          <Spinner testID="history-loading" />
+          <Paragraph>履歴を読み込んでいます。</Paragraph>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentsQuery.isError || judgmentsQuery.data === undefined) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+          <H2>判定履歴</H2>
+          <Paragraph theme="alt2">これまでの判定結果を確認できます。</Paragraph>
+        </YStack>
+        <YStack flex={1} justifyContent="center" gap="$4" padding="$4">
+          <Paragraph testID="history-error-message">
+            {problemMessage ?? '履歴の取得に失敗しました。'}
+          </Paragraph>
+          <Button themeInverse onPress={() => void judgmentsQuery.refetch()} testID="history-retry">
+            再取得する
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (judgmentsQuery.data.items.length === 0) {
+    return (
+      <YStack flex={1}>
+        <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+          <H2>判定履歴</H2>
+          <Paragraph theme="alt2">これまでの判定結果を確認できます。</Paragraph>
+        </YStack>
+        <YStack flex={1} justifyContent="center" gap="$4" padding="$4">
+          <Paragraph testID="history-empty-message">
+            まだ判定履歴がありません。セッションを完了するとここに表示されます。
+          </Paragraph>
+          <Button
+            themeInverse
+            onPress={() => void judgmentsQuery.refetch()}
+            testID="history-refetch"
+          >
+            再取得する
+          </Button>
+        </YStack>
+      </YStack>
+    );
+  }
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>履歴 (placeholder)</H1>
+    <YStack flex={1}>
+      <YStack paddingHorizontal="$4" paddingVertical="$3" gap="$2">
+        <H2>判定履歴</H2>
+        <Paragraph theme="alt2">過去の判定結果から復習ポイントを見直せます。</Paragraph>
+      </YStack>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <YStack gap="$3">
+          {judgmentsQuery.data.items.map((judgment) => (
+            <JudgmentListItem
+              key={judgment.id}
+              judgment={judgment}
+              onPress={() => router.push(`../history/${judgment.id}` as RelativePathString)}
+            />
+          ))}
+
+          <Button
+            alignSelf="flex-start"
+            onPress={() => void judgmentsQuery.refetch()}
+            testID="history-refetch"
+          >
+            一覧を更新
+          </Button>
+        </YStack>
+      </ScrollView>
     </YStack>
   );
 }

--- a/mobile/src/features/history/screens/__tests__/HistoryDetailScreen.test.tsx
+++ b/mobile/src/features/history/screens/__tests__/HistoryDetailScreen.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as judgmentApi from '@/features/history/api/judgmentApi';
+import { HistoryDetailScreen } from '@/features/history/screens/HistoryDetailScreen';
+import { ApiError } from '@/shared/lib/api';
+
+const mockBack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack, push: jest.fn(), replace: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'jdg-1' }),
+}));
+
+jest.mock('@/features/history/api/judgmentApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('HistoryDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('詳細取得成功時は score / advice / items を表示する', async () => {
+    (judgmentApi.getJudgmentDetail as jest.Mock).mockResolvedValue({
+      id: 'jdg-1',
+      session_id: 'ses-1',
+      verdict: 'partial',
+      score: 72,
+      advice: 'もう少し具体例を増やすと安定します。',
+      items: [
+        { label: '理解度', comment: '要点は押さえられています。' },
+        { label: '具体例', comment: '例があるとさらに伝わります。' },
+      ],
+      judged_at: '2026-04-10T15:30:00.000Z',
+    });
+
+    const { getByTestId, getByText } = renderWithProviders(<HistoryDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-detail-summary')).toBeTruthy();
+    });
+    expect(getByTestId('judgment-card')).toBeTruthy();
+    expect(getByText('スコア: 72')).toBeTruthy();
+    expect(getByText('具体例')).toBeTruthy();
+  });
+
+  it('取得失敗時はエラーメッセージと再取得ボタンを表示する', async () => {
+    (judgmentApi.getJudgmentDetail as jest.Mock).mockRejectedValue(
+      new ApiError(404, {
+        type: 'not_found',
+        title: 'Not Found',
+        status: 404,
+        detail: 'judgment not found',
+      }),
+    );
+
+    const { getByTestId } = renderWithProviders(<HistoryDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-detail-error-message')).toBeTruthy();
+    });
+    expect(getByTestId('history-detail-retry')).toBeTruthy();
+  });
+
+  it('「一覧へ戻る」押下で back 遷移する', async () => {
+    (judgmentApi.getJudgmentDetail as jest.Mock).mockResolvedValue({
+      id: 'jdg-1',
+      session_id: 'ses-1',
+      verdict: 'correct',
+      score: 91,
+      advice: '十分に整理されています。',
+      items: [{ label: '再現性', comment: '説明が具体的です。' }],
+      judged_at: '2026-04-10T15:30:00.000Z',
+    });
+
+    const { getByTestId } = renderWithProviders(<HistoryDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-detail-back')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('history-detail-back'));
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it('初回取得中はローディング状態を表示する', () => {
+    (judgmentApi.getJudgmentDetail as jest.Mock).mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    const { getByTestId } = renderWithProviders(<HistoryDetailScreen />);
+
+    expect(getByTestId('history-detail-loading')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/history/screens/__tests__/HistoryScreen.test.tsx
+++ b/mobile/src/features/history/screens/__tests__/HistoryScreen.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as judgmentApi from '@/features/history/api/judgmentApi';
+import { HistoryScreen } from '@/features/history/screens/HistoryScreen';
+import { ApiError } from '@/shared/lib/api';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@/features/history/api/judgmentApi');
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('HistoryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('一覧が表示され、item 押下で詳細へ遷移する', async () => {
+    (judgmentApi.listJudgments as jest.Mock).mockResolvedValue({
+      items: [
+        {
+          id: 'jdg-1',
+          session_id: 'ses-1',
+          verdict: 'partial',
+          score: 72,
+          advice: 'もう少し具体例を増やすと安定します。',
+          items: [{ label: '理解度', comment: '要点は押さえられています。' }],
+          judged_at: '2026-04-10T15:30:00.000Z',
+        },
+        {
+          id: 'jdg-2',
+          session_id: 'ses-2',
+          verdict: 'correct',
+          score: 91,
+          advice: '十分に整理されています。',
+          items: [{ label: '再現性', comment: '説明が具体的です。' }],
+          judged_at: '2026-04-11T15:30:00.000Z',
+        },
+      ],
+      next_cursor: null,
+    });
+
+    const { getByTestId, getByText } = renderWithProviders(<HistoryScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-item-jdg-1')).toBeTruthy();
+    });
+    expect(getByText('判定履歴')).toBeTruthy();
+
+    fireEvent.press(getByTestId('history-item-jdg-1'));
+    expect(mockPush).toHaveBeenCalledWith('../history/jdg-1');
+  });
+
+  it('履歴が空のときは空状態を表示する', async () => {
+    (judgmentApi.listJudgments as jest.Mock).mockResolvedValue({
+      items: [],
+      next_cursor: null,
+    });
+
+    const { getByTestId } = renderWithProviders(<HistoryScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-empty-message')).toBeTruthy();
+    });
+  });
+
+  it('取得失敗時はエラーメッセージと再取得ボタンを表示する', async () => {
+    (judgmentApi.listJudgments as jest.Mock).mockRejectedValue(
+      new ApiError(500, {
+        type: 'server_error',
+        title: 'Server Error',
+        status: 500,
+        detail: 'history fetch failed',
+      }),
+    );
+
+    const { getByTestId } = renderWithProviders(<HistoryScreen />);
+
+    await waitFor(() => {
+      expect(getByTestId('history-error-message')).toBeTruthy();
+    });
+    expect(getByTestId('history-retry')).toBeTruthy();
+  });
+
+  it('初回取得中はローディング状態を表示する', () => {
+    (judgmentApi.listJudgments as jest.Mock).mockImplementation(() => new Promise(() => undefined));
+
+    const { getByTestId } = renderWithProviders(<HistoryScreen />);
+
+    expect(getByTestId('history-loading')).toBeTruthy();
+  });
+});

--- a/mobile/src/features/session/components/JudgmentCard.tsx
+++ b/mobile/src/features/session/components/JudgmentCard.tsx
@@ -5,33 +5,24 @@ import { H3, Paragraph, SizableText, XStack, YStack } from 'tamagui';
 
 import type { Judgment } from '@/features/session/types';
 import { Card } from '@/shared/components/Card';
+import {
+  JUDGMENT_VERDICT_COLORS,
+  JUDGMENT_VERDICT_LABELS,
+} from '@/shared/lib/judgmentPresentation';
 
 type JudgmentCardProps = {
   judgment: Judgment;
+  title?: string;
 };
 
-const VERDICT_LABELS: Record<Judgment['verdict'], string> = {
-  correct: 'Good',
-  partial: 'Partial',
-  incorrect: 'Needs Work',
-  rejected: 'Rejected',
-};
-
-const VERDICT_COLORS: Record<Judgment['verdict'], string> = {
-  correct: '$green10',
-  partial: '$orange10',
-  incorrect: '$red10',
-  rejected: '$red10',
-};
-
-export function JudgmentCard({ judgment }: JudgmentCardProps) {
+export function JudgmentCard({ judgment, title = '今回の判定' }: JudgmentCardProps) {
   return (
     <Card testID="judgment-card">
       <YStack gap="$3">
         <XStack alignItems="center" justifyContent="space-between">
-          <H3>今回の判定</H3>
-          <SizableText color={VERDICT_COLORS[judgment.verdict]} fontWeight="700" size="$3">
-            {VERDICT_LABELS[judgment.verdict]}
+          <H3>{title}</H3>
+          <SizableText color={JUDGMENT_VERDICT_COLORS[judgment.verdict]} fontWeight="700" size="$3">
+            {JUDGMENT_VERDICT_LABELS[judgment.verdict]}
           </SizableText>
         </XStack>
         <Paragraph testID="judgment-score">スコア: {judgment.score}</Paragraph>

--- a/mobile/src/shared/lib/judgmentPresentation.ts
+++ b/mobile/src/shared/lib/judgmentPresentation.ts
@@ -1,0 +1,28 @@
+import type { JudgmentVerdict } from '@/features/session/types';
+
+export const JUDGMENT_VERDICT_LABELS: Record<JudgmentVerdict, string> = {
+  correct: 'Good',
+  partial: 'Partial',
+  incorrect: 'Needs Work',
+  rejected: 'Rejected',
+};
+
+export const JUDGMENT_VERDICT_COLORS: Record<JudgmentVerdict, string> = {
+  correct: '$green10',
+  partial: '$orange10',
+  incorrect: '$red10',
+  rejected: '$red10',
+};
+
+const judgedAtFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+export function formatJudgedAt(value: string): string {
+  return judgedAtFormatter.format(new Date(value));
+}


### PR DESCRIPTION
## 概要

mobile に判定履歴の一覧画面と詳細画面を追加し、過去の判定結果を見返せるようにしました。
一覧から詳細への遷移に加えて、ロード中・空状態・取得失敗時の再取得導線も実装しています。

## 関連 Issue

- Closes #53
- Refs #20
- Refs #5

## 変更内容

- `features/history` に履歴一覧取得・詳細取得の API / hook を追加
- 履歴一覧画面にローディング、空状態、エラー、再取得 UI を追加
- 一覧 item から詳細画面へ遷移し、`score / advice / items` を確認できるようにした
- 判定の verdict 表示と日時整形の共通表現を shared に切り出し、既存 `JudgmentCard` でも再利用するようにした
- 履歴一覧・詳細画面のテストを追加した

## スコープ外 / 残課題

- backend の `GET /api/v1/judgments` / `GET /api/v1/judgments/{id}` は別タスクで未実装のため、現状の実機確認では 404 によるエラー状態表示になる
- ページネーションや絞り込みは今回のスコープ外

## 動作確認

```bash
npm run typecheck
npm test -- --runInBand src/features/history/screens/__tests__/HistoryScreen.test.tsx src/features/history/screens/__tests__/HistoryDetailScreen.test.tsx src/features/session/screens/__tests__/ResultScreen.test.tsx
```

### スクリーンショット / 動画

- backend の履歴 API が未実装で正常系画面を安定表示できないため、今回は未添付

## チェックリスト

- [ ] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [ ] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
