### PR TITLE
feat: 設定画面でタイマー・通知・プロフィール導線を編集できるようにする

### DIFF
--- a/backend/src/application/dto/user_settings_dto.py
+++ b/backend/src/application/dto/user_settings_dto.py
@@ -1,0 +1,32 @@
+"""UserSettings の DTO / コマンド。
+
+CQRS 的な命名で役割を明示する:
+- `UserSettingsView`: クライアントに返却する読み出し用ビュー
+- `UpdateUserSettingsCommand`: 設定更新の意図を表す書き込み用コマンド
+"""
+
+from datetime import datetime
+
+from src.common.models import FrozenModel
+
+
+class UserSettingsView(FrozenModel):
+    """GET / PATCH /users/me/settings のレスポンス元になるビュー。"""
+
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+    notification_enabled: bool
+    updated_at: datetime
+
+
+class UpdateUserSettingsCommand(FrozenModel):
+    """PATCH /users/me/settings の入力コマンド。
+
+    送られなかったフィールドは現在値を保持するため、ここでは省略可能（None）として表現する。
+    """
+
+    input_minutes: int | None = None
+    output_minutes: int | None = None
+    break_minutes: int | None = None
+    notification_enabled: bool | None = None

--- a/backend/src/application/use_cases/delete_account.py
+++ b/backend/src/application/use_cases/delete_account.py
@@ -1,4 +1,20 @@
-"""アカウント削除のユースケース。
+"""DELETE /users/me の UseCase。
 
-実装は Epic #6 で追加する。
+DB 上の users 行を削除すると、FK ondelete=CASCADE 設定により
+user_settings / sessions / outputs / judgments も連鎖削除される。
+Firebase Authentication 上のアカウント自体の削除は本 UseCase の責務外で、
+mobile 側で signOut させる方針。
 """
+
+from src.domain.entities.user import User
+from src.domain.repositories.user_repository import UserRepository
+
+
+class DeleteAccount:
+    """認証済みユーザ自身のアカウントを削除する。"""
+
+    def __init__(self, user_repository: UserRepository) -> None:
+        self._user_repository = user_repository
+
+    async def execute(self, current_user: User) -> None:
+        await self._user_repository.delete_by_id(current_user.id)

--- a/backend/src/application/use_cases/get_user_settings.py
+++ b/backend/src/application/use_cases/get_user_settings.py
@@ -1,0 +1,34 @@
+"""GET /users/me/settings の UseCase。"""
+
+from src.application.dto.user_settings_dto import UserSettingsView
+from src.domain.entities.user import User
+from src.domain.repositories.user_repository import UserRepository
+
+
+class UserSettingsNotFoundError(Exception):
+    """user_settings が存在しない場合に上位層へ知らせるためのドメイン例外。
+
+    通常は auth_middleware がユーザー作成と同時に user_settings を初期化するため
+    発生しないが、整合性が崩れた場合に備えて防御的に取り扱う。
+    """
+
+
+class GetUserSettings:
+    """認証済みユーザ自身の user_settings をビュー化して返す。"""
+
+    def __init__(self, user_repository: UserRepository) -> None:
+        self._user_repository = user_repository
+
+    async def execute(self, current_user: User) -> UserSettingsView:
+        settings = await self._user_repository.find_settings_by_user_id(current_user.id)
+        if settings is None:
+            raise UserSettingsNotFoundError(
+                f"user_settings not found for user_id={current_user.id}"
+            )
+        return UserSettingsView(
+            input_minutes=settings.input_minutes,
+            output_minutes=settings.output_minutes,
+            break_minutes=settings.break_minutes,
+            notification_enabled=settings.notification_enabled,
+            updated_at=settings.updated_at,
+        )

--- a/backend/src/application/use_cases/update_user_settings.py
+++ b/backend/src/application/use_cases/update_user_settings.py
@@ -1,0 +1,47 @@
+"""PATCH /users/me/settings の UseCase。"""
+
+from datetime import UTC, datetime
+
+from src.application.dto.user_settings_dto import (
+    UpdateUserSettingsCommand,
+    UserSettingsView,
+)
+from src.application.use_cases.get_user_settings import UserSettingsNotFoundError
+from src.domain.entities.user import User
+from src.domain.repositories.user_repository import UserRepository
+
+
+class UpdateUserSettings:
+    """user_settings を部分更新する。None のフィールドは現在値を保持する。"""
+
+    def __init__(self, user_repository: UserRepository) -> None:
+        self._user_repository = user_repository
+
+    async def execute(
+        self, current_user: User, command: UpdateUserSettingsCommand
+    ) -> UserSettingsView:
+        current = await self._user_repository.find_settings_by_user_id(current_user.id)
+        if current is None:
+            raise UserSettingsNotFoundError(
+                f"user_settings not found for user_id={current_user.id}"
+            )
+
+        update_fields: dict[str, object] = {"updated_at": datetime.now(UTC)}
+        if command.input_minutes is not None:
+            update_fields["input_minutes"] = command.input_minutes
+        if command.output_minutes is not None:
+            update_fields["output_minutes"] = command.output_minutes
+        if command.break_minutes is not None:
+            update_fields["break_minutes"] = command.break_minutes
+        if command.notification_enabled is not None:
+            update_fields["notification_enabled"] = command.notification_enabled
+
+        updated = current.model_copy(update=update_fields)
+        await self._user_repository.update_settings(updated)
+        return UserSettingsView(
+            input_minutes=updated.input_minutes,
+            output_minutes=updated.output_minutes,
+            break_minutes=updated.break_minutes,
+            notification_enabled=updated.notification_enabled,
+            updated_at=updated.updated_at,
+        )

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -7,11 +7,14 @@ presentation からは `request.app.state.container` 経由で参照する。
 from pydantic import BaseModel, ConfigDict
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
+from src.application.use_cases.update_user_settings import UpdateUserSettings
 from src.config import Settings
 from src.domain.repositories.judgment_repository import JudgmentRepository
 from src.domain.repositories.output_repository import OutputRepository
@@ -47,6 +50,9 @@ class Container(BaseModel):
     judgment_repository: JudgmentRepository
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
+    get_user_settings: GetUserSettings
+    update_user_settings: UpdateUserSettings
+    delete_account: DeleteAccount
     create_session: CreateSession
     update_session_status: UpdateSessionStatus
     submit_output: SubmitOutput
@@ -63,6 +69,9 @@ def build_container(settings: Settings) -> Container:
     judgment_repository: JudgmentRepository = PgJudgmentRepository(database=database)
     get_user_profile = GetUserProfile()
     update_user_profile = UpdateUserProfile(user_repository=user_repository)
+    get_user_settings = GetUserSettings(user_repository=user_repository)
+    update_user_settings = UpdateUserSettings(user_repository=user_repository)
+    delete_account = DeleteAccount(user_repository=user_repository)
     create_session = CreateSession(session_repository=session_repository)
     update_session_status = UpdateSessionStatus(session_repository=session_repository)
     submit_output = SubmitOutput(
@@ -84,6 +93,9 @@ def build_container(settings: Settings) -> Container:
         judgment_repository=judgment_repository,
         get_user_profile=get_user_profile,
         update_user_profile=update_user_profile,
+        get_user_settings=get_user_settings,
+        update_user_settings=update_user_settings,
+        delete_account=delete_account,
         create_session=create_session,
         update_session_status=update_session_status,
         submit_output=submit_output,

--- a/backend/src/domain/repositories/user_repository.py
+++ b/backend/src/domain/repositories/user_repository.py
@@ -4,6 +4,7 @@
 """
 
 from abc import ABC, abstractmethod
+from uuid import UUID
 
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
@@ -23,3 +24,19 @@ class UserRepository(ABC):
     @abstractmethod
     async def update(self, user: User) -> None:
         """既存ユーザのプロフィールを更新する。"""
+
+    @abstractmethod
+    async def find_settings_by_user_id(self, user_id: UUID) -> UserSettings | None:
+        """ユーザ ID から user_settings を取得する。未登録時は None。"""
+
+    @abstractmethod
+    async def update_settings(self, settings: UserSettings) -> None:
+        """user_settings を更新する。user_id で対象を特定する前提。"""
+
+    @abstractmethod
+    async def delete_by_id(self, user_id: UUID) -> None:
+        """ユーザを削除する。
+
+        FK ondelete=CASCADE により user_settings / sessions / outputs / judgments も
+        連鎖削除される前提。
+        """

--- a/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
@@ -87,9 +87,7 @@ class PgUserRepository(UserRepository):
 
     async def update_settings(self, settings: UserSettings) -> None:
         async with self._database.session() as session:
-            stmt = select(UserSettingsModel).where(
-                UserSettingsModel.user_id == settings.user_id
-            )
+            stmt = select(UserSettingsModel).where(UserSettingsModel.user_id == settings.user_id)
             result = await session.execute(stmt)
             model = result.scalar_one()
             model.input_minutes = settings.input_minutes

