### PR TITLE
feat(mobile): サインイン画面の UI を作成

### DIFF
--- a/mobile/src/features/auth/screens/SignInScreen.tsx
+++ b/mobile/src/features/auth/screens/SignInScreen.tsx
@@ -1,24 +1,251 @@
 /**
- * サインイン待機画面。
+ * サインイン画面。
  *
- * Apple / Google サインイン本実装は #32 で対応する。
+ * Apple / Google サインインの本実装は #32 で対応予定。現状は UI のみで、
+ * プロバイダ連携ハンドラはプレースホルダとしておく。
  */
-import { H1, Paragraph, YStack } from 'tamagui';
+import { useRouter, type Href } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { useCallback } from 'react';
+import { Image, ImageBackground, Pressable, SafeAreaView, StyleSheet, View } from 'react-native';
+import { Path, Svg } from 'react-native-svg';
+import { SizableText } from 'tamagui';
 
-export function SignInScreen() {
+const SIGN_IN_BACKGROUND = require('../../../../assets/images/overview-screen-background.png');
+const TYPOGRAPHY_WHITE = require('../../../../assets/images/typography_white.png');
+
+const TABS_ROUTE = '/(tabs)' as unknown as Href;
+
+function AppleLogo({ size = 18 }: { size?: number }) {
   return (
-    <YStack
-      flex={1}
-      alignItems="center"
-      justifyContent="center"
-      padding="$4"
-      gap="$4"
-      testID="sign-in-root"
-    >
-      <H1>サインイン</H1>
-      <Paragraph theme="alt2" textAlign="center" testID="sign-in-description">
-        Apple / Google サインインは近日対応予定です。
-      </Paragraph>
-    </YStack>
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="#FFFFFF">
+      <Path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.08zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+    </Svg>
   );
 }
+
+function GoogleLogo({ size = 18 }: { size?: number }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24">
+      <Path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        fill="#4285F4"
+      />
+      <Path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <Path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+        fill="#FBBC05"
+      />
+      <Path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </Svg>
+  );
+}
+
+export function SignInScreen() {
+  const router = useRouter();
+
+  const handleAppleSignIn = useCallback(() => {
+    // #32 で Firebase の Apple サインインに差し替える
+  }, []);
+
+  const handleGoogleSignIn = useCallback(() => {
+    // #32 で Firebase の Google サインインに差し替える
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    router.replace(TABS_ROUTE);
+  }, [router]);
+
+  return (
+    <ImageBackground
+      source={SIGN_IN_BACKGROUND}
+      style={styles.background}
+      imageStyle={styles.backgroundImage}
+      testID="sign-in-root"
+    >
+      <StatusBar style="light" />
+      <View pointerEvents="none" style={styles.softOverlay} />
+
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.content}>
+          <View style={styles.hero}>
+            <Image
+              source={TYPOGRAPHY_WHITE}
+              style={styles.logo}
+              resizeMode="contain"
+              testID="sign-in-logo"
+            />
+            <SizableText style={styles.title} testID="sign-in-title">
+              {'アカウントを作って\n学習の成果を振り返りましょう'}
+            </SizableText>
+          </View>
+
+          <View style={styles.actionArea}>
+            <SizableText style={styles.caption} testID="sign-in-caption">
+              会員登録後レポート機能を使用できます
+            </SizableText>
+
+            <Pressable
+              accessibilityRole="button"
+              style={({ pressed }) => [styles.appleButton, pressed ? styles.buttonPressed : null]}
+              onPress={handleAppleSignIn}
+              testID="sign-in-apple"
+            >
+              <AppleLogo />
+              <SizableText style={styles.appleButtonText}>Appleで続ける</SizableText>
+            </Pressable>
+
+            <Pressable
+              accessibilityRole="button"
+              style={({ pressed }) => [styles.googleButton, pressed ? styles.buttonPressed : null]}
+              onPress={handleGoogleSignIn}
+              testID="sign-in-google"
+            >
+              <View style={styles.googleIconCircle}>
+                <GoogleLogo />
+              </View>
+              <SizableText style={styles.googleButtonText}>Googleで続ける</SizableText>
+            </Pressable>
+
+            <SizableText style={styles.termsText} testID="sign-in-terms">
+              利用規約・プライバシーポリシー
+            </SizableText>
+          </View>
+
+          <Pressable
+            accessibilityRole="button"
+            style={({ pressed }) => [styles.skipButton, pressed ? styles.skipButtonPressed : null]}
+            onPress={handleSkip}
+            testID="sign-in-skip"
+          >
+            <SizableText style={styles.skipButtonText}>あとで</SizableText>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    </ImageBackground>
+  );
+}
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+  },
+  backgroundImage: {
+    resizeMode: 'cover',
+  },
+  safeArea: {
+    flex: 1,
+  },
+  softOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(20, 28, 48, 0.28)',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 32,
+    paddingTop: 24,
+    paddingBottom: 24,
+  },
+  hero: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logo: {
+    width: 224,
+    height: 53,
+    marginBottom: 32,
+  },
+  title: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 28,
+    letterSpacing: 0.24,
+    textAlign: 'center',
+    textShadowColor: 'rgba(20, 28, 48, 0.3)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 12,
+  },
+  actionArea: {
+    gap: 12,
+  },
+  caption: {
+    color: 'rgba(255, 255, 255, 0.82)',
+    fontSize: 12,
+    fontWeight: '500',
+    lineHeight: 18,
+    textAlign: 'center',
+    marginBottom: 6,
+  },
+  appleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    height: 52,
+    borderRadius: 999,
+    backgroundColor: '#000000',
+  },
+  appleButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
+  googleButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    height: 52,
+    borderRadius: 999,
+    backgroundColor: '#4B5CFF',
+  },
+  googleIconCircle: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  googleButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
+  buttonPressed: {
+    opacity: 0.9,
+  },
+  termsText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontSize: 12,
+    fontWeight: '500',
+    lineHeight: 18,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  skipButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    marginTop: 16,
+  },
+  skipButtonPressed: {
+    opacity: 0.7,
+  },
+  skipButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/features/auth/screens/__tests__/SignInScreen.test.tsx
+++ b/mobile/src/features/auth/screens/__tests__/SignInScreen.test.tsx
@@ -1,12 +1,18 @@
 /**
- * SignInScreen の初期表示を検証する。
+ * SignInScreen の初期表示とスキップ導線を検証する。
  */
