### PR TITLE
test(backend): アウトプット重複送信時の上書き挙動を検証

### DIFF
--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -436,6 +436,7 @@ async def test_submit_output_allows_resubmission_and_overwrites_existing_output(
     assert second_body["output"]["session_id"] == session_id
     # UNIQUE(session_id) と upsert により output.id は再利用される
     assert second_body["output"]["id"] == first_body["output"]["id"]
+    # 2 回目の本文が DB に実際に反映されたことの検証（upsert no-op 退行を捕まえる要）
     assert second_body["output"]["content"] == "2 回目の本文です。内容を書き直しました。"
     assert second_body["output"]["submitted_at"].startswith("2026-04-10T15:30:00")
 

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -405,7 +405,7 @@ async def test_submit_output_allows_resubmission_and_overwrites_existing_output(
     client: AsyncClient,
 ):
     """1 セッション 1 アウトプット制約と重複送信時の上書き挙動を固定する。"""
-    auth_uid = "submit-user-resubmit"
+    auth_uid = "submit-user-005"
     created = await _create_session(client, auth_uid)
     session_id = created["id"]
     await _advance_status(client, auth_uid, session_id, "output")
@@ -430,6 +430,8 @@ async def test_submit_output_allows_resubmission_and_overwrites_existing_output(
     assert second.status_code == 202
     first_body = first.json()
     second_body = second.json()
+    # JUDGING からの再送でも受理され、status は judging のまま
+    # (SubmitOutput の update スキップ分岐)
     assert second_body["status"] == "judging"
     assert second_body["output"]["session_id"] == session_id
     # UNIQUE(session_id) と upsert により output.id は再利用される

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -436,7 +436,6 @@ async def test_submit_output_allows_resubmission_and_overwrites_existing_output(
     assert second_body["output"]["session_id"] == session_id
     # UNIQUE(session_id) と upsert により output.id は再利用される
     assert second_body["output"]["id"] == first_body["output"]["id"]
-    # content / submitted_at は 2 回目の値で上書きされる
     assert second_body["output"]["content"] == "2 回目の本文です。内容を書き直しました。"
     assert second_body["output"]["submitted_at"].startswith("2026-04-10T15:30:00")
 

--- a/backend/tests/integration/test_api_sessions.py
+++ b/backend/tests/integration/test_api_sessions.py
@@ -401,6 +401,45 @@ async def test_submit_output_rejects_invalid_session_state(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_submit_output_allows_resubmission_and_overwrites_existing_output(
+    client: AsyncClient,
+):
+    """1 セッション 1 アウトプット制約と重複送信時の上書き挙動を固定する。"""
+    auth_uid = "submit-user-resubmit"
+    created = await _create_session(client, auth_uid)
+    session_id = created["id"]
+    await _advance_status(client, auth_uid, session_id, "output")
+
+    first = await _submit_output(
+        client,
+        auth_uid,
+        session_id,
+        content="1 回目の本文です。関係代名詞の復習をここに書きます。",
+        submitted_at="2026-04-10T15:25:00Z",
+    )
+    assert first.status_code == 202
+
+    second = await _submit_output(
+        client,
+        auth_uid,
+        session_id,
+        content="2 回目の本文です。内容を書き直しました。",
+        submitted_at="2026-04-10T15:30:00Z",
+    )
+
+    assert second.status_code == 202
+    first_body = first.json()
+    second_body = second.json()
+    assert second_body["status"] == "judging"
+    assert second_body["output"]["session_id"] == session_id
+    # UNIQUE(session_id) と upsert により output.id は再利用される
+    assert second_body["output"]["id"] == first_body["output"]["id"]
+    # content / submitted_at は 2 回目の値で上書きされる
+    assert second_body["output"]["content"] == "2 回目の本文です。内容を書き直しました。"
+    assert second_body["output"]["submitted_at"].startswith("2026-04-10T15:30:00")
+
+
+@pytest.mark.asyncio
 async def test_submit_output_rejects_blank_content_with_problem_details(client: AsyncClient):
     auth_uid = "submit-user-004"
     created = await _create_session(client, auth_uid)


### PR DESCRIPTION
## 概要

issue #43 の完了条件「1 セッション 1 アウトプット制約が守られる」「重複送信時の挙動が定義どおりであること」をテストで明示的に固定する。実装本体は PR #51 系で既に載っているため、本 PR はテスト 1 件の追加のみ。

## 関連 Issue

- Closes #43

## 変更内容

- `test_submit_output_allows_resubmission_and_overwrites_existing_output` を追加
  - 同一セッションへの 2 回目 POST が 202 Accepted + `status=judging` のまま受理されること
  - `output.id` が 1 回目と同一（`UNIQUE(session_id)` と `upsert` による再利用）
  - `output.content` が 2 回目の値で上書きされていること（`upsert` no-op 退行を捕まえる要）
  - `submitted_at` が 2 回目の送信時刻を prefix で保持していること

## スコープ外 / 残課題

- `infrastructure/queue/cloud_tasks.py` の実体実装（Epic #4）
- 実 PostgreSQL に対する `PgOutputRepository` のリポジトリテスト（本テストは Fake 経由）
- 要件書 3.3.2 の 201 Created と実装 202 Accepted の差分整合（別 issue 想定）

## 動作確認

```bash
cd backend
task test            # 84 passed（新規 1 件を含む）
task lint
task format:check
task lint:imports
task typecheck
```

## チェックリスト

- [x] `task ci` 相当（lint / format:check / lint:imports / typecheck / test）がローカルで通る
- [x] 関連 Issue を `Closes` で紐付け
- [x] 仕様書との差分（202 vs 201）を本文に明記
- [x] 破壊的変更なし