--- a/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
@@ -4,7 +4,9 @@ AsyncSession を外部から渡して扱う。現実装では 1 リクエスト 
 `Database.session()` で取り出したものを呼び出し側で commit / rollback する。
 """
 
-from sqlalchemy import select
+from uuid import UUID
+
+from sqlalchemy import delete, select
 
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
@@ -76,6 +78,33 @@ class PgUserRepository(UserRepository):
             model.deleted_at = user.deleted_at
             await session.commit()
 
+    async def find_settings_by_user_id(self, user_id: UUID) -> UserSettings | None:
+        async with self._database.session() as session:
+            stmt = select(UserSettingsModel).where(UserSettingsModel.user_id == user_id)
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+            return _to_settings(row) if row is not None else None
+
+    async def update_settings(self, settings: UserSettings) -> None:
+        async with self._database.session() as session:
+            stmt = select(UserSettingsModel).where(
+                UserSettingsModel.user_id == settings.user_id
+            )
+            result = await session.execute(stmt)
+            model = result.scalar_one()
+            model.input_minutes = settings.input_minutes
+            model.output_minutes = settings.output_minutes
+            model.break_minutes = settings.break_minutes
+            model.notification_enabled = settings.notification_enabled
+            model.updated_at = settings.updated_at
+            await session.commit()
+
+    async def delete_by_id(self, user_id: UUID) -> None:
+        async with self._database.session() as session:
+            stmt = delete(UserModel).where(UserModel.id == user_id)
+            await session.execute(stmt)
+            await session.commit()
+
 
 def _to_user(model: UserModel) -> User:
     """ORM モデル → domain.User の変換。"""
@@ -90,4 +119,18 @@ def _to_user(model: UserModel) -> User:
         created_at=model.created_at,
         updated_at=model.updated_at,
         deleted_at=model.deleted_at,
+    )
+
+
+def _to_settings(model: UserSettingsModel) -> UserSettings:
+    """ORM モデル → domain.UserSettings の変換。"""
+    return UserSettings(
+        id=model.id,
+        user_id=model.user_id,
+        input_minutes=model.input_minutes,
+        output_minutes=model.output_minutes,
+        break_minutes=model.break_minutes,
+        notification_enabled=model.notification_enabled,
+        created_at=model.created_at,
+        updated_at=model.updated_at,
     )

--- a/backend/src/presentation/api/v1/users.py
+++ b/backend/src/presentation/api/v1/users.py
@@ -1,18 +1,31 @@
 """ユーザーエンドポイント。
 
