### PR TITLE
feat(backend): /api/v1/users/me の論理削除を実装

### DIFF
--- a/backend/src/application/use_cases/delete_account.py
+++ b/backend/src/application/use_cases/delete_account.py
@@ -1,20 +1,28 @@
-"""DELETE /users/me の UseCase。
+"""DELETE /users/me の UseCase（論理削除）。
 
-DB 上の users 行を削除すると、FK ondelete=CASCADE 設定により
-user_settings / sessions / outputs / judgments も連鎖削除される。
-Firebase Authentication 上のアカウント自体の削除は本 UseCase の責務外で、
-mobile 側で signOut させる方針。
+`users.deleted_at` をセットし、`fcm_token` をクリアする。user_settings / sessions /
+outputs / judgments は FK ondelete=CASCADE を張っているが、本 UseCase では DB 行
+を物理削除しないため連鎖削除は発生しない。30 日後のバッチジョブ（Issue #61）で
+物理削除される時点で FK CASCADE が効く。Firebase Authentication 上のアカウント
+自体の削除は本 UseCase の責務外で、mobile 側で signOut させる方針。
 """
+
+from datetime import UTC, datetime
 
 from src.domain.entities.user import User
 from src.domain.repositories.user_repository import UserRepository
 
 
 class DeleteAccount:
-    """認証済みユーザ自身のアカウントを削除する。"""
+    """認証済みユーザ自身のアカウントを論理削除する。"""
 
     def __init__(self, user_repository: UserRepository) -> None:
         self._user_repository = user_repository
 
     async def execute(self, current_user: User) -> None:
-        await self._user_repository.delete_by_id(current_user.id)
+        if current_user.deleted_at is not None:
+            # auth_middleware が生きているユーザのみ渡す前提だが、冪等性のため
+            # 既に削除済みなら no-op として扱う。
+            return
+        soft_deleted = current_user.with_deleted_at(deleted_at=datetime.now(UTC))
+        await self._user_repository.update(soft_deleted)

--- a/backend/src/domain/entities/user.py
+++ b/backend/src/domain/entities/user.py
@@ -46,3 +46,17 @@ class User(FrozenModel):
                 "updated_at": updated_at,
             }
         )
+
+    def with_deleted_at(self, *, deleted_at: datetime) -> "User":
+        """論理削除済みの新しい User を返す。
+
+        deleted_at をセットし、以降の push 通知が飛ばないよう fcm_token をクリアする。
+        updated_at も同時刻で更新し、他フィールドは保持する。
+        """
+        return self.model_copy(
+            update={
+                "deleted_at": deleted_at,
+                "fcm_token": None,
+                "updated_at": deleted_at,
+            }
+        )

--- a/backend/src/domain/repositories/user_repository.py
+++ b/backend/src/domain/repositories/user_repository.py
@@ -10,20 +10,37 @@ from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
 
 
+class UserAlreadyExistsError(Exception):
+    """firebase_uid が既存行と衝突した場合に送出される。
+
+    論理削除済みのユーザが残っている状態で、同じ firebase_uid で新規作成しようと
+    したときに発生する。保護 API では 401 として扱い、アカウントの再利用を防ぐ。
+    """
+
+
 class UserRepository(ABC):
     """User の永続化に対する抽象 IF。"""
 
     @abstractmethod
     async def find_by_firebase_uid(self, firebase_uid: str) -> User | None:
-        """Firebase UID から内部ユーザを取得する。未登録時は None。"""
+        """Firebase UID から「生きている」内部ユーザを取得する。
+
+        論理削除済み（deleted_at が設定済み）のユーザは None として扱う。未登録時
+        も None。auth_middleware が未登録判定にそのまま使う前提で、削除済みを返さ
+        ないことでアカウントの再利用を防ぐ。
+        """
 
     @abstractmethod
     async def add(self, user: User, settings: UserSettings) -> None:
-        """新規ユーザと初期設定を同一トランザクションで保存する。"""
+        """新規ユーザと初期設定を同一トランザクションで保存する。
+
+        同じ firebase_uid の行（論理削除済みを含む）が既に存在する場合は
+        `UserAlreadyExistsError` を送出する。
+        """
 
     @abstractmethod
     async def update(self, user: User) -> None:
-        """既存ユーザのプロフィールを更新する。"""
+        """既存ユーザのプロフィールを更新する。論理削除（deleted_at セット）もここで行う。"""
 
     @abstractmethod
     async def find_settings_by_user_id(self, user_id: UUID) -> UserSettings | None:
@@ -35,8 +52,10 @@ class UserRepository(ABC):
 
     @abstractmethod
     async def delete_by_id(self, user_id: UUID) -> None:
-        """ユーザを削除する。
+        """ユーザを物理削除する（30 日後バッチ用、Issue #61）。
 
-        FK ondelete=CASCADE により user_settings / sessions / outputs / judgments も
-        連鎖削除される前提。
+        通常のアカウント削除（DELETE /users/me）は `update` 経由での論理削除
+        （deleted_at セット）を使う。本メソッドは論理削除から 30 日経過したレコードを
+        GC する定期ジョブ専用で、FK ondelete=CASCADE により user_settings / sessions
+        / outputs / judgments も連鎖削除される。
         """