-import { render } from '@testing-library/react-native';
+import { cleanup, fireEvent, render } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
 import config from '../../../../../tamagui.config';
 import { SignInScreen } from '@/features/auth/screens/SignInScreen';
+
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
 
 function renderWithProviders(ui: ReactNode) {
   return render(
@@ -17,12 +23,37 @@ function renderWithProviders(ui: ReactNode) {
 }
 
 describe('SignInScreen', () => {
-  it('サインイン待機画面を表示する', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('サインイン導線のヒーローとボタンを表示する', () => {
     const screen = renderWithProviders(<SignInScreen />);
 
     expect(screen.getByTestId('sign-in-root')).toBeTruthy();
-    expect(screen.getByTestId('sign-in-description')).toBeTruthy();
-    expect(screen.getByText('サインイン')).toBeTruthy();
-    expect(screen.getByText('Apple / Google サインインは近日対応予定です。')).toBeTruthy();
+    expect(screen.getByTestId('sign-in-logo')).toBeTruthy();
+    expect(screen.getByTestId('sign-in-title')).toBeTruthy();
+    expect(screen.getByText(/アカウントを作って/)).toBeTruthy();
+    expect(screen.getByText(/学習の成果を振り返りましょう/)).toBeTruthy();
+    expect(screen.getByText('会員登録後レポート機能を使用できます')).toBeTruthy();
+    expect(screen.getByTestId('sign-in-apple')).toBeTruthy();
+    expect(screen.getByText('Appleで続ける')).toBeTruthy();
+    expect(screen.getByTestId('sign-in-google')).toBeTruthy();
+    expect(screen.getByText('Googleで続ける')).toBeTruthy();
+    expect(screen.getByText('利用規約・プライバシーポリシー')).toBeTruthy();
+    expect(screen.getByTestId('sign-in-skip')).toBeTruthy();
+    expect(screen.getByText('あとで')).toBeTruthy();
+  });
+
+  it('あとでを押すとタブ画面へ置き換え遷移する', () => {
+    const screen = renderWithProviders(<SignInScreen />);
+
+    fireEvent.press(screen.getByTestId('sign-in-skip'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
   });
 });


### PR DESCRIPTION
#32 で Apple / Google サインインを実装する前段として、
デザインに合わせたヒーロー・各プロバイダボタン・
「あとで」導線を備えたサインイン画面を用意する。
プロバイダ連携ハンドラは #32 で差し替える想定のプレースホルダとする。

<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->

## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #
- Refs #

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

-

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

-

## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

### スクリーンショット / 動画

<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [ ] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [ ] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [ ] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [ ] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