-本 PR では要件書 3.2.6 のうち `/api/v1/users/me/profile` を実装する。
-`/api/v1/users/me`、`/api/v1/users/me/settings`、削除系は後続 Task で実装する。
+要件書 3.2.6 のうち、
+- `GET/PATCH /api/v1/users/me/profile`: プロフィール取得・更新
+- `GET/PATCH /api/v1/users/me/settings`: タイマー / 通知設定の取得・更新
+- `DELETE /api/v1/users/me`: アカウント削除（FK ondelete=CASCADE で関連レコードも削除される）
+を提供する。Firebase Auth 上のアカウント削除はクライアント側 (signOut) の責務。
 """
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response, status
 
 from src.application.dto.user_dto import UpdateUserProfileCommand, UserProfileView
+from src.application.dto.user_settings_dto import (
+    UpdateUserSettingsCommand,
+    UserSettingsView,
+)
+from src.application.use_cases.get_user_settings import UserSettingsNotFoundError
 from src.domain.entities.user import User
 from src.presentation.container_access import get_presentation_container
 from src.presentation.middleware.auth_middleware import get_current_user
+from src.presentation.problem_details import ProblemDetailsError
 from src.presentation.schemas.user_schema import (
     UpdateUserProfileRequest,
     UserProfileResponse,
+)
+from src.presentation.schemas.user_settings_schema import (
+    UpdateUserSettingsRequest,
+    UserSettingsResponse,
 )
 
 users_router = APIRouter(prefix="/users", tags=["users"])
@@ -26,7 +39,7 @@ async def get_my_profile(
     """自分のプロフィールを取得する。未オンボーディング時は onboarding_completed=false。"""
     container = get_presentation_container(request)
     dto = await container.get_user_profile.execute(current_user)
-    return _to_response(dto)
+    return _to_profile_response(dto)
 
 
 @users_router.patch("/me/profile", response_model=UserProfileResponse)
@@ -42,10 +55,81 @@ async def update_my_profile(
         age_group=body.age_group,
     )
     dto = await container.update_user_profile.execute(current_user, command)
-    return _to_response(dto)
+    return _to_profile_response(dto)
 
 
-def _to_response(dto: UserProfileView) -> UserProfileResponse:
+@users_router.get("/me/settings", response_model=UserSettingsResponse)
+async def get_my_settings(
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> UserSettingsResponse:
+    """ユーザーのタイマー / 通知設定を取得する。"""
+    container = get_presentation_container(request)
+    try:
+        view = await container.get_user_settings.execute(current_user)
+    except UserSettingsNotFoundError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            problem_type="user_settings_not_found",
+            title="User Settings Not Found",
+            detail="ユーザー設定が見つかりません。",
+        ) from exc
+    return _to_settings_response(view)
+
+
+@users_router.patch("/me/settings", response_model=UserSettingsResponse)
+async def update_my_settings(
+    body: UpdateUserSettingsRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> UserSettingsResponse:
+    """ユーザーのタイマー / 通知設定を部分更新する。空 body は 422 で蹴る。"""
+    if body.is_empty():
+        raise ProblemDetailsError(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            problem_type="validation_error",
+            title="Validation Error",
+            detail="少なくとも 1 つのフィールドを指定してください。",
+        )
+    container = get_presentation_container(request)
+    command = UpdateUserSettingsCommand(
+        input_minutes=body.input_minutes,
+        output_minutes=body.output_minutes,
+        break_minutes=body.break_minutes,
+        notification_enabled=body.notification_enabled,
+    )
+    try:
+        view = await container.update_user_settings.execute(current_user, command)
+    except UserSettingsNotFoundError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            problem_type="user_settings_not_found",
+            title="User Settings Not Found",
+            detail="ユーザー設定が見つかりません。",
+        ) from exc
+    return _to_settings_response(view)
+
+
+@users_router.delete(
+    "/me",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_my_account(
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> Response:
+    """認証ユーザー本人のアカウントを削除する。
+
+    関連する user_settings / sessions / outputs / judgments は FK CASCADE により
+    DB 側で連鎖削除される。Firebase Auth 上のアカウント本体は対象外。
+    """
+    container = get_presentation_container(request)
+    await container.delete_account.execute(current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _to_profile_response(dto: UserProfileView) -> UserProfileResponse:
     return UserProfileResponse(
         id=dto.id,
         firebase_uid=dto.firebase_uid,
@@ -55,4 +139,14 @@ def _to_response(dto: UserProfileView) -> UserProfileResponse:
         onboarding_completed=dto.onboarding_completed,
         created_at=dto.created_at,
         updated_at=dto.updated_at,
+    )
+
+
+def _to_settings_response(view: UserSettingsView) -> UserSettingsResponse:
+    return UserSettingsResponse(
+        input_minutes=view.input_minutes,
+        output_minutes=view.output_minutes,
+        break_minutes=view.break_minutes,
+        notification_enabled=view.notification_enabled,
+        updated_at=view.updated_at,
     )

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -6,11 +6,14 @@ from typing import cast
 from fastapi import Request
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
+from src.application.use_cases.update_user_settings import UpdateUserSettings
 from src.domain.repositories.user_repository import UserRepository
 from src.domain.services.auth_verifier import AuthVerifier
 
@@ -31,6 +34,9 @@ class PresentationContainer(ABC):
     user_repository: UserRepository
     get_user_profile: GetUserProfile
     update_user_profile: UpdateUserProfile
+    get_user_settings: GetUserSettings
+    update_user_settings: UpdateUserSettings
+    delete_account: DeleteAccount
     create_session: CreateSession
     update_session_status: UpdateSessionStatus
     submit_output: SubmitOutput

--- a/backend/src/presentation/schemas/user_settings_schema.py
+++ b/backend/src/presentation/schemas/user_settings_schema.py
@@ -1,0 +1,46 @@
+"""/api/v1/users/me/settings の Pydantic スキーマ。"""
+
+from datetime import datetime
+
+from pydantic import Field
+
+from src.common.models import FrozenModel, StrictRequestModel
+
+# タイマー値の許容範囲。要件書 3.2.6 / 4.3.2 に明記された絶対値はないため、
+# 1 分以上 180 分以下を「実用範囲」として採用する。境界値テストもこの値で行う。
+_MINUTES_MIN = 1
+_MINUTES_MAX = 180
+
+
+class UserSettingsResponse(FrozenModel):
+    """GET /users/me/settings, PATCH /users/me/settings のレスポンス。"""
+
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+    notification_enabled: bool
+    updated_at: datetime
+
+
+class UpdateUserSettingsRequest(StrictRequestModel):
+    """PATCH /users/me/settings の body。
+
+    すべてのフィールドが省略可能。minutes 系は 1 ～ 180 の範囲を要求し、未知フィールドは
+    StrictRequestModel により拒否する。「全フィールド未指定（空 body）」のチェックは、
+    Pydantic の model_validator で投げると ValidationError の ctx に ValueError が入って
+    Problem Details のシリアライズが失敗するため、ルーター層で明示的にハンドリングする。
+    """
+
+    input_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
+    output_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
+    break_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
+    notification_enabled: bool | None = None
+
+    def is_empty(self) -> bool:
+        """すべてのフィールドが None かどうか。ルーター層で空 body を弾くために使う。"""
+        return (
+            self.input_minutes is None
+            and self.output_minutes is None
+            and self.break_minutes is None
+            and self.notification_enabled is None
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,11 +15,14 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.application.use_cases.create_session import CreateSession
+from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_user_profile import GetUserProfile
+from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.submit_output import SubmitOutput
 from src.application.use_cases.update_session_status import UpdateSessionStatus
 from src.application.use_cases.update_user_profile import UpdateUserProfile
+from src.application.use_cases.update_user_settings import UpdateUserSettings
 from src.config import Settings
 from src.container import Container
 from src.infrastructure.persistence.database import Database
@@ -89,6 +92,9 @@ def container(
         judgment_repository=fake_judgment_repository,
         get_user_profile=GetUserProfile(),
         update_user_profile=UpdateUserProfile(user_repository=fake_user_repository),
+        get_user_settings=GetUserSettings(user_repository=fake_user_repository),
+        update_user_settings=UpdateUserSettings(user_repository=fake_user_repository),
+        delete_account=DeleteAccount(user_repository=fake_user_repository),
         create_session=CreateSession(session_repository=fake_session_repository),
         update_session_status=UpdateSessionStatus(session_repository=fake_session_repository),
         submit_output=SubmitOutput(

--- a/backend/tests/fakes/fake_user_repository.py
+++ b/backend/tests/fakes/fake_user_repository.py
@@ -1,5 +1,7 @@
 """インメモリな UserRepository 実装。"""
 
+from uuid import UUID
+
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
 from src.domain.repositories.user_repository import UserRepository
@@ -10,14 +12,31 @@ class FakeUserRepository(UserRepository):
 
     def __init__(self) -> None:
         self.users: dict[str, User] = {}
-        self.settings: dict[str, UserSettings] = {}
+        # user_id (UUID) をキーにする。auth_middleware が add 直後に
+        # find_settings_by_user_id で参照できるように対応させる。
+        self.settings: dict[UUID, UserSettings] = {}
 
     async def find_by_firebase_uid(self, firebase_uid: str) -> User | None:
         return self.users.get(firebase_uid)
 
     async def add(self, user: User, settings: UserSettings) -> None:
         self.users[user.firebase_uid] = user
-        self.settings[user.firebase_uid] = settings
+        self.settings[settings.user_id] = settings
 
     async def update(self, user: User) -> None:
         self.users[user.firebase_uid] = user
+
+    async def find_settings_by_user_id(self, user_id: UUID) -> UserSettings | None:
+        return self.settings.get(user_id)
+
+    async def update_settings(self, settings: UserSettings) -> None:
+        self.settings[settings.user_id] = settings
+
+    async def delete_by_id(self, user_id: UUID) -> None:
+        target_uid = next(
+            (firebase_uid for firebase_uid, u in self.users.items() if u.id == user_id),
+            None,
+        )
+        if target_uid is not None:
+            del self.users[target_uid]
+        self.settings.pop(user_id, None)

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -1,0 +1,149 @@
+"""`/api/v1/users/me/settings` と `/api/v1/users/me` の API integration test。
+
+FakeAuthVerifier + FakeUserRepository 経由で、実 DB / Firebase 無しで経路を検証する。
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.fakes.fake_user_repository import FakeUserRepository
+
+
+@pytest.mark.asyncio
+async def test_get_settings_requires_authorization_header(client: AsyncClient):
+    response = await client.get("/api/v1/users/me/settings")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_settings_auto_creates_user_and_returns_defaults(client: AsyncClient):
+    response = await client.get(
+        "/api/v1/users/me/settings",
+        headers={"Authorization": "Bearer settings-user-001"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_minutes"] == 20
+    assert body["output_minutes"] == 5
+    assert body["break_minutes"] == 5
+    assert body["notification_enabled"] is True
+    assert "updated_at" in body
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_persists_partial_update(client: AsyncClient):
+    headers = {"Authorization": "Bearer settings-user-002"}
+    # 初回 GET で auth_middleware が user_settings を自動作成
+    await client.get("/api/v1/users/me/settings", headers=headers)
+
+    patch_response = await client.patch(
+        "/api/v1/users/me/settings",
+        headers=headers,
+        json={"input_minutes": 30, "notification_enabled": False},
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched["input_minutes"] == 30
+    assert patched["notification_enabled"] is False
+    # 指定しなかったフィールドはデフォルトを保持
+    assert patched["output_minutes"] == 5
+    assert patched["break_minutes"] == 5
+
+    # 再取得しても反映されている
+    get_response = await client.get("/api/v1/users/me/settings", headers=headers)
+    refreshed = get_response.json()
+    assert refreshed["input_minutes"] == 30
+    assert refreshed["notification_enabled"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "field"),
+    [
+        ({"input_minutes": 0}, "input_minutes"),
+        ({"input_minutes": 181}, "input_minutes"),
+        ({"output_minutes": -1}, "output_minutes"),
+        ({"break_minutes": 999}, "break_minutes"),
+    ],
+)
+async def test_patch_settings_rejects_out_of_range_minutes(
+    client: AsyncClient, payload: dict, field: str
+):
+    headers = {"Authorization": f"Bearer settings-range-{field}"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+
+    response = await client.patch(
+        "/api/v1/users/me/settings", headers=headers, json=payload
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_rejects_non_numeric_string(client: AsyncClient):
+    """Pydantic は数値文字列 "20" を int に強制変換する（既存 session API と同じ挙動）が、
+    数値として解釈できない文字列は 422 で蹴ることを担保する。
+    """
+    headers = {"Authorization": "Bearer settings-user-string"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+
+    response = await client.patch(
+        "/api/v1/users/me/settings",
+        headers=headers,
+        json={"input_minutes": "abc"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_forbids_extra_fields(client: AsyncClient):
+    headers = {"Authorization": "Bearer settings-user-extra"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+
+    response = await client.patch(
+        "/api/v1/users/me/settings",
+        headers=headers,
+        json={"unknown_field": 1},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_rejects_empty_body(client: AsyncClient):
+    headers = {"Authorization": "Bearer settings-user-empty"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+
+    response = await client.patch(
+        "/api/v1/users/me/settings", headers=headers, json={}
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_requires_authorization_header(client: AsyncClient):
+    response = await client.patch(
+        "/api/v1/users/me/settings", json={"input_minutes": 30}
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_account_requires_authorization_header(client: AsyncClient):
+    response = await client.delete("/api/v1/users/me")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_account_removes_user_and_returns_204(
+    client: AsyncClient, fake_user_repository: FakeUserRepository
+):
+    headers = {"Authorization": "Bearer settings-user-delete"}
+    # 初回 GET で users + user_settings を auth_middleware に作らせる
+    get_response = await client.get("/api/v1/users/me/settings", headers=headers)
+    assert get_response.status_code == 200
+    assert "settings-user-delete" in fake_user_repository.users
+
+    delete_response = await client.delete("/api/v1/users/me", headers=headers)
+    assert delete_response.status_code == 204
+    assert delete_response.text == ""
+    assert "settings-user-delete" not in fake_user_repository.users

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -73,9 +73,7 @@ async def test_patch_settings_rejects_out_of_range_minutes(
     headers = {"Authorization": f"Bearer settings-range-{field}"}
     await client.get("/api/v1/users/me/settings", headers=headers)
 
-    response = await client.patch(
-        "/api/v1/users/me/settings", headers=headers, json=payload
-    )
+    response = await client.patch("/api/v1/users/me/settings", headers=headers, json=payload)
     assert response.status_code == 422
 
 
@@ -113,17 +111,13 @@ async def test_patch_settings_rejects_empty_body(client: AsyncClient):
     headers = {"Authorization": "Bearer settings-user-empty"}
     await client.get("/api/v1/users/me/settings", headers=headers)
 
-    response = await client.patch(
-        "/api/v1/users/me/settings", headers=headers, json={}
-    )
+    response = await client.patch("/api/v1/users/me/settings", headers=headers, json={})
     assert response.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_patch_settings_requires_authorization_header(client: AsyncClient):
-    response = await client.patch(
-        "/api/v1/users/me/settings", json={"input_minutes": 30}
-    )
+    response = await client.patch("/api/v1/users/me/settings", json={"input_minutes": 30})
     assert response.status_code == 401
 
 

--- a/backend/tests/unit/test_use_cases/test_delete_account.py
+++ b/backend/tests/unit/test_use_cases/test_delete_account.py
@@ -1,0 +1,60 @@
+"""DeleteAccount UseCase の振る舞い。"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from src.application.use_cases.delete_account import DeleteAccount
+from src.domain.entities.user import User
+from src.domain.entities.user_settings import UserSettings
+from src.domain.value_objects.auth_provider import AuthProvider
+from tests.fakes.fake_user_repository import FakeUserRepository
+
+
+def _make_user_with_settings() -> tuple[User, UserSettings]:
+    now = datetime.now(UTC)
+    user = User(
+        id=uuid4(),
+        firebase_uid="uid-001",
+        auth_provider=AuthProvider.GOOGLE,
+        created_at=now,
+        updated_at=now,
+    )
+    settings = UserSettings(
+        id=uuid4(),
+        user_id=user.id,
+        created_at=now,
+        updated_at=now,
+    )
+    return user, settings
+
+
+@pytest.mark.asyncio
+async def test_delete_account_removes_user_and_settings():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+    assert user.firebase_uid in repo.users
+    assert user.id in repo.settings
+
+    use_case = DeleteAccount(user_repository=repo)
+    await use_case.execute(user)
+
+    assert user.firebase_uid not in repo.users
+    assert user.id not in repo.settings
+
+
+@pytest.mark.asyncio
+async def test_delete_account_is_idempotent():
+    """既に削除済みのユーザーに対して例外を投げないことを担保する。"""
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+
+    use_case = DeleteAccount(user_repository=repo)
+    await use_case.execute(user)
+    # 2 度目の呼び出しでも例外にならない
+    await use_case.execute(user)
+
+    assert user.firebase_uid not in repo.users

--- a/backend/tests/unit/test_use_cases/test_get_user_settings.py
+++ b/backend/tests/unit/test_use_cases/test_get_user_settings.py
@@ -1,0 +1,61 @@
+"""GetUserSettings UseCase の振る舞い。"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from src.application.use_cases.get_user_settings import (
+    GetUserSettings,
+    UserSettingsNotFoundError,
+)
+from src.domain.entities.user import User
+from src.domain.entities.user_settings import UserSettings
+from src.domain.value_objects.auth_provider import AuthProvider
+from tests.fakes.fake_user_repository import FakeUserRepository
+
+
+def _make_user_with_settings() -> tuple[User, UserSettings]:
+    now = datetime.now(UTC)
+    user = User(
+        id=uuid4(),
+        firebase_uid="uid-001",
+        auth_provider=AuthProvider.GOOGLE,
+        created_at=now,
+        updated_at=now,
+    )
+    settings = UserSettings(
+        id=uuid4(),
+        user_id=user.id,
+        created_at=now,
+        updated_at=now,
+    )
+    return user, settings
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_returns_defaults_when_freshly_created():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+
+    use_case = GetUserSettings(user_repository=repo)
+    view = await use_case.execute(user)
+
+    assert view.input_minutes == 20
+    assert view.output_minutes == 5
+    assert view.break_minutes == 5
+    assert view.notification_enabled is True
+    assert view.updated_at == settings.updated_at
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_raises_when_settings_missing():
+    repo = FakeUserRepository()
+    user, _ = _make_user_with_settings()
+    # users だけ登録し、settings は意図的に未登録にしておく。
+    repo.users[user.firebase_uid] = user
+
+    use_case = GetUserSettings(user_repository=repo)
+    with pytest.raises(UserSettingsNotFoundError):
+        await use_case.execute(user)

--- a/backend/tests/unit/test_use_cases/test_update_user_settings.py
+++ b/backend/tests/unit/test_use_cases/test_update_user_settings.py
@@ -89,9 +89,7 @@ async def test_update_user_settings_can_disable_notification_only():
     await repo.add(user, settings)
 
     use_case = UpdateUserSettings(user_repository=repo)
-    view = await use_case.execute(
-        user, UpdateUserSettingsCommand(notification_enabled=False)
-    )
+    view = await use_case.execute(user, UpdateUserSettingsCommand(notification_enabled=False))
 
     assert view.notification_enabled is False
     assert view.input_minutes == 20  # 他はデフォルトのまま

--- a/backend/tests/unit/test_use_cases/test_update_user_settings.py
+++ b/backend/tests/unit/test_use_cases/test_update_user_settings.py
@@ -1,0 +1,108 @@
+"""UpdateUserSettings UseCase の振る舞い。"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from src.application.dto.user_settings_dto import UpdateUserSettingsCommand
+from src.application.use_cases.get_user_settings import UserSettingsNotFoundError
+from src.application.use_cases.update_user_settings import UpdateUserSettings
+from src.domain.entities.user import User
+from src.domain.entities.user_settings import UserSettings
+from src.domain.value_objects.auth_provider import AuthProvider
+from tests.fakes.fake_user_repository import FakeUserRepository
+
+
+def _make_user_with_settings() -> tuple[User, UserSettings]:
+    # 過去時刻にしておくことで update 後に updated_at が前進したかを判定できる。
+    past = datetime.now(UTC) - timedelta(days=1)
+    user = User(
+        id=uuid4(),
+        firebase_uid="uid-001",
+        auth_provider=AuthProvider.GOOGLE,
+        created_at=past,
+        updated_at=past,
+    )
+    settings = UserSettings(
+        id=uuid4(),
+        user_id=user.id,
+        created_at=past,
+        updated_at=past,
+    )
+    return user, settings
+
+
+@pytest.mark.asyncio
+async def test_update_user_settings_updates_single_field_and_preserves_others():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+
+    use_case = UpdateUserSettings(user_repository=repo)
+    view = await use_case.execute(user, UpdateUserSettingsCommand(input_minutes=45))
+
+    assert view.input_minutes == 45
+    # 他フィールドはデフォルトのまま保持される
+    assert view.output_minutes == 5
+    assert view.break_minutes == 5
+    assert view.notification_enabled is True
+    # 永続化されている
+    persisted = repo.settings[user.id]
+    assert persisted.input_minutes == 45
+    assert persisted.notification_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_update_user_settings_updates_multiple_fields_and_advances_updated_at():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+    original_updated_at = settings.updated_at
+
+    use_case = UpdateUserSettings(user_repository=repo)
+    view = await use_case.execute(
+        user,
+        UpdateUserSettingsCommand(
+            input_minutes=30,
+            output_minutes=10,
+            break_minutes=8,
+            notification_enabled=False,
+        ),
+    )
+
+    assert view.input_minutes == 30
+    assert view.output_minutes == 10
+    assert view.break_minutes == 8
+    assert view.notification_enabled is False
+    assert view.updated_at > original_updated_at
+
+
+@pytest.mark.asyncio
+async def test_update_user_settings_can_disable_notification_only():
+    """notification_enabled=False の単独更新が反映されることを担保する。
+
+    bool は falsy になり得るため `if value:` ではなく `is not None` での判定が必須。
+    """
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+
+    use_case = UpdateUserSettings(user_repository=repo)
+    view = await use_case.execute(
+        user, UpdateUserSettingsCommand(notification_enabled=False)
+    )
+
+    assert view.notification_enabled is False
+    assert view.input_minutes == 20  # 他はデフォルトのまま
+
+
+@pytest.mark.asyncio
+async def test_update_user_settings_raises_when_settings_missing():
+    repo = FakeUserRepository()
+    user, _ = _make_user_with_settings()
+    repo.users[user.firebase_uid] = user
+
+    use_case = UpdateUserSettings(user_repository=repo)
+    with pytest.raises(UserSettingsNotFoundError):
+        await use_case.execute(user, UpdateUserSettingsCommand(input_minutes=30))

--- a/mobile/app/profile/_layout.tsx
+++ b/mobile/app/profile/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function ProfileLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -1,0 +1,5 @@
+import { ProfileEditScreen } from '@/features/profile/screens/ProfileEditScreen';
+
+export default function ProfileEditRoute() {
+  return <ProfileEditScreen />;
+}

--- a/mobile/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/mobile/src/features/profile/screens/ProfileEditScreen.tsx
@@ -1,0 +1,172 @@
+/**
+ * プロフィール編集画面。
+ *
+ * 設定画面（SettingsScreen）から遷移し、display_name と age_group を変更できる。
+ * 既存の useProfile / useUpdateProfile を再利用し、保存成功後は router.back() で
+ * 設定画面に戻る。AgeGroupSelectScreen はオンボーディング専用のため、本画面では
+ * 既存ユーザー向けに display_name も同時編集できる構成にする。
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'expo-router';
+import { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  Button,
+  H2,
+  Input,
+  Paragraph,
+  RadioGroup,
+  SizableText,
+  Spinner,
+  XStack,
+  YStack,
+} from 'tamagui';
+import { z } from 'zod';
+
+import { useProfile } from '@/features/profile/hooks/useProfile';
+import { useUpdateProfile } from '@/features/profile/hooks/useUpdateProfile';
+import { isApiError } from '@/shared/lib/api';
+import { AGE_GROUP_LABELS, AGE_GROUPS, type AgeGroup } from '@/shared/types/user';
+
+const schema = z.object({
+  display_name: z.string().trim().max(50, '50 文字以内で入力してください'),
+  age_group: z.enum(AGE_GROUPS, { required_error: '年代を選択してください' }),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const DEFAULT_AGE_GROUP: AgeGroup = '20s';
+
+export function ProfileEditScreen() {
+  const router = useRouter();
+  const profileQuery = useProfile();
+  const updateProfile = useUpdateProfile();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty, isValid },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { display_name: '', age_group: DEFAULT_AGE_GROUP },
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    const profile = profileQuery.data;
+    if (profile === undefined) return;
+    reset({
+      display_name: profile.display_name ?? '',
+      age_group: profile.age_group ?? DEFAULT_AGE_GROUP,
+    });
+  }, [profileQuery.data, reset]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    await updateProfile.mutateAsync({
+      // 空文字は null として送り、display_name 未設定状態を許容する。
+      display_name: values.display_name === '' ? null : values.display_name,
+      age_group: values.age_group,
+    });
+    router.back();
+  });
+
+  const isInitialLoading = profileQuery.isLoading || profileQuery.data === undefined;
+  const errorMessage = resolveErrorMessage(updateProfile.error);
+
+  if (isInitialLoading) {
+    return (
+      <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
+        <Spinner />
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack flex={1} padding="$4" gap="$4" testID="profile-edit-root">
+      <YStack gap="$2">
+        <H2>プロフィール編集</H2>
+        <Paragraph theme="alt2">表示名と年代を変更できます。</Paragraph>
+      </YStack>
+
+      <YStack gap="$2">
+        <SizableText size="$3">表示名</SizableText>
+        <Controller
+          control={control}
+          name="display_name"
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Input
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder="（任意）"
+              testID="profile-display-name"
+            />
+          )}
+        />
+        {errors.display_name ? (
+          <SizableText color="$red10" size="$2">
+            {errors.display_name.message}
+          </SizableText>
+        ) : null}
+      </YStack>
+
+      <YStack gap="$2">
+        <SizableText size="$3">年代</SizableText>
+        <Controller
+          control={control}
+          name="age_group"
+          render={({ field: { onChange, value } }) => (
+            <RadioGroup value={value} onValueChange={(v) => onChange(v as AgeGroup)}>
+              <YStack gap="$2">
+                {AGE_GROUPS.map((group) => (
+                  <XStack key={group} alignItems="center" gap="$3">
+                    <RadioGroup.Item
+                      value={group}
+                      id={`profile-age-group-${group}`}
+                      testID={`profile-age-group-${group}`}
+                      size="$4"
+                    >
+                      <RadioGroup.Indicator />
+                    </RadioGroup.Item>
+                    <SizableText htmlFor={`profile-age-group-${group}`} size="$4">
+                      {AGE_GROUP_LABELS[group]}
+                    </SizableText>
+                  </XStack>
+                ))}
+              </YStack>
+            </RadioGroup>
+          )}
+        />
+        {errors.age_group ? (
+          <SizableText color="$red10" size="$2">
+            {errors.age_group.message}
+          </SizableText>
+        ) : null}
+      </YStack>
+
+      {errorMessage ? (
+        <SizableText color="$red10" size="$3" testID="profile-edit-error">
+          {errorMessage}
+        </SizableText>
+      ) : null}
+
+      <Button
+        onPress={onSubmit}
+        disabled={!isDirty || !isValid || updateProfile.isPending}
+        themeInverse
+        testID="profile-edit-save"
+      >
+        {updateProfile.isPending ? <Spinner /> : '保存'}
+      </Button>
+    </YStack>
+  );
+}
+
+function resolveErrorMessage(error: Error | null | undefined): string | null {
+  if (!error) return null;
+  if (isApiError(error)) {
+    return error.problem?.detail ?? error.problem?.title ?? '保存に失敗しました。';
+  }
+  return '通信に失敗しました。時間をおいて再度お試しください。';
+}

--- a/mobile/src/features/profile/screens/__tests__/ProfileEditScreen.test.tsx
+++ b/mobile/src/features/profile/screens/__tests__/ProfileEditScreen.test.tsx
@@ -4,7 +4,7 @@
  * - 値を変更して保存すると updateMyProfile が呼ばれ、router.back が実行されること
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
@@ -58,7 +58,8 @@ describe('ProfileEditScreen', () => {
   });
 
   afterEach(() => {
-    useAuthStore.getState().clear();
+    cleanup();
+    useAuthStore.setState({ uid: null, idToken: null });
   });
 
   it('取得完了後に display_name が初期値として入る', async () => {

--- a/mobile/src/features/profile/screens/__tests__/ProfileEditScreen.test.tsx
+++ b/mobile/src/features/profile/screens/__tests__/ProfileEditScreen.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ProfileEditScreen の振る舞いを検証する。
+ * - useProfile の取得が完了すると初期値がフォームに入ること
+ * - 値を変更して保存すると updateMyProfile が呼ばれ、router.back が実行されること
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as profileApi from '@/features/profile/api/profileApi';
+import { ProfileEditScreen } from '@/features/profile/screens/ProfileEditScreen';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+const mockBack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock('@/features/profile/api/profileApi');
+
+const PROFILE_FIXTURE = {
+  id: 'u-1',
+  firebase_uid: 'fuid-1',
+  auth_provider: 'google' as const,
+  display_name: '太郎',
+  age_group: '30s' as const,
+  onboarding_completed: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('ProfileEditScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.setState({ uid: 'u-1', idToken: 'token-1' });
+    (profileApi.fetchMyProfile as jest.Mock).mockResolvedValue(PROFILE_FIXTURE);
+    (profileApi.updateMyProfile as jest.Mock).mockResolvedValue({
+      ...PROFILE_FIXTURE,
+      display_name: '次郎',
+    });
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clear();
+  });
+
+  it('取得完了後に display_name が初期値として入る', async () => {
+    const { findByTestId } = renderWithProviders(<ProfileEditScreen />);
+
+    const input = await findByTestId('profile-display-name');
+    await waitFor(() => {
+      expect(input.props.value).toBe('太郎');
+    });
+  });
+
+  it('display_name を変更して保存すると updateMyProfile が呼ばれ、router.back が実行される', async () => {
+    const { findByTestId } = renderWithProviders(<ProfileEditScreen />);
+
+    const input = await findByTestId('profile-display-name');
+    await waitFor(() => {
+      expect(input.props.value).toBe('太郎');
+    });
+
+    fireEvent.changeText(input, '次郎');
+    const saveButton = await findByTestId('profile-edit-save');
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(profileApi.updateMyProfile).toHaveBeenCalledWith({
+        display_name: '次郎',
+        age_group: '30s',
+      });
+    });
+    await waitFor(() => {
+      expect(mockBack).toHaveBeenCalled();
+    });
+  });
+
+  it('display_name を空文字にして保存すると null として送信される', async () => {
+    const { findByTestId } = renderWithProviders(<ProfileEditScreen />);
+
+    const input = await findByTestId('profile-display-name');
+    await waitFor(() => {
+      expect(input.props.value).toBe('太郎');
+    });
+
+    fireEvent.changeText(input, '');
+    const saveButton = await findByTestId('profile-edit-save');
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(profileApi.updateMyProfile).toHaveBeenCalledWith({
+        display_name: null,
+        age_group: '30s',
+      });
+    });
+  });
+});

--- a/mobile/src/features/session/components/__tests__/SessionHeader.test.tsx
+++ b/mobile/src/features/session/components/__tests__/SessionHeader.test.tsx
@@ -5,7 +5,7 @@
  * 直接呼び出して、確認ダイアログを承諾した状態をシミュレートする。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { Alert } from 'react-native';
 import { TamaguiProvider } from 'tamagui';
@@ -41,9 +41,22 @@ function renderWithProviders(ui: ReactNode) {
   );
 }
 
+function flushPendingTimers() {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+}
+
 describe('SessionHeader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    flushPendingTimers();
+    jest.useRealTimers();
   });
 
   it('中断ボタン押下 → 「中断する」承諾で onBeforeCancel → cancelled PATCH → ホームへ replace', async () => {
@@ -59,8 +72,10 @@ describe('SessionHeader', () => {
     const { getByTestId } = renderWithProviders(
       <SessionHeader sessionId="ses-1" title="インプット" onBeforeCancel={onBeforeCancel} />,
     );
+    flushPendingTimers();
 
     fireEvent.press(getByTestId('session-header-cancel'));
+    flushPendingTimers();
 
     expect(alertSpy).toHaveBeenCalled();
     expect(onBeforeCancel).toHaveBeenCalledTimes(1);
@@ -84,7 +99,10 @@ describe('SessionHeader', () => {
     const { getByTestId } = renderWithProviders(
       <SessionHeader sessionId="ses-1" title="インプット" />,
     );
+    flushPendingTimers();
+
     fireEvent.press(getByTestId('session-header-cancel'));
+    flushPendingTimers();
 
     expect(sessionApi.updateSessionStatus).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();

--- a/mobile/src/features/settings/api/settingsApi.ts
+++ b/mobile/src/features/settings/api/settingsApi.ts
@@ -1,3 +1,19 @@
 /**
- * 設定 API。Epic #5 / Epic #6 で実装する。
+ * GET / PATCH /api/v1/users/me/settings と DELETE /api/v1/users/me の API 呼び出し。
  */
+import { api } from '@/shared/lib/api';
+import type { UpdateUserSettingsInput, UserSettings } from '@/shared/types/userSettings';
+
+export async function fetchMySettings(): Promise<UserSettings> {
+  const { data } = await api.get<UserSettings>('/users/me/settings');
+  return data;
+}
+
+export async function updateMySettings(input: UpdateUserSettingsInput): Promise<UserSettings> {
+  const { data } = await api.patch<UserSettings>('/users/me/settings', input);
+  return data;
+}
+
+export async function deleteMyAccount(): Promise<void> {
+  await api.delete<void>('/users/me');
+}

--- a/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
+++ b/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
@@ -3,7 +3,7 @@
  * 成功時に QueryClient のキャッシュ全消去と authStore のクリアが行われることを担保する。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook } from '@testing-library/react-native';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
 
@@ -32,7 +32,8 @@ describe('useDeleteAccount', () => {
   });
 
   afterEach(() => {
-    useAuthStore.getState().clear();
+    cleanup();
+    useAuthStore.setState({ uid: null, idToken: null });
   });
 
   it('mutate で deleteMyAccount を呼び、成功時に queryClient.clear() と authStore.clear() を実行する', async () => {
@@ -42,8 +43,12 @@ describe('useDeleteAccount', () => {
 
     const { result } = renderHook(() => useDeleteAccount(), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync();
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
     });
 
     expect(settingsApi.deleteMyAccount).toHaveBeenCalledTimes(1);

--- a/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
+++ b/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
@@ -1,0 +1,54 @@
+/**
+ * useDeleteAccount の振る舞いを検証する。
+ * 成功時に QueryClient のキャッシュ全消去と authStore のクリアが行われることを担保する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+import * as settingsApi from '@/features/settings/api/settingsApi';
+import { useDeleteAccount } from '@/features/settings/hooks/useDeleteAccount';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+jest.mock('@/features/settings/api/settingsApi');
+
+function buildWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+describe('useDeleteAccount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.setState({ uid: 'u-1', idToken: 'token-1' });
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clear();
+  });
+
+  it('mutate で deleteMyAccount を呼び、成功時に queryClient.clear() と authStore.clear() を実行する', async () => {
+    (settingsApi.deleteMyAccount as jest.Mock).mockResolvedValue(undefined);
+    const { queryClient, wrapper } = buildWrapper();
+    queryClient.setQueryData(['profile', 'me'], { id: 'u-1' });
+
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(settingsApi.deleteMyAccount).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['profile', 'me'])).toBeUndefined();
+    expect(useAuthStore.getState().uid).toBeNull();
+    expect(useAuthStore.getState().idToken).toBeNull();
+  });
+});

--- a/mobile/src/features/settings/hooks/__tests__/useUpdateSettings.test.ts
+++ b/mobile/src/features/settings/hooks/__tests__/useUpdateSettings.test.ts
@@ -4,7 +4,7 @@
  * 成功時に SETTINGS_QUERY_KEY のキャッシュへ反映されることを担保する。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
 
@@ -32,6 +32,10 @@ describe('useUpdateSettings', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('mutate で updateMySettings を呼び出し、成功時に SETTINGS_QUERY_KEY のキャッシュを更新する', async () => {
     const updated: UserSettings = {
       input_minutes: 30,
@@ -45,8 +49,12 @@ describe('useUpdateSettings', () => {
 
     const { result } = renderHook(() => useUpdateSettings(), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync({ input_minutes: 30 });
+    act(() => {
+      result.current.mutate({ input_minutes: 30 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
     });
 
     expect(settingsApi.updateMySettings).toHaveBeenCalledWith({ input_minutes: 30 });

--- a/mobile/src/features/settings/hooks/__tests__/useUpdateSettings.test.ts
+++ b/mobile/src/features/settings/hooks/__tests__/useUpdateSettings.test.ts
@@ -1,0 +1,57 @@
+/**
+ * useUpdateSettings の振る舞いを検証する。
+ * mutationFn が settingsApi.updateMySettings を呼ぶことと、
+ * 成功時に SETTINGS_QUERY_KEY のキャッシュへ反映されることを担保する。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+import * as settingsApi from '@/features/settings/api/settingsApi';
+import { SETTINGS_QUERY_KEY } from '@/features/settings/hooks/useSettings';
+import { useUpdateSettings } from '@/features/settings/hooks/useUpdateSettings';
+import type { UserSettings } from '@/shared/types/userSettings';
+
+jest.mock('@/features/settings/api/settingsApi');
+
+function buildWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+describe('useUpdateSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mutate で updateMySettings を呼び出し、成功時に SETTINGS_QUERY_KEY のキャッシュを更新する', async () => {
+    const updated: UserSettings = {
+      input_minutes: 30,
+      output_minutes: 5,
+      break_minutes: 5,
+      notification_enabled: true,
+      updated_at: '2026-04-16T00:00:00Z',
+    };
+    (settingsApi.updateMySettings as jest.Mock).mockResolvedValue(updated);
+    const { queryClient, wrapper } = buildWrapper();
+
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ input_minutes: 30 });
+    });
+
+    expect(settingsApi.updateMySettings).toHaveBeenCalledWith({ input_minutes: 30 });
+    await waitFor(() => {
+      expect(queryClient.getQueryData<UserSettings>(SETTINGS_QUERY_KEY)).toEqual(updated);
+    });
+  });
+});

--- a/mobile/src/features/settings/hooks/useDeleteAccount.ts
+++ b/mobile/src/features/settings/hooks/useDeleteAccount.ts
@@ -1,0 +1,23 @@
+/**
+ * DELETE /users/me のための useMutation hook。
+ *
+ * 成功時は QueryClient のキャッシュを全て破棄し、authStore からセッションを消すことで
+ * AuthGate が自動的にサインイン画面へ戻す。Firebase Auth 上のサインアウトは呼び出し側
+ * （SettingsScreen）の責務にして、副作用の責務を分離する。
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteMyAccount } from '@/features/settings/api/settingsApi';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+  const clearAuth = useAuthStore((s) => s.clear);
+  return useMutation<void, Error, void>({
+    mutationFn: () => deleteMyAccount(),
+    onSuccess: () => {
+      queryClient.clear();
+      clearAuth();
+    },
+  });
+}

--- a/mobile/src/features/settings/hooks/useSettings.ts
+++ b/mobile/src/features/settings/hooks/useSettings.ts
@@ -1,6 +1,21 @@
 /**
- * ユーザー設定フック。Epic #5 / Epic #6 で実装する。
+ * GET /users/me/settings を TanStack Query で取得する hook。
+ * idToken が無いときは fetch しない（サインイン前は不要）。
  */
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchMySettings } from '@/features/settings/api/settingsApi';
+import { useAuthStore } from '@/shared/stores/authStore';
+import type { UserSettings } from '@/shared/types/userSettings';
+
+export const SETTINGS_QUERY_KEY = ['settings', 'me'] as const;
+
 export function useSettings() {
-  return { settings: null };
+  const idToken = useAuthStore((s) => s.idToken);
+  return useQuery<UserSettings>({
+    queryKey: SETTINGS_QUERY_KEY,
+    queryFn: fetchMySettings,
+    enabled: idToken !== null,
+    staleTime: 60 * 1000,
+  });
 }

--- a/mobile/src/features/settings/hooks/useUpdateSettings.ts
+++ b/mobile/src/features/settings/hooks/useUpdateSettings.ts
@@ -1,0 +1,19 @@
+/**
+ * PATCH /users/me/settings のための useMutation hook。
+ * 成功時は SETTINGS_QUERY_KEY のキャッシュを直接更新する（再 fetch を抑える）。
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateMySettings } from '@/features/settings/api/settingsApi';
+import { SETTINGS_QUERY_KEY } from '@/features/settings/hooks/useSettings';
+import type { UpdateUserSettingsInput, UserSettings } from '@/shared/types/userSettings';
+
+export function useUpdateSettings() {
+  const queryClient = useQueryClient();
+  return useMutation<UserSettings, Error, UpdateUserSettingsInput>({
+    mutationFn: (input) => updateMySettings(input),
+    onSuccess: (settings) => {
+      queryClient.setQueryData<UserSettings>(SETTINGS_QUERY_KEY, settings);
+    },
+  });
+}

--- a/mobile/src/features/settings/lib/userSettingsSchema.ts
+++ b/mobile/src/features/settings/lib/userSettingsSchema.ts
@@ -1,0 +1,32 @@
+/**
+ * 設定画面のフォーム入力に対する Zod スキーマ。
+ *
+ * 画面側は TextInput で値を扱うため、フォームでは string で受け取り、submit 時に
+ * `Number(value)` で変換する前提のスキーマと、変換後に backend へ送る `UpdateUserSettingsInput`
+ * 用のスキーマを別に持つ。タイマーの境界値は backend と一致させる。
+ */
+import { z } from 'zod';
+
+import { TIMER_MINUTES_MAX, TIMER_MINUTES_MIN } from '@/shared/types/userSettings';
+
+const minutesField = z
+  .string()
+  .trim()
+  .regex(/^\d+$/, '半角数字で入力してください')
+  .transform((v) => Number(v))
+  .pipe(
+    z
+      .number()
+      .int()
+      .min(TIMER_MINUTES_MIN, `${TIMER_MINUTES_MIN} 分以上を入力してください`)
+      .max(TIMER_MINUTES_MAX, `${TIMER_MINUTES_MAX} 分以下を入力してください`),
+  );
+
+export const timerFormSchema = z.object({
+  input_minutes: minutesField,
+  output_minutes: minutesField,
+  break_minutes: minutesField,
+});
+
+export type TimerFormValues = z.input<typeof timerFormSchema>;
+export type TimerFormParsed = z.output<typeof timerFormSchema>;

--- a/mobile/src/features/settings/screens/SettingsScreen.tsx
+++ b/mobile/src/features/settings/screens/SettingsScreen.tsx
@@ -1,9 +1,282 @@
-import { H1, YStack } from 'tamagui';
+/**
+ * 設定画面。要件書 3.2.6 のうち、
+ * - タイマー時間（input/output/break_minutes）の編集と保存
+ * - 通知トグル（notification_enabled）の即時保存
+ * - プロフィール編集 / ログアウト / アカウント削除への導線
+ * を提供する。
+ *
+ * タイマーは保存ボタン押下で PATCH。通知は Switch を切り替えた瞬間に PATCH する。
+ * アカウント削除は React Native の Alert.alert を確認ダイアログとして利用し、確定後に
+ * useDeleteAccount → AuthGate のリダイレクトで /(auth)/sign-in に戻す。
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'expo-router';
+import { useEffect } from 'react';
+import { Alert, Pressable, ScrollView } from 'react-native';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  Button,
+  H2,
+  Input,
+  Paragraph,
+  Separator,
+  SizableText,
+  Spinner,
+  Switch,
+  XStack,
+  YStack,
+} from 'tamagui';
+
+import { useDeleteAccount } from '@/features/settings/hooks/useDeleteAccount';
+import { useSettings } from '@/features/settings/hooks/useSettings';
+import { useUpdateSettings } from '@/features/settings/hooks/useUpdateSettings';
+import {
+  type TimerFormParsed,
+  type TimerFormValues,
+  timerFormSchema,
+} from '@/features/settings/lib/userSettingsSchema';
+import { isApiError } from '@/shared/lib/api';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+const DEFAULT_FORM: TimerFormValues = {
+  input_minutes: '20',
+  output_minutes: '5',
+  break_minutes: '5',
+};
 
 export function SettingsScreen() {
+  const router = useRouter();
+  const settingsQuery = useSettings();
+  const updateSettings = useUpdateSettings();
+  const deleteAccount = useDeleteAccount();
+  const clearAuth = useAuthStore((s) => s.clear);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty, isValid },
+  } = useForm<TimerFormValues, unknown, TimerFormParsed>({
+    resolver: zodResolver(timerFormSchema),
+    defaultValues: DEFAULT_FORM,
+    mode: 'onChange',
+  });
+
+  // 取得した最新値でフォームの defaultValues を上書きする。
+  // reset で isDirty が false に戻るので、保存ボタンの活性化が変更時のみになる。
+  useEffect(() => {
+    const data = settingsQuery.data;
+    if (data === undefined) return;
+    reset({
+      input_minutes: String(data.input_minutes),
+      output_minutes: String(data.output_minutes),
+      break_minutes: String(data.break_minutes),
+    });
+  }, [settingsQuery.data, reset]);
+
+  const onSaveTimer = handleSubmit(async (parsed) => {
+    await updateSettings.mutateAsync({
+      input_minutes: parsed.input_minutes,
+      output_minutes: parsed.output_minutes,
+      break_minutes: parsed.break_minutes,
+    });
+  });
+
+  const onToggleNotification = (next: boolean) => {
+    updateSettings.mutate({ notification_enabled: next });
+  };
+
+  const onPressLogout = () => {
+    clearAuth();
+    router.replace('/(auth)/sign-in');
+  };
+
+  const onPressDelete = () => {
+    Alert.alert(
+      'アカウントを削除しますか？',
+      'タイマー設定や学習履歴を含むすべてのデータが削除されます。この操作は取り消せません。',
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '削除する',
+          style: 'destructive',
+          onPress: () => {
+            // mutateAsync の例外は onError 経由でエラー表示に流すため、ここでは握り潰す。
+            void deleteAccount.mutateAsync();
+          },
+        },
+      ],
+    );
+  };
+
+  const isInitialLoading = settingsQuery.isLoading || settingsQuery.data === undefined;
+  const notificationEnabled = settingsQuery.data?.notification_enabled ?? true;
+  const errorMessage = resolveErrorMessage(updateSettings.error ?? deleteAccount.error);
+
   return (
-    <YStack flex={1} alignItems="center" justifyContent="center" padding="$4">
-      <H1>設定 (placeholder)</H1>
-    </YStack>
+    <ScrollView contentContainerStyle={{ paddingBottom: 32 }}>
+      <YStack padding="$4" gap="$5" testID="settings-root">
+        <H2>設定</H2>
+
+        {isInitialLoading ? (
+          <YStack alignItems="center" padding="$4">
+            <Spinner />
+          </YStack>
+        ) : (
+          <>
+            <YStack gap="$3" testID="settings-timer-section">
+              <H2 size="$6">タイマー設定 (分)</H2>
+              <Paragraph theme="alt2" size="$2">
+                1 〜 180 分の範囲で指定できます。
+              </Paragraph>
+
+              <YStack gap="$2">
+                <SizableText size="$3">インプット時間</SizableText>
+                <Controller
+                  control={control}
+                  name="input_minutes"
+                  render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                      keyboardType="number-pad"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      testID="settings-input-minutes"
+                    />
+                  )}
+                />
+                {errors.input_minutes ? (
+                  <SizableText color="$red10" size="$2">
+                    {errors.input_minutes.message}
+                  </SizableText>
+                ) : null}
+              </YStack>
+
+              <YStack gap="$2">
+                <SizableText size="$3">アウトプット時間</SizableText>
+                <Controller
+                  control={control}
+                  name="output_minutes"
+                  render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                      keyboardType="number-pad"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      testID="settings-output-minutes"
+                    />
+                  )}
+                />
+                {errors.output_minutes ? (
+                  <SizableText color="$red10" size="$2">
+                    {errors.output_minutes.message}
+                  </SizableText>
+                ) : null}
+              </YStack>
+
+              <YStack gap="$2">
+                <SizableText size="$3">休憩時間</SizableText>
+                <Controller
+                  control={control}
+                  name="break_minutes"
+                  render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                      keyboardType="number-pad"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      testID="settings-break-minutes"
+                    />
+                  )}
+                />
+                {errors.break_minutes ? (
+                  <SizableText color="$red10" size="$2">
+                    {errors.break_minutes.message}
+                  </SizableText>
+                ) : null}
+              </YStack>
+
+              <Button
+                onPress={onSaveTimer}
+                disabled={!isDirty || !isValid || updateSettings.isPending}
+                themeInverse
+                testID="settings-timer-save"
+              >
+                {updateSettings.isPending ? <Spinner /> : '保存'}
+              </Button>
+            </YStack>
+
+            <Separator />
+
+            <YStack gap="$3" testID="settings-notification-section">
+              <H2 size="$6">通知</H2>
+              <XStack alignItems="center" justifyContent="space-between">
+                <SizableText>リマインダー通知</SizableText>
+                <Switch
+                  checked={notificationEnabled}
+                  onCheckedChange={onToggleNotification}
+                  testID="settings-notification-switch"
+                >
+                  <Switch.Thumb animation="quick" />
+                </Switch>
+              </XStack>
+            </YStack>
+
+            <Separator />
+
+            <YStack gap="$3">
+              <H2 size="$6">プロフィール</H2>
+              <Pressable
+                onPress={() => router.push('/profile/edit')}
+                testID="settings-nav-profile-edit"
+              >
+                <XStack
+                  paddingVertical="$3"
+                  paddingHorizontal="$3"
+                  borderRadius="$3"
+                  backgroundColor="$backgroundHover"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <SizableText>プロフィール編集</SizableText>
+                  <SizableText theme="alt2">›</SizableText>
+                </XStack>
+              </Pressable>
+            </YStack>
+
+            <Separator />
+
+            <YStack gap="$3">
+              <H2 size="$6">アカウント</H2>
+              <Button onPress={onPressLogout} testID="settings-logout">
+                ログアウト
+              </Button>
+              <Button
+                onPress={onPressDelete}
+                theme="red"
+                disabled={deleteAccount.isPending}
+                testID="settings-delete-account"
+              >
+                {deleteAccount.isPending ? <Spinner /> : 'アカウントを削除'}
+              </Button>
+            </YStack>
+
+            {errorMessage ? (
+              <SizableText color="$red10" size="$3" testID="settings-error">
+                {errorMessage}
+              </SizableText>
+            ) : null}
+          </>
+        )}
+      </YStack>
+    </ScrollView>
   );
+}
+
+function resolveErrorMessage(error: Error | null | undefined): string | null {
+  if (!error) return null;
+  if (isApiError(error)) {
+    return error.problem?.detail ?? error.problem?.title ?? '保存に失敗しました。';
+  }
+  return '通信に失敗しました。時間をおいて再度お試しください。';
 }

--- a/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
@@ -10,7 +10,7 @@
  * AlertGate / Firebase 周りには触れず、API レイヤと expo-router をモックする。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { Alert } from 'react-native';
 import { TamaguiProvider } from 'tamagui';
@@ -51,9 +51,17 @@ function renderWithProviders(ui: ReactNode) {
   );
 }
 
+async function flushAsyncUpdates() {
+  await act(async () => {});
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+}
+
 describe('SettingsScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     // useSettings の enabled が true になるよう idToken をセット
     useAuthStore.setState({ uid: 'u-1', idToken: 'token-1' });
     (settingsApi.fetchMySettings as jest.Mock).mockResolvedValue(SETTINGS_FIXTURE);
@@ -62,34 +70,43 @@ describe('SettingsScreen', () => {
   });
 
   afterEach(() => {
-    useAuthStore.getState().clear();
+    cleanup();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    useAuthStore.setState({ uid: null, idToken: null });
+    jest.useRealTimers();
   });
 
   it('取得完了後にタイマー値がフォームに反映される', async () => {
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
 
     await waitFor(() => {
       expect(settingsApi.fetchMySettings).toHaveBeenCalled();
     });
-    const input = await findByTestId('settings-input-minutes');
+    await flushAsyncUpdates();
+
+    const input = getByTestId('settings-input-minutes');
     await waitFor(() => {
       expect(input.props.value).toBe('25');
     });
   });
 
   it('タイマー値を変更して保存すると updateMySettings が呼ばれる', async () => {
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
+    await flushAsyncUpdates();
 
-    const input = await findByTestId('settings-input-minutes');
+    const input = getByTestId('settings-input-minutes');
     await waitFor(() => {
       expect(input.props.value).toBe('25');
     });
 
     fireEvent.changeText(input, '40');
-    const saveButton = await findByTestId('settings-timer-save');
+    const saveButton = getByTestId('settings-timer-save');
     await act(async () => {
       fireEvent.press(saveButton);
     });
+    await flushAsyncUpdates();
 
     await waitFor(() => {
       expect(settingsApi.updateMySettings).toHaveBeenCalledWith({
@@ -101,9 +118,10 @@ describe('SettingsScreen', () => {
   });
 
   it('通知トグル切替で notification_enabled が PATCH される', async () => {
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
+    await flushAsyncUpdates();
 
-    const switchEl = await findByTestId('settings-notification-switch');
+    const switchEl = getByTestId('settings-notification-switch');
     await waitFor(() => {
       // 初期値が反映されてからトグルする
       expect(switchEl.props.accessibilityState?.checked ?? true).toBe(true);
@@ -112,6 +130,7 @@ describe('SettingsScreen', () => {
     await act(async () => {
       fireEvent.press(switchEl);
     });
+    await flushAsyncUpdates();
 
     await waitFor(() => {
       expect(settingsApi.updateMySettings).toHaveBeenCalledWith({
@@ -121,9 +140,10 @@ describe('SettingsScreen', () => {
   });
 
   it('プロフィール編集の導線で router.push が呼ばれる', async () => {
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
+    await flushAsyncUpdates();
 
-    const link = await findByTestId('settings-nav-profile-edit');
+    const link = getByTestId('settings-nav-profile-edit');
     fireEvent.press(link);
 
     expect(mockPush).toHaveBeenCalledWith('/profile/edit');
@@ -132,8 +152,10 @@ describe('SettingsScreen', () => {
   it('アカウント削除ボタンで確認ダイアログを開き、確定で deleteMyAccount が呼ばれる', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
-    const deleteButton = await findByTestId('settings-delete-account');
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
+    await flushAsyncUpdates();
+
+    const deleteButton = getByTestId('settings-delete-account');
     fireEvent.press(deleteButton);
 
     expect(alertSpy).toHaveBeenCalledTimes(1);
@@ -145,19 +167,25 @@ describe('SettingsScreen', () => {
     await act(async () => {
       destructive!.onPress?.();
     });
+    await flushAsyncUpdates();
 
     await waitFor(() => {
       expect(settingsApi.deleteMyAccount).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(useAuthStore.getState().uid).toBeNull();
     });
 
     alertSpy.mockRestore();
   });
 
   it('ログアウトボタンで authStore.clear() と router.replace が呼ばれる', async () => {
-    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const { getByTestId } = renderWithProviders(<SettingsScreen />);
+    await flushAsyncUpdates();
 
-    const logout = await findByTestId('settings-logout');
+    const logout = getByTestId('settings-logout');
     fireEvent.press(logout);
+    await flushAsyncUpdates();
 
     expect(useAuthStore.getState().uid).toBeNull();
     expect(mockReplace).toHaveBeenCalledWith('/(auth)/sign-in');

--- a/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * SettingsScreen の主要な振る舞いを検証する。
+ *
+ * - useSettings の取得が完了するとフォームに値が入ること
+ * - タイマー値を変更して保存すると updateMySettings が呼ばれること
+ * - 通知 Switch を切り替えると notification_enabled が PATCH されること
+ * - プロフィール編集の導線が router.push を呼ぶこと
+ * - 削除ボタン押下で Alert.alert が確認ダイアログを表示し、確定で deleteMyAccount が呼ばれること
+ *
+ * AlertGate / Firebase 周りには触れず、API レイヤと expo-router をモックする。
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+import { Alert } from 'react-native';
+import { TamaguiProvider } from 'tamagui';
+
+import config from '../../../../../tamagui.config';
+import * as settingsApi from '@/features/settings/api/settingsApi';
+import { SettingsScreen } from '@/features/settings/screens/SettingsScreen';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+jest.mock('@/features/settings/api/settingsApi');
+
+const SETTINGS_FIXTURE = {
+  input_minutes: 25,
+  output_minutes: 7,
+  break_minutes: 6,
+  notification_enabled: true,
+  updated_at: '2026-04-16T00:00:00Z',
+};
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: Infinity },
+    },
+  });
+  return render(
+    <TamaguiProvider config={config} defaultTheme="light">
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('SettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // useSettings の enabled が true になるよう idToken をセット
+    useAuthStore.setState({ uid: 'u-1', idToken: 'token-1' });
+    (settingsApi.fetchMySettings as jest.Mock).mockResolvedValue(SETTINGS_FIXTURE);
+    (settingsApi.updateMySettings as jest.Mock).mockResolvedValue(SETTINGS_FIXTURE);
+    (settingsApi.deleteMyAccount as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clear();
+  });
+
+  it('取得完了後にタイマー値がフォームに反映される', async () => {
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(settingsApi.fetchMySettings).toHaveBeenCalled();
+    });
+    const input = await findByTestId('settings-input-minutes');
+    await waitFor(() => {
+      expect(input.props.value).toBe('25');
+    });
+  });
+
+  it('タイマー値を変更して保存すると updateMySettings が呼ばれる', async () => {
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+
+    const input = await findByTestId('settings-input-minutes');
+    await waitFor(() => {
+      expect(input.props.value).toBe('25');
+    });
+
+    fireEvent.changeText(input, '40');
+    const saveButton = await findByTestId('settings-timer-save');
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(settingsApi.updateMySettings).toHaveBeenCalledWith({
+        input_minutes: 40,
+        output_minutes: 7,
+        break_minutes: 6,
+      });
+    });
+  });
+
+  it('通知トグル切替で notification_enabled が PATCH される', async () => {
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+
+    const switchEl = await findByTestId('settings-notification-switch');
+    await waitFor(() => {
+      // 初期値が反映されてからトグルする
+      expect(switchEl.props.accessibilityState?.checked ?? true).toBe(true);
+    });
+
+    await act(async () => {
+      fireEvent.press(switchEl);
+    });
+
+    await waitFor(() => {
+      expect(settingsApi.updateMySettings).toHaveBeenCalledWith({
+        notification_enabled: false,
+      });
+    });
+  });
+
+  it('プロフィール編集の導線で router.push が呼ばれる', async () => {
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+
+    const link = await findByTestId('settings-nav-profile-edit');
+    fireEvent.press(link);
+
+    expect(mockPush).toHaveBeenCalledWith('/profile/edit');
+  });
+
+  it('アカウント削除ボタンで確認ダイアログを開き、確定で deleteMyAccount が呼ばれる', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+    const deleteButton = await findByTestId('settings-delete-account');
+    fireEvent.press(deleteButton);
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    const buttons = alertSpy.mock.calls[0]![2];
+    expect(buttons).toBeDefined();
+    const destructive = buttons!.find((b) => b.style === 'destructive');
+    expect(destructive).toBeDefined();
+
+    await act(async () => {
+      destructive!.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(settingsApi.deleteMyAccount).toHaveBeenCalledTimes(1);
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it('ログアウトボタンで authStore.clear() と router.replace が呼ばれる', async () => {
+    const { findByTestId } = renderWithProviders(<SettingsScreen />);
+
+    const logout = await findByTestId('settings-logout');
+    fireEvent.press(logout);
+
+    expect(useAuthStore.getState().uid).toBeNull();
+    expect(mockReplace).toHaveBeenCalledWith('/(auth)/sign-in');
+  });
+});

--- a/mobile/src/shared/lib/api.ts
+++ b/mobile/src/shared/lib/api.ts
@@ -127,6 +127,10 @@ class ApiClient {
     });
   }
 
+  async delete<T>(path: string): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { method: 'DELETE' });
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<ApiResponse<T>> {
     const response = await this.fetchWithAuth(path, init);
     const data = await parseResponseBody<T | ProblemDetails>(response);

--- a/mobile/src/shared/types/userSettings.ts
+++ b/mobile/src/shared/types/userSettings.ts
@@ -1,0 +1,28 @@
+/**
+ * ユーザ設定（タイマー / 通知）の共通型。
+ * backend の `src/domain/entities/user_settings.py` と
+ * `src/presentation/schemas/user_settings_schema.py` のフィールド名と一致させる。
+ */
+
+export type UserSettings = {
+  input_minutes: number;
+  output_minutes: number;
+  break_minutes: number;
+  notification_enabled: boolean;
+  updated_at: string;
+};
+
+/**
+ * PATCH /users/me/settings の入力。すべてのフィールドが任意で、
+ * 指定されたフィールドのみ更新される（部分更新）。
+ */
+export type UpdateUserSettingsInput = {
+  input_minutes?: number;
+  output_minutes?: number;
+  break_minutes?: number;
+  notification_enabled?: boolean;
+};
+
+/** タイマー値の許容範囲（backend のバリデーションと一致）。 */
+export const TIMER_MINUTES_MIN = 1;
+export const TIMER_MINUTES_MAX = 180;


### PR DESCRIPTION
## 概要

mobile の設定画面にタイマー時間 / 通知設定の編集と、プロフィール編集 / アカウント削除 / ログアウトの導線を実装する。Story #22 の前提となる settings API（`GET/PATCH /users/me/settings`）と削除 API（`DELETE /users/me`）も同 PR で追加する。

## 関連 Issue

- Closes #57
- Refs #22, #5

## 変更内容

### Backend
- `UserRepository` に `find_settings_by_user_id` / `update_settings` / `delete_by_id` を追加（Pg / Fake 両実装）
- `UserSettingsView` / `UpdateUserSettingsCommand` と `GetUserSettings` / `UpdateUserSettings` / `DeleteAccount` UseCase
- `GET /api/v1/users/me/settings`（200）/ `PATCH /api/v1/users/me/settings`（200、minutes は 1〜180 でバリデーション、空 body は 422）/ `DELETE /api/v1/users/me`（204、FK CASCADE で関連レコードも連鎖削除）
- 単体・統合テストで境界値・空 body・未知フィールド・未認証・削除完了までを網羅

### Mobile
- `ApiClient.delete` を追加（既存の Authorization 付与・401 リトライ・Problem Details 取り回しを共有）
- `useSettings` / `useUpdateSettings` / `useDeleteAccount` を実装。useUpdateSettings は `setQueryData` で即時反映、useDeleteAccount は `queryClient.clear()` + `authStore.clear()` で AuthGate に委ねる
- `SettingsScreen` を本実装：常時表示フォームでタイマー編集、Switch で通知即時保存、Pressable で `/profile/edit` 遷移、`Alert.alert` でアカウント削除確認、ログアウトボタン
- `ProfileEditScreen` と `app/profile/{_layout,edit}.tsx` を新規追加（display_name と age_group を編集、空文字は null として送信）

## スコープ外 / 残課題

- Firebase Authentication 上のユーザー本体の削除はクライアント責務。本 PR では DB の `users` 行のみ削除し、再サインインで auth_middleware が新規ユーザーを作る挙動になる
- 通知の OS パーミッション要求や FCM 連携は対象外（既存スコープ）

## 動作確認

```bash
# CI 相当
task ci

# Backend を起動して API を直接叩く場合
task backend:dev
# GET /api/v1/users/me/settings → デフォルト 20/5/5/true
# PATCH .../settings {"input_minutes":30} → 200、再 GET で 30
# PATCH .../settings {"input_minutes":0} → 422
# PATCH .../settings {} → 422
# DELETE /api/v1/users/me → 204、再 GET でデフォルトに戻る

# Mobile を起動
task mobile:start
# 設定画面で初期値が GET の値で表示
# タイマー編集→保存→再読込で値が残る
# 通知トグル切替で即時 PATCH
# 「プロフィール編集」→ display_name と年代を変更→保存→戻る
# 「ログアウト」でサインイン画面へ
# 「アカウントを削除」→ Alert 確認→「削除する」でサインイン画面へ
```

### スクリーンショット / 動画

<!-- レビュアーで実機確認時に追記 -->

## チェックリスト

- [x] `task ci` がローカルで通る（backend pytest 79/79、ruff 緑 / mobile jest 107/107、tsc / eslint / prettier 緑）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md` 3.2.6 / 4.3.2 / 8.3）と矛盾なし
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)