--- a/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_user_repository.py
@@ -7,10 +7,14 @@ AsyncSession を外部から渡して扱う。現実装では 1 リクエスト 
 from uuid import UUID
 
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
-from src.domain.repositories.user_repository import UserRepository
+from src.domain.repositories.user_repository import (
+    UserAlreadyExistsError,
+    UserRepository,
+)
 from src.domain.value_objects.age_group import AgeGroup
 from src.domain.value_objects.auth_provider import AuthProvider
 from src.infrastructure.persistence.database import Database
@@ -26,7 +30,10 @@ class PgUserRepository(UserRepository):
 
     async def find_by_firebase_uid(self, firebase_uid: str) -> User | None:
         async with self._database.session() as session:
-            stmt = select(UserModel).where(UserModel.firebase_uid == firebase_uid)
+            stmt = select(UserModel).where(
+                UserModel.firebase_uid == firebase_uid,
+                UserModel.deleted_at.is_(None),
+            )
             result = await session.execute(stmt)
             row = result.scalar_one_or_none()
             return _to_user(row) if row is not None else None
@@ -61,7 +68,15 @@ class PgUserRepository(UserRepository):
                     updated_at=settings.updated_at,
                 )
             )
-            await session.commit()
+            try:
+                await session.commit()
+            except IntegrityError as exc:
+                # firebase_uid UNIQUE 制約違反（論理削除済み行との衝突を含む）を
+                # domain 例外に変換して middleware 側で 401 化できるようにする。
+                await session.rollback()
+                raise UserAlreadyExistsError(
+                    f"firebase_uid={user.firebase_uid} already exists"
+                ) from exc
 
     async def update(self, user: User) -> None:
         age_group = user.age_group

--- a/backend/src/presentation/api/v1/users.py
+++ b/backend/src/presentation/api/v1/users.py
@@ -3,7 +3,7 @@
 要件書 3.2.6 のうち、
 - `GET/PATCH /api/v1/users/me/profile`: プロフィール取得・更新
 - `GET/PATCH /api/v1/users/me/settings`: タイマー / 通知設定の取得・更新
-- `DELETE /api/v1/users/me`: アカウント削除（FK ondelete=CASCADE で関連レコードも削除される）
+- `DELETE /api/v1/users/me`: アカウントの論理削除（`deleted_at` をセット、30 日後バッチで物理削除）
 を提供する。Firebase Auth 上のアカウント削除はクライアント側 (signOut) の責務。
 """
 
@@ -119,10 +119,13 @@ async def delete_my_account(
     request: Request,
     current_user: User = Depends(get_current_user),  # noqa: B008
 ) -> Response:
-    """認証ユーザー本人のアカウントを削除する。
+    """認証ユーザー本人のアカウントを論理削除する。
 
-    関連する user_settings / sessions / outputs / judgments は FK CASCADE により
-    DB 側で連鎖削除される。Firebase Auth 上のアカウント本体は対象外。
+    `users.deleted_at` をセットして FCM トークンをクリアする。関連する
+    user_settings / sessions / outputs / judgments は保持され、30 日後のバッチ
+    ジョブ（Issue #61）で物理削除される時点で FK ondelete=CASCADE により連鎖
+    削除される。Firebase Auth 上のアカウント本体は対象外で、mobile 側で signOut
+    させる。
     """
     container = get_presentation_container(request)
     await container.delete_account.execute(current_user)

