### PR TITLE
feat(mobile): 休憩画面デザイン対応 & タイマー挙動のバグ修正

### DIFF
--- a/backend/src/presentation/schemas/user_settings_schema.py
+++ b/backend/src/presentation/schemas/user_settings_schema.py
@@ -6,10 +6,11 @@ from pydantic import Field
 
 from src.common.models import FrozenModel, StrictRequestModel
 
-# タイマー値の許容範囲。要件書 3.2.6 / 4.3.2 に明記された絶対値はないため、
-# 1 分以上 180 分以下を「実用範囲」として採用する。境界値テストもこの値で行う。
+# タイマー値の許容範囲。セッション作成 (CreateSessionRequest) が 1〜120 分を要求するため、
+# 設定値が 120 分を超えるとセッション作成が 422 で失敗してしまう。ここを session 側に
+# 揃えて 1〜120 分にすることで、設定で保存した値がそのままセッション開始に使える。
 _MINUTES_MIN = 1
-_MINUTES_MAX = 180
+_MINUTES_MAX = 120
 
 
 class UserSettingsResponse(FrozenModel):
@@ -25,7 +26,7 @@ class UserSettingsResponse(FrozenModel):
 class UpdateUserSettingsRequest(StrictRequestModel):
     """PATCH /users/me/settings の body。
 
-    すべてのフィールドが省略可能。minutes 系は 1 ～ 180 の範囲を要求し、未知フィールドは
+    すべてのフィールドが省略可能。minutes 系は 1 ～ 120 の範囲を要求し、未知フィールドは
     StrictRequestModel により拒否する。「全フィールド未指定（空 body）」のチェックは、
     Pydantic の model_validator で投げると ValidationError の ctx に ValueError が入って
     Problem Details のシリアライズが失敗するため、ルーター層で明示的にハンドリングする。

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -62,7 +62,7 @@ async def test_patch_settings_persists_partial_update(client: AsyncClient):
     ("payload", "field"),
     [
         ({"input_minutes": 0}, "input_minutes"),
-        ({"input_minutes": 181}, "input_minutes"),
+        ({"input_minutes": 121}, "input_minutes"),
         ({"output_minutes": -1}, "output_minutes"),
         ({"break_minutes": 999}, "break_minutes"),
     ],

--- a/mobile/src/features/session/screens/BreakScreen.tsx
+++ b/mobile/src/features/session/screens/BreakScreen.tsx
@@ -1,18 +1,194 @@
 /**
- * 休憩フェーズ画面。
+ * 休憩フェーズ画面 (S-07 / S-08-2)。
  *
- * 状態機械上は `judging` に相当（判定待ちの期間を UI 上は「休憩」として扱う）。
- * タイマー完了後に結果画面へ遷移し、実際の判定取得は ResultScreen で行う。
+ * 状態機械上は `judging` に相当 (判定待ちの期間を UI 上は「休憩」として扱う)。
+ * 画面は Input / Output と同じ骨格 (設定アイコン + 砂時計バッジ + フェーズタブ +
+ * 円形タイマー + 下部カード) で構成し、下部カードに AI 採点の進捗を表示する。
+ *
+ * 進捗表示は backend から割合を取得できないため、休憩タイマーの経過に合わせて
+ * 12% → 90% まで連動させ、判定が ready になった瞬間に 100% に切り替える。
+ * タイマー完了時は従来どおり結果画面へ `router.replace` する。
  */
 import { useIsFocused } from '@react-navigation/native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
 import { useEffect, useRef } from 'react';
-import { Paragraph, YStack } from 'tamagui';
+import { Pressable, SafeAreaView, StyleSheet, View } from 'react-native';
+import { Circle, Path, Svg } from 'react-native-svg';
+import { SizableText } from 'tamagui';
 
-import { SessionHeader } from '@/features/session/components/SessionHeader';
-import { Timer } from '@/features/session/components/Timer';
 import { DEFAULT_TIMER } from '@/features/session/config';
-import { useTimer } from '@/features/session/hooks/useTimer';
+import { formatMmSs, useSmoothRemainingSeconds, useTimer } from '@/features/session/hooks/useTimer';
+import { useJudgment } from '@/features/session/hooks/useJudgment';
+import { LOOP_COUNT_MAX, useLoopStore } from '@/shared/stores/loopStore';
+import { useTimerStore } from '@/shared/stores/timerStore';
+
+const SETTINGS_ROUTE = '/(tabs)/settings' as unknown as Href;
+
+const PHASES = ['input', 'output', 'break'] as const;
+type Phase = (typeof PHASES)[number];
+
+const PHASE_LABELS: Record<Phase, string> = {
+  input: 'インプット',
+  output: 'アウトプット',
+  break: '休憩',
+};
+
+const CURRENT_PHASE: Phase = 'break';
+
+// 休憩フェーズはグレー基調。タイマーリングと大きい数字に同じグレーを使う。
+const PRIMARY_COLOR = '#9CA3AF';
+const TEXT_ACTIVE = '#2F2F2F';
+const TEXT_INACTIVE = '#9CA3AF';
+const DOT_INACTIVE = '#D9D9D9';
+const BORDER_COLOR = '#E5E7EB';
+const CAPTION_COLOR = '#777777';
+
+// 下部の「採点進捗カード」用トークン。濃い背景に青いプログレスバーを乗せる。
+const PROGRESS_CARD_BG = '#2A2A2E';
+const PROGRESS_CARD_TEXT = '#FFFFFF';
+const PROGRESS_CARD_SUBTEXT = '#B5B7BC';
+const PROGRESS_TRACK_COLOR = '#4A4A50';
+const PROGRESS_FILL_COLOR = '#4B5CFF';
+
+// 採点進捗の下限 / 上限。ready になるまでは 90% で頭打ちにする。
+const PROGRESS_PENDING_MIN = 12;
+const PROGRESS_PENDING_MAX = 90;
+
+const HOURGLASS_BADGE_COUNT = LOOP_COUNT_MAX;
+const HOURGLASS_BADGE_BASE_WIDTH = 18;
+const HOURGLASS_BADGE_BASE_HEIGHT = 24;
+const HOURGLASS_BADGE_ACTIVE_SCALE = 1.45;
+const HOURGLASS_ICON_PATH =
+  'M2 2 H14 V4 C14 6.5 11 7.5 11 10 C11 12.5 14 13.5 14 16 V18 H2 V16 C2 13.5 5 12.5 5 10 C5 7.5 2 6.5 2 4 Z';
+
+type HourglassBadgeIconProps = {
+  active: boolean;
+  testID?: string;
+};
+
+function HourglassBadgeIcon({ active, testID }: HourglassBadgeIconProps) {
+  const width = active
+    ? HOURGLASS_BADGE_BASE_WIDTH * HOURGLASS_BADGE_ACTIVE_SCALE
+    : HOURGLASS_BADGE_BASE_WIDTH;
+  const height = active
+    ? HOURGLASS_BADGE_BASE_HEIGHT * HOURGLASS_BADGE_ACTIVE_SCALE
+    : HOURGLASS_BADGE_BASE_HEIGHT;
+  const color = active ? PRIMARY_COLOR : TEXT_INACTIVE;
+  return (
+    <Svg width={width} height={height} viewBox="0 0 16 20" testID={testID}>
+      <Path
+        d={HOURGLASS_ICON_PATH}
+        stroke={color}
+        strokeWidth={active ? 1.5 : 1.3}
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </Svg>
+  );
+}
+
+const SETTINGS_ICON_HEX_PATH = 'M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z';
+
+function SettingsIcon({ size = 26, color = TEXT_ACTIVE }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d={SETTINGS_ICON_HEX_PATH}
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <Circle cx={12} cy={12} r={2.4} stroke={color} strokeWidth={1.8} fill="none" />
+    </Svg>
+  );
+}
+
+type CircularTimerProps = {
+  phaseLabel: string;
+};
+
+function CircularTimer({ phaseLabel }: CircularTimerProps) {
+  const smoothRemainingSeconds = useSmoothRemainingSeconds();
+  const totalSeconds = useTimerStore((s) => s.totalSeconds);
+
+  const size = 260;
+  const strokeWidth = 14;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const displayRemainingSeconds = Math.max(0, Math.ceil(smoothRemainingSeconds));
+  // 残り割合。開始時はリング全周が塗られ、残り時間が減るにつれてストロークも短くなる。
+  // dashOffset を負にすることで、ギャップが 12 時位置から時計回りに広がる。
+  const remainingRatio =
+    totalSeconds > 0 ? Math.min(1, Math.max(0, smoothRemainingSeconds / totalSeconds)) : 0;
+  const dashOffset = -circumference * (1 - remainingRatio);
+
+  return (
+    <View style={[styles.timerWrap, { width: size, height: size }]} testID="break-circular-timer">
+      <Svg width={size} height={size}>
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={BORDER_COLOR}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={PRIMARY_COLOR}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          fill="none"
+          strokeDasharray={`${circumference} ${circumference}`}
+          strokeDashoffset={dashOffset}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      </Svg>
+      <View style={styles.timerCenter} pointerEvents="none">
+        <SizableText style={styles.timerPhaseLabel}>{phaseLabel}</SizableText>
+        <SizableText style={styles.timerText} testID="timer-display">
+          {formatMmSs(displayRemainingSeconds)}
+        </SizableText>
+      </View>
+    </View>
+  );
+}
+
+type JudgingProgressCardProps = {
+  progressPercent: number;
+  isReady: boolean;
+};
+
+function JudgingProgressCard({ progressPercent, isReady }: JudgingProgressCardProps) {
+  const clamped = Math.min(100, Math.max(0, Math.round(progressPercent)));
+  return (
+    <View style={styles.progressCard} testID="break-progress-card">
+      <View style={styles.progressHeaderRow}>
+        <SizableText style={styles.progressHeaderLabel}>
+          {isReady ? ' ' : 'テキストの解析...'}
+        </SizableText>
+        <SizableText style={styles.progressHeaderPercent} testID="break-progress-percent">
+          {clamped}%
+        </SizableText>
+      </View>
+      <View style={styles.progressTrack}>
+        <View style={[styles.progressFill, { width: `${clamped}%` }]} />
+      </View>
+      {isReady ? (
+        <View style={styles.progressReadyBlock} testID="break-progress-ready">
+          <SizableText style={styles.progressReadyTitle}>✓ 採点完了</SizableText>
+          <SizableText style={styles.progressReadySub}>
+            次のサイクルのインプットで{'\n'}結果を確認できます。
+          </SizableText>
+        </View>
+      ) : null}
+    </View>
+  );
+}
 
 type SessionRouteParams = {
   id?: string;
@@ -26,6 +202,19 @@ export function BreakScreen() {
 
   const router = useRouter();
   const isFocused = useIsFocused();
+  const currentLoop = useLoopStore((s) => s.currentLoop);
+
+  const judgmentQuery = useJudgment(sessionId);
+  const isJudgmentReady = judgmentQuery.data?.kind === 'ready';
+
+  const smoothRemainingSeconds = useSmoothRemainingSeconds();
+  const totalSeconds = useTimerStore((s) => s.totalSeconds);
+  const elapsedRatio =
+    totalSeconds > 0 ? Math.min(1, Math.max(0, 1 - smoothRemainingSeconds / totalSeconds)) : 0;
+  const pendingProgress = Math.round(
+    PROGRESS_PENDING_MIN + elapsedRatio * (PROGRESS_PENDING_MAX - PROGRESS_PENDING_MIN),
+  );
+  const progressPercent = isJudgmentReady ? 100 : pendingProgress;
 
   const { start, reset } = useTimer({
     enabled: isFocused,
@@ -48,13 +237,252 @@ export function BreakScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const captionText = isJudgmentReady
+    ? '休憩後次のサイクルを回すか決めることができます。'
+    : 'AI採点中です。ゆっくり休憩してください。';
+
   return (
-    <YStack flex={1}>
-      <SessionHeader sessionId={sessionId} title="休憩" onBeforeCancel={reset} />
-      <YStack flex={1} alignItems="center" justifyContent="center" gap="$4" padding="$4">
-        <Paragraph>休憩中です。終了後に判定結果を確認します。</Paragraph>
-        <Timer />
-      </YStack>
-    </YStack>
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <View style={styles.container} testID="break-root">
+        <View style={styles.settingsRow}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="設定"
+            onPress={() => router.push(SETTINGS_ROUTE)}
+            style={({ pressed }) => [
+              styles.settingsButton,
+              pressed ? styles.settingsButtonPressed : null,
+            ]}
+            hitSlop={8}
+            testID="break-settings-button"
+          >
+            <SettingsIcon />
+          </Pressable>
+        </View>
+
+        <View style={styles.badgeRow}>
+          <View style={styles.badge} testID="break-hourglass-badge">
+            {Array.from({ length: HOURGLASS_BADGE_COUNT }).map((_, index) => {
+              const isActive = index + 1 === currentLoop;
+              return (
+                <HourglassBadgeIcon
+                  key={index}
+                  active={isActive}
+                  testID={`break-hourglass-badge-icon-${index + 1}`}
+                />
+              );
+            })}
+          </View>
+        </View>
+
+        <View style={styles.phaseTabs} testID="break-phase-tabs">
+          {PHASES.map((p, index) => {
+            const isActive = p === CURRENT_PHASE;
+            const isLast = index === PHASES.length - 1;
+            return (
+              <View key={p} style={styles.phaseTabItemRow}>
+                <View style={styles.phaseTab} testID={`break-phase-tab-${p}`}>
+                  <View style={[styles.phaseTabDot, isActive ? styles.phaseTabDotActive : null]} />
+                  <SizableText
+                    size="$3"
+                    style={[styles.phaseTabLabel, isActive ? styles.phaseTabLabelActive : null]}
+                  >
+                    {PHASE_LABELS[p]}
+                  </SizableText>
+                </View>
+                {isLast ? null : <View style={styles.phaseTabSeparator} />}
+              </View>
+            );
+          })}
+        </View>
+
+        <View style={styles.timerStage}>
+          <CircularTimer phaseLabel={PHASE_LABELS[CURRENT_PHASE]} />
+          <SizableText style={styles.timerCaption} testID="break-timer-caption">
+            {captionText}
+          </SizableText>
+        </View>
+
+        <JudgingProgressCard progressPercent={progressPercent} isReady={isJudgmentReady} />
+      </View>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  container: {
+    flex: 1,
+    paddingTop: 12,
+    paddingRight: 24,
+    paddingBottom: 32,
+    paddingLeft: 24,
+  },
+  settingsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 4,
+    marginBottom: 12,
+  },
+  settingsButton: {
+    width: 26,
+    height: 26,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  settingsButtonPressed: {
+    opacity: 0.6,
+  },
+  badgeRow: {
+    alignItems: 'center',
+    marginTop: 4,
+    marginBottom: 20,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 999,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: BORDER_COLOR,
+    shadowColor: '#000000',
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  phaseTabs: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 24,
+  },
+  phaseTabItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  phaseTab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+  },
+  phaseTabDot: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 1.5,
+    borderColor: DOT_INACTIVE,
+    backgroundColor: 'transparent',
+  },
+  phaseTabDotActive: {
+    borderColor: PRIMARY_COLOR,
+    backgroundColor: PRIMARY_COLOR,
+  },
+  phaseTabLabel: {
+    color: DOT_INACTIVE,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  phaseTabLabelActive: {
+    color: TEXT_ACTIVE,
+    fontWeight: '700',
+  },
+  phaseTabSeparator: {
+    width: 16,
+    height: 1.5,
+    marginHorizontal: 6,
+    backgroundColor: DOT_INACTIVE,
+  },
+  timerStage: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 20,
+  },
+  timerWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timerCenter: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  timerPhaseLabel: {
+    color: PRIMARY_COLOR,
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 22,
+  },
+  timerText: {
+    color: PRIMARY_COLOR,
+    fontSize: 56,
+    fontWeight: '700',
+    lineHeight: 64,
+  },
+  timerCaption: {
+    color: CAPTION_COLOR,
+    fontSize: 13,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+  progressCard: {
+    gap: 12,
+    padding: 16,
+    borderRadius: 18,
+    backgroundColor: PROGRESS_CARD_BG,
+  },
+  progressHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  progressHeaderLabel: {
+    color: PROGRESS_CARD_TEXT,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  progressHeaderPercent: {
+    color: PROGRESS_CARD_TEXT,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  progressTrack: {
+    width: '100%',
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: PROGRESS_TRACK_COLOR,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 4,
+    backgroundColor: PROGRESS_FILL_COLOR,
+  },
+  progressReadyBlock: {
+    alignItems: 'center',
+    gap: 6,
+    paddingTop: 4,
+  },
+  progressReadyTitle: {
+    color: PROGRESS_CARD_TEXT,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  progressReadySub: {
+    color: PROGRESS_CARD_SUBTEXT,
+    fontSize: 12,
+    lineHeight: 18,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/features/session/screens/InputScreen.tsx
+++ b/mobile/src/features/session/screens/InputScreen.tsx
@@ -110,10 +110,12 @@ function CircularTimer({ phaseLabel }: CircularTimerProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const displayRemainingSeconds = Math.max(0, Math.ceil(smoothRemainingSeconds));
-  // 経過割合。経過分だけ progress ストロークが伸びる (12 時方向から時計回り)。
-  const progressRatio =
-    totalSeconds > 0 ? Math.min(1, Math.max(0, 1 - smoothRemainingSeconds / totalSeconds)) : 0;
-  const dashOffset = circumference * (1 - progressRatio);
+  // 残り割合。開始時はリング全周が塗られ、残り時間が減るにつれてストロークも短くなる
+  // (砂時計の砂が落ちていくイメージ)。dashOffset を負にすることで、ギャップが 12 時
+  // 位置から時計回り (12→3→6→9) に広がっていく見た目にする。
+  const remainingRatio =
+    totalSeconds > 0 ? Math.min(1, Math.max(0, smoothRemainingSeconds / totalSeconds)) : 0;
+  const dashOffset = -circumference * (1 - remainingRatio);
 
   return (
     <View style={[styles.timerWrap, { width: size, height: size }]} testID="input-circular-timer">

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -120,9 +120,11 @@ function CircularTimer({ phaseLabel, compact = false }: CircularTimerProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const displayRemainingSeconds = Math.max(0, Math.ceil(smoothRemainingSeconds));
-  const progressRatio =
-    totalSeconds > 0 ? Math.min(1, Math.max(0, 1 - smoothRemainingSeconds / totalSeconds)) : 0;
-  const dashOffset = circumference * (1 - progressRatio);
+  // 残り割合。開始時はリング全周が塗られ、残り時間が減るにつれてストロークも短くなる。
+  // dashOffset を負にすることで、ギャップが 12 時位置から時計回りに広がる。
+  const remainingRatio =
+    totalSeconds > 0 ? Math.min(1, Math.max(0, smoothRemainingSeconds / totalSeconds)) : 0;
+  const dashOffset = -circumference * (1 - remainingRatio);
 
   return (
     <View style={[styles.timerWrap, { width: size, height: size }]} testID="output-circular-timer">

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -61,9 +61,12 @@ describe('BreakScreen', () => {
     jest.useRealTimers();
   });
 
-  it('マウントで phase=break のタイマーが開始され、タイトルが表示される', () => {
-    const { getByText } = renderWithProviders(<BreakScreen />);
-    expect(getByText('休憩')).toBeTruthy();
+  it('マウントで phase=break のタイマーが開始され、主要 UI が表示される', () => {
+    const { getAllByText, getByTestId } = renderWithProviders(<BreakScreen />);
+    // 画面タイトル / フェーズタブ / タイマー中央ラベルで複数回「休憩」が出現する
+    expect(getAllByText('休憩').length).toBeGreaterThan(0);
+    expect(getByTestId('break-settings-button')).toBeTruthy();
+    expect(getByTestId('break-progress-card')).toBeTruthy();
     expect(useTimerStore.getState().phase).toBe('break');
     expect(useTimerStore.getState().totalSeconds).toBe(60);
   });

--- a/mobile/src/features/settings/screens/SettingsScreen.tsx
+++ b/mobile/src/features/settings/screens/SettingsScreen.tsx
@@ -20,8 +20,10 @@ import { isApiError } from '@/shared/lib/api';
 import { useAuthStore } from '@/shared/stores/authStore';
 import type { UpdateUserSettingsInput } from '@/shared/types/userSettings';
 
-// タイマーのプリセット値。backend の許容範囲 (1〜180 分) に収めた代表値を並べる。
-const MINUTE_OPTIONS = [1, 5, 10, 15, 20, 25, 30, 45, 60, 90, 120, 180] as const;
+// タイマーのプリセット値。backend の許容範囲 (1〜120 分、セッション作成 / 設定保存で共通)
+// に収めた代表値を並べる。120 分を超える値を選ばせると、設定保存はできてもセッション開始で
+// 422 になりタイマーが動かなくなるため、必ずこの範囲内に閉じる。
+const MINUTE_OPTIONS = [1, 5, 10, 15, 20, 25, 30, 45, 60, 90, 120] as const;
 
 const NOTIFICATION_OPTIONS = [
   { value: true, label: 'あり' },

--- a/mobile/src/shared/types/userSettings.ts
+++ b/mobile/src/shared/types/userSettings.ts
@@ -25,4 +25,4 @@ export type UpdateUserSettingsInput = {
 
 /** タイマー値の許容範囲（backend のバリデーションと一致）。 */
 export const TIMER_MINUTES_MIN = 1;
-export const TIMER_MINUTES_MAX = 180;
+export const TIMER_MINUTES_MAX = 120;


### PR DESCRIPTION
## Summary

- 休憩画面を S-07 / S-08-2 デザイン (グレー基調の円形タイマー + AI 採点進捗カード) に作り直す
- ユーザ設定とセッション作成でタイマー時間の許容範囲がずれていた不具合を修正 (1〜180 → 1〜120 分に統一) — 180 分保存時に「スタートを押してもタイマーが動かない」事象を解消
- 3 画面のタイマーリングを時計回りに減るアニメーションに修正 (砂時計イメージ)

## 変更点

### `feat(mobile): 休憩画面を S-07 / S-08-2 デザインに作り直す`
- `BreakScreen.tsx` を Input / Output と同じ土台 (設定アイコン + 砂時計バッジ + フェーズタブ + 円形タイマー) に揃えつつ、下部に `useJudgment` のポーリング結果で状態が切り替わる黒い採点進捗カードを追加
- pending 時: 「AI採点中です」「テキストの解析... XX%」、ready 時: 「採点完了」と次サイクル案内
- 進捗 % は休憩経過に連動 (12% → 90%) し、ready になった瞬間 100%

### `fix: タイマー時間の許容範囲をセッション作成と揃えて 1〜120 分に統一`
- backend `user_settings_schema._MINUTES_MAX` を 180 → 120
- backend 境界値テストを 181 → 121
- mobile `MINUTE_OPTIONS` から 180 を削除、`TIMER_MINUTES_MAX` を 120 に

### `fix(mobile): タイマーリングを時計回りに減るアニメーションに修正`
- 3 画面 (Input / Output / Break) の円形タイマーを「経過で伸びる」から「残りで減る」に変更
- `strokeDashoffset` を負にして、ギャップが 12 時位置から時計回り (12→3→6→9) に広がるアニメーションに

## Test plan

- [ ] mobile: 休憩画面の主要 UI (設定アイコン / 砂時計バッジ / フェーズタブ / 円形タイマー / 採点進捗カード) が S-07 のように表示されるか
- [ ] mobile: 休憩中は進捗 % が徐々に増え、判定が ready になったら 100% + 「採点完了」に切り替わるか
- [ ] mobile: 設定画面で時間を変更 (例: 30 分) → ホームに戻って「スタート」を押すとタイマー画面へ遷移しタイマーが動くか
- [ ] mobile: Input / Output / Break いずれの画面でも、タイマーリングが 12 時から時計回りに減っていくか
- [ ] backend: `uv run pytest` が通る (83 passed)
- [ ] mobile: `npm test` が通る (156 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)