--- a/backend/src/presentation/middleware/auth_middleware.py
+++ b/backend/src/presentation/middleware/auth_middleware.py
@@ -13,6 +13,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
+from src.domain.repositories.user_repository import UserAlreadyExistsError
 from src.domain.services.auth_verifier import (
     AuthVerifier,
     InvalidTokenError,
@@ -58,7 +59,18 @@ async def get_current_user(
     existing = await container.user_repository.find_by_firebase_uid(verified["uid"])
     if existing is not None:
         return existing
-    return await _auto_create_user(container, verified)
+    try:
+        return await _auto_create_user(container, verified)
+    except UserAlreadyExistsError as exc:
+        # 論理削除済みユーザが同じ firebase_uid で再アクセスしてきたケース。
+        # 30 日後バッチで物理削除されるまではアカウントの再利用を拒否する。
+        raise ProblemDetailsError(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            problem_type="authentication_required",
+            title="Authentication Required",
+            detail="このアカウントは削除されています。",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
 
 
 async def _auto_create_user(container: PresentationContainer, verified: VerifiedToken) -> User:

--- a/backend/tests/fakes/fake_user_repository.py
+++ b/backend/tests/fakes/fake_user_repository.py
@@ -4,7 +4,10 @@ from uuid import UUID
 
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
-from src.domain.repositories.user_repository import UserRepository
+from src.domain.repositories.user_repository import (
+    UserAlreadyExistsError,
+    UserRepository,
+)
 
 
 class FakeUserRepository(UserRepository):
@@ -17,9 +20,14 @@ class FakeUserRepository(UserRepository):
         self.settings: dict[UUID, UserSettings] = {}
 
     async def find_by_firebase_uid(self, firebase_uid: str) -> User | None:
-        return self.users.get(firebase_uid)
+        user = self.users.get(firebase_uid)
+        if user is None or user.deleted_at is not None:
+            return None
+        return user
 
     async def add(self, user: User, settings: UserSettings) -> None:
+        if user.firebase_uid in self.users:
+            raise UserAlreadyExistsError(f"firebase_uid={user.firebase_uid} already exists")
         self.users[user.firebase_uid] = user
         self.settings[settings.user_id] = settings
 

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -128,7 +128,7 @@ async def test_delete_account_requires_authorization_header(client: AsyncClient)
 
 
 @pytest.mark.asyncio
-async def test_delete_account_removes_user_and_returns_204(
+async def test_delete_account_soft_deletes_user_and_returns_204(
     client: AsyncClient, fake_user_repository: FakeUserRepository
 ):
     headers = {"Authorization": "Bearer settings-user-delete"}
@@ -140,4 +140,39 @@ async def test_delete_account_removes_user_and_returns_204(
     delete_response = await client.delete("/api/v1/users/me", headers=headers)
     assert delete_response.status_code == 204
     assert delete_response.text == ""
-    assert "settings-user-delete" not in fake_user_repository.users
+
+    # 論理削除: 行は残り、deleted_at がセットされ、fcm_token がクリアされる
+    soft_deleted = fake_user_repository.users["settings-user-delete"]
+    assert soft_deleted.deleted_at is not None
+    assert soft_deleted.fcm_token is None
+    # user_settings は保持される（30 日後バッチで物理削除される時点で CASCADE）
+    assert soft_deleted.id in fake_user_repository.settings
+
+
+@pytest.mark.asyncio
+async def test_protected_api_returns_401_after_account_deleted(
+    client: AsyncClient,
+):
+    """論理削除後に同じトークンで保護 API を叩くと 401 になる（再利用防止）。"""
+    headers = {"Authorization": "Bearer settings-user-afterdel"}
+    assert (await client.get("/api/v1/users/me/settings", headers=headers)).status_code == 200
+    assert (await client.delete("/api/v1/users/me", headers=headers)).status_code == 204
+
+    retry = await client.get("/api/v1/users/me/settings", headers=headers)
+    assert retry.status_code == 401
+    body = retry.json()
+    assert body["type"] == "authentication_required"
+
+
+@pytest.mark.asyncio
+async def test_delete_account_second_call_returns_401_for_already_deleted_user(
+    client: AsyncClient,
+):
+    """2 度目の DELETE は auth_middleware 段階で 401 になる。"""
+    headers = {"Authorization": "Bearer settings-user-twicedel"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+    first = await client.delete("/api/v1/users/me", headers=headers)
+    assert first.status_code == 204
+
+    second = await client.delete("/api/v1/users/me", headers=headers)
+    assert second.status_code == 401

--- a/backend/tests/unit/test_entities/test_user.py
+++ b/backend/tests/unit/test_entities/test_user.py
@@ -66,3 +66,32 @@ def test_with_profile_does_not_mark_onboarding_without_age_group():
 
     assert updated.age_group is None
     assert updated.onboarding_completed is False
+
+
+def test_with_deleted_at_sets_timestamp_and_clears_fcm_token():
+    user = _make_user().model_copy(update={"fcm_token": "fcm-xyz"})
+    ts = datetime.now(UTC)
+
+    deleted = user.with_deleted_at(deleted_at=ts)
+
+    assert deleted.deleted_at == ts
+    assert deleted.fcm_token is None
+    # updated_at も削除時刻で上書きされる（論理削除も更新の一種として扱う）
+    assert deleted.updated_at == ts
+
+
+def test_with_deleted_at_preserves_other_fields():
+    user = _make_user(age_group=AgeGroup.TWENTIES, onboarding_completed=True).model_copy(
+        update={"display_name": "太郎"}
+    )
+    ts = datetime.now(UTC)
+
+    deleted = user.with_deleted_at(deleted_at=ts)
+
+    assert deleted.id == user.id
+    assert deleted.firebase_uid == user.firebase_uid
+    assert deleted.auth_provider is user.auth_provider
+    assert deleted.display_name == "太郎"
+    assert deleted.age_group is AgeGroup.TWENTIES
+    assert deleted.onboarding_completed is True
+    assert deleted.created_at == user.created_at

--- a/backend/tests/unit/test_use_cases/test_delete_account.py
+++ b/backend/tests/unit/test_use_cases/test_delete_account.py
@@ -1,4 +1,4 @@
-"""DeleteAccount UseCase の振る舞い。"""
+"""DeleteAccount UseCase の振る舞い（論理削除）。"""
 
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -20,7 +20,7 @@ def _make_user_with_settings() -> tuple[User, UserSettings]:
         auth_provider=AuthProvider.GOOGLE,
         created_at=now,
         updated_at=now,
-    )
+    ).model_copy(update={"fcm_token": "fcm-xyz"})
     settings = UserSettings(
         id=uuid4(),
         user_id=user.id,
@@ -31,30 +31,37 @@ def _make_user_with_settings() -> tuple[User, UserSettings]:
 
 
 @pytest.mark.asyncio
-async def test_delete_account_removes_user_and_settings():
+async def test_delete_account_soft_deletes_user_and_preserves_settings():
     repo = FakeUserRepository()
     user, settings = _make_user_with_settings()
     await repo.add(user, settings)
-    assert user.firebase_uid in repo.users
-    assert user.id in repo.settings
 
     use_case = DeleteAccount(user_repository=repo)
     await use_case.execute(user)
 
-    assert user.firebase_uid not in repo.users
-    assert user.id not in repo.settings
+    # 行は残り、deleted_at がセットされ、fcm_token がクリアされる
+    stored = repo.users[user.firebase_uid]
+    assert stored.deleted_at is not None
+    assert stored.fcm_token is None
+    # user_settings は保持される（30 日後バッチで物理削除されるまで残す）
+    assert user.id in repo.settings
+    # find_by_firebase_uid 経由では生きているユーザとして見えない
+    assert await repo.find_by_firebase_uid(user.firebase_uid) is None
 
 
 @pytest.mark.asyncio
 async def test_delete_account_is_idempotent():
-    """既に削除済みのユーザーに対して例外を投げないことを担保する。"""
+    """既に削除済みのユーザーに対して例外を投げず、deleted_at も上書きしない。"""
     repo = FakeUserRepository()
     user, settings = _make_user_with_settings()
     await repo.add(user, settings)
 
     use_case = DeleteAccount(user_repository=repo)
     await use_case.execute(user)
-    # 2 度目の呼び出しでも例外にならない
-    await use_case.execute(user)
+    first_deleted_at = repo.users[user.firebase_uid].deleted_at
+    assert first_deleted_at is not None
 
-    assert user.firebase_uid not in repo.users
+    # 既に削除済みの User を渡しても例外にならず、deleted_at も上書きされない
+    already_deleted = repo.users[user.firebase_uid]
+    await use_case.execute(already_deleted)
+    assert repo.users[user.firebase_uid].deleted_at == first_deleted_at


### PR DESCRIPTION
## Summary
- `DELETE /api/v1/users/me` を物理削除から論理削除（`deleted_at` 設定 + `fcm_token` クリア）に差し替え
- 削除済み `firebase_uid` で再アクセスしたリクエストを `auth_middleware` で 401 に変換し、アカウントの再利用を防止
- `User.with_deleted_at` と `UserAlreadyExistsError` を追加し、既存の `UserRepository.update` 経由で整合的に保存
- `delete_by_id` は Issue #61（30 日後物理削除バッチ）用として残し docstring を更新
- mobile 側は既に完成済みのため変更なし

Closes #60

## Test plan
- [x] `task backend:test`（pytest 83 件）
- [x] `task backend:lint` / `backend:format:check`
- [x] `task backend:lint:imports`（レイヤ依存方向）
- [x] `task backend:typecheck`
- [ ] マージ後ステージングで `DELETE /api/v1/users/me` → 同じトークンで保護 API が 401 になることを確認
- [ ] mobile から設定画面 → アカウント削除 → サインイン画面へ戻る一連の E2E を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)