### PR TITLE
Update backend, mobile, and docs to match the current architecture

### DIFF
--- a/.claude/rules/backend-architecture-rule.md
+++ b/.claude/rules/backend-architecture-rule.md
@@ -8,8 +8,8 @@ Puttokei backend は FastAPI / Python 3.12 / SQLAlchemy / Alembic / Pydantic / F
 - 依存方向は `domain <- application <- infrastructure / presentation`
 - `src.main` と `src.container` を Composition Root とし、依存の組み立てはここに集約する
 - `domain` は外部依存を持たない。entity、value object、repository IF、service IF を置く
-- `application` は use case と DTO を置く。adapter や Composition Root を import しない
-- `infrastructure` は DB、Firebase、Cloud Tasks、LLM、FCM など外部依存の実装を置く
+- `application` は use case、DTO、mapper、Unit of Work IF を置く。adapter や Composition Root を import しない
+- `infrastructure` は DB、SQLAlchemy Unit of Work、Firebase、Cloud Tasks、LLM、FCM など外部依存の実装を置く
 - `presentation` は FastAPI の HTTP 境界、schema、middleware、worker entrypoint を置く
 - `infrastructure` と `presentation` は水平依存させない
 - import 方向は `backend/pyproject.toml` の import-linter contract と整合させる
@@ -24,8 +24,8 @@ backend/
 │   ├── config.py            # pydantic-settings による環境変数管理
 │   ├── common/              # layer をまたいで使う最小限の共通基底
 │   ├── domain/              # entity / value object / repository IF / service IF
-│   ├── application/         # use case / DTO
-│   ├── infrastructure/      # persistence / auth / queue / llm / notification
+│   ├── application/         # use case / DTO / mapper / Unit of Work IF
+│   ├── infrastructure/      # persistence / Unit of Work 実装 / auth / queue / llm / notification
 │   └── presentation/        # FastAPI router / schema / middleware / health / workers
 ├── db/
 │   └── migrations/          # Alembic migration
@@ -48,7 +48,9 @@ backend/
 - `domain/services`: 認証検証や LLM 判定などの service interface
 - `application/use_cases`: API や worker から呼ばれる application service
 - `application/dto`: use case の入出力型
+- `application/unit_of_work.py`: use case 単位のトランザクション境界を表す Unit of Work IF
 - `infrastructure/persistence`: DB 接続、SQLAlchemy model、PostgreSQL repository 実装
+- `infrastructure/persistence/unit_of_work.py`: SQLAlchemy `AsyncSession` と repository 実装を束ねる Unit of Work 実装
 - `infrastructure/auth`: Firebase Admin SDK など認証実装
 - `infrastructure/queue`: Cloud Tasks など queue 実装
 - `infrastructure/llm`: LLM provider、prompt、provider factory
@@ -62,6 +64,8 @@ backend/
 
 - 新しいビジネスルールはまず `domain` に置けるか検討する
 - API endpoint から DB や外部 API を直接呼ばず、use case を経由する
+- Use Case は repository を個別に受け取らず、`UnitOfWorkFactory` を受け取って `async with` の単位で repository と transaction を扱う
+- 成功時だけ `uow.commit()` し、未 commit または例外発生時は Unit of Work の `__aexit__` で rollback させる
 - SQLAlchemy model と domain entity を混同しない
 - HTTP request / response の型は `presentation/schemas`、use case の入出力は `application/dto` に置く
 - repository IF を増やす場合は `domain/repositories`、実装は `infrastructure/persistence/repositories` に分ける

--- a/.claude/rules/mobile-architecture-rule.md
+++ b/.claude/rules/mobile-architecture-rule.md
@@ -38,7 +38,7 @@ mobile/
 │       └── types/           # API と共有 domain type
 ├── assets/
 ├── plugins/
-├── app.json
+├── app.json.example
 ├── eas.json
 ├── package.json
 └── tamagui.config.ts

--- a/.claude/rules/project-architecture-rule.md
+++ b/.claude/rules/project-architecture-rule.md
@@ -6,7 +6,7 @@ Puttokei で `backend/` `mobile/` `infra/` を触るときは、この構成と�
 
 - `backend/`: FastAPI / Python 3.12 の API。Cloud Run で動かす前提
 - `mobile/`: Expo / React Native / TypeScript のモバイルアプリ
-- `infra/`: Terraform + Google Cloud のインフラ定義
+- `infra/`: Terraform + Google Cloud のインフラ定義。現時点では未作成
 - `docs/requirements/`: 要件、API、DB、認証、CI/CD、構成の主資料
 - `AGENTS.md` / `CLAUDE.md`: エージェント向け運用ルール
 - `.codex/skills` / `.claude/skills`: 作業用 skill
@@ -19,8 +19,9 @@ Puttokei で `backend/` `mobile/` `infra/` を触るときは、この構成と�
 
 ## infra
 
-- Terraform + Google Cloud を前提にする
+- 現時点では `infra/` ディレクトリは存在しない
+- 新規作成する場合は Terraform + Google Cloud を前提にする
 - 再利用単位は `infra/modules`
 - 環境差分は `infra/environments/{staging,production}`
 - Cloud Run、Cloud SQL、Cloud Tasks、Secret Manager、Firebase / FCM 連携を想定する
-- `infra/` が空または未整備の場合は、`docs/requirements/requirements.md` に沿って module / environment の骨組みから作る
+- `infra/` を作る場合は、`docs/requirements/requirements.md` に沿って module / environment の骨組みから作る

--- a/.claude/skills/puttokei-project/SKILL.md
+++ b/.claude/skills/puttokei-project/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 ## 概要
 
-このリポジトリは実装より設計書が先行している。トップレベルの `README` や `Taskfile.yaml`、各ディレクトリ内の実装が空のことがあるため、足りないものを作るときは `docs/requirements/requirements.md` を正として扱う。
+このリポジトリは backend と mobile の土台実装が進んでいる一方、infra は未作成。既存実装がある領域ではローカルの構成とテストを優先して確認し、未実装領域を作るときは `docs/requirements/requirements.md` を正として扱う。
 
 ## 使う場面
 
@@ -21,7 +21,7 @@ disable-model-invocation: true
 
 1. まず変更対象ディレクトリの現状を確認する
 2. 既存コードがある場合は、その周辺の流儀を崩さずに合わせる
-3. 空ディレクトリやプレースホルダーしかない場合は、設計書に沿って素直に土台を作る
+3. 未作成ディレクトリやプレースホルダーしかない領域は、設計書に沿って素直に土台を作る
 4. 実装と設計書が食い違う場合は、変更箇所の一貫性を優先しつつ、最終報告で差分を明示する
 5. 詳細が必要なときだけ `references/` と `.claude/rules/` を読む
 
@@ -34,6 +34,7 @@ disable-model-invocation: true
 - 依存方向は `domain <- application <- infrastructure / presentation`
 - `src.main` と `src.container` を Composition Root とし、依存の組み立てはここに集約する
 - リポジトリ IF と外部サービス IF は `domain`、ユースケースと DTO は `application`
+- Unit of Work IF は `application`、SQLAlchemy による実装は `infrastructure/persistence`
 - DB、認証、キュー、LLM、通知など外部依存の実装は `infrastructure`
 - HTTP 入出力、Pydantic schema、middleware、worker entrypoint は `presentation`
 
@@ -48,6 +49,7 @@ disable-model-invocation: true
 
 ### infra
 
+- 現時点では `infra/` ディレクトリは存在しない
 - Terraform + Google Cloud
 - 再利用単位は `infra/modules`
 - 環境差分は `infra/environments/{staging,production}`

--- a/.claude/skills/puttokei-project/references/architecture.md
+++ b/.claude/skills/puttokei-project/references/architecture.md
@@ -7,7 +7,7 @@
 - 全体構成と infra の規則は `.claude/rules/project-architecture-rule.md`
 - backend の詳細なディレクトリ構成とアーキテクチャ規則は `.claude/rules/backend-architecture-rule.md`
 - mobile の詳細なディレクトリ構成とアーキテクチャ規則は `.claude/rules/mobile-architecture-rule.md`
-- ルート直下の `README` `Taskfile.yaml` `workflow` 群は空のことがあるので、実装前に必ず中身を確認する
+- ルート直下の `README` `Taskfile.yaml` `workflow` 群は実装済み。変更前に必ず中身を確認する
 
 ## 全体構成
 
@@ -29,11 +29,14 @@
 - `src/main.py`: FastAPI エントリポイント
 - `src/domain`: エンティティ、値オブジェクト、リポジトリ IF、サービス IF
 - `src/application`: ユースケースと DTO
+- `src/application/unit_of_work.py`: use case 単位の Unit of Work 抽象 IF
 - `src/infrastructure`: DB、LLM、認証、キュー、通知の実装
+- `src/infrastructure/persistence/unit_of_work.py`: SQLAlchemy Unit of Work 実装
 - `src/presentation`: FastAPI ルーター、スキーマ、ヘルスチェック、ミドルウェア、ワーカー
 - `tests/unit` `tests/integration` `tests/e2e`: テスト種別ごとに分割
 
 依存方向は常に `domain <- application <- infrastructure / presentation` を維持する。
+Use Case は `UnitOfWorkFactory` を受け取り、成功時だけ commit、未 commit または例外時は rollback する。
 
 ## mobile の期待構成
 
@@ -45,6 +48,7 @@
 
 ## infra の期待構成
 
+- 現時点では `infra/` ディレクトリは存在しない
 - `infra/modules`: 再利用する Terraform モジュール
 - `infra/environments/staging`: ステージング環境
 - `infra/environments/production`: 本番環境

--- a/.claude/skills/puttokei-project/references/contracts.md
+++ b/.claude/skills/puttokei-project/references/contracts.md
@@ -6,26 +6,23 @@
 - `judgments.verdict`: `correct`, `partial`, `incorrect`, `rejected`
 - 1 セッションに対して output と judgment はそれぞれ 1 件を想定する
 
-## API 一覧
+## API 一覧（現状）
 
-- `POST /api/v1/auth/verify`
 - `POST /api/v1/sessions`
-- `GET /api/v1/sessions/{id}`
 - `PATCH /api/v1/sessions/{id}`
-- `GET /api/v1/sessions`
+- `GET /api/v1/sessions/outputs/today`
 - `POST /api/v1/sessions/{id}/output`
 - `GET /api/v1/sessions/{id}/judgment`
-- `GET /api/v1/judgments`
-- `GET /api/v1/judgments/{id}`
-- `GET /api/v1/stats/summary`
-- `GET /api/v1/stats/daily`
-- `GET /api/v1/stats/weekly`
-- `GET /api/v1/stats/monthly`
-- `GET /api/v1/users/me`
+- `GET /api/v1/users/me/profile`
+- `PATCH /api/v1/users/me/profile`
+- `GET /api/v1/users/me/settings`
 - `PATCH /api/v1/users/me/settings`
 - `DELETE /api/v1/users/me`
 - `GET /health`
 - `GET /health/ready`
+
+`auth` / `judgments` / `stats` の router ファイルはあるが、現時点では `api_v1_router` に未登録。
+mobile 側には `/judgments` と `/stats` の API client があるため、結合時は backend の公開状況を確認する。
 
 ## DB の期待値
 
@@ -40,7 +37,7 @@
 
 ## LLM の契約
 
-- LLM 応答は `verdict` `score` `items` `advice` を持つ JSON
+- LLM 応答は `verdict` `score` `advice` `corrections` を持つ JSON
 - 不明な内容は推測で断定しない
 - フィードバックは高校生でも読める平易な日本語
 - 学習と無関係な入力は拒否できるようにする

--- a/.codex/rules/backend-architecture-rule.md
+++ b/.codex/rules/backend-architecture-rule.md
@@ -8,8 +8,8 @@ Puttokei backend は FastAPI / Python 3.12 / SQLAlchemy / Alembic / Pydantic / F
 - 依存方向は `domain <- application <- infrastructure / presentation`
 - `src.main` と `src.container` を Composition Root とし、依存の組み立てはここに集約する
 - `domain` は外部依存を持たない。entity、value object、repository IF、service IF を置く
-- `application` は use case と DTO を置く。adapter や Composition Root を import しない
-- `infrastructure` は DB、Firebase、Cloud Tasks、LLM、FCM など外部依存の実装を置く
+- `application` は use case、DTO、mapper、Unit of Work IF を置く。adapter や Composition Root を import しない
+- `infrastructure` は DB、SQLAlchemy Unit of Work、Firebase、Cloud Tasks、LLM、FCM など外部依存の実装を置く
 - `presentation` は FastAPI の HTTP 境界、schema、middleware、worker entrypoint を置く
 - `infrastructure` と `presentation` は水平依存させない
 - import 方向は `backend/pyproject.toml` の import-linter contract と整合させる
@@ -24,8 +24,8 @@ backend/
 │   ├── config.py            # pydantic-settings による環境変数管理
 │   ├── common/              # layer をまたいで使う最小限の共通基底
 │   ├── domain/              # entity / value object / repository IF / service IF
-│   ├── application/         # use case / DTO
-│   ├── infrastructure/      # persistence / auth / queue / llm / notification
+│   ├── application/         # use case / DTO / mapper / Unit of Work IF
+│   ├── infrastructure/      # persistence / Unit of Work 実装 / auth / queue / llm / notification
 │   └── presentation/        # FastAPI router / schema / middleware / health / workers
 ├── db/
 │   └── migrations/          # Alembic migration
@@ -48,7 +48,9 @@ backend/
 - `domain/services`: 認証検証や LLM 判定などの service interface
 - `application/use_cases`: API や worker から呼ばれる application service
 - `application/dto`: use case の入出力型
+- `application/unit_of_work.py`: use case 単位のトランザクション境界を表す Unit of Work IF
 - `infrastructure/persistence`: DB 接続、SQLAlchemy model、PostgreSQL repository 実装
+- `infrastructure/persistence/unit_of_work.py`: SQLAlchemy `AsyncSession` と repository 実装を束ねる Unit of Work 実装
 - `infrastructure/auth`: Firebase Admin SDK など認証実装
 - `infrastructure/queue`: Cloud Tasks など queue 実装
 - `infrastructure/llm`: LLM provider、prompt、provider factory
@@ -62,6 +64,8 @@ backend/
 
 - 新しいビジネスルールはまず `domain` に置けるか検討する
 - API endpoint から DB や外部 API を直接呼ばず、use case を経由する
+- Use Case は repository を個別に受け取らず、`UnitOfWorkFactory` を受け取って `async with` の単位で repository と transaction を扱う
+- 成功時だけ `uow.commit()` し、未 commit または例外発生時は Unit of Work の `__aexit__` で rollback させる
 - SQLAlchemy model と domain entity を混同しない
 - HTTP request / response の型は `presentation/schemas`、use case の入出力は `application/dto` に置く
 - repository IF を増やす場合は `domain/repositories`、実装は `infrastructure/persistence/repositories` に分ける

--- a/.codex/rules/mobile-architecture-rule.md
+++ b/.codex/rules/mobile-architecture-rule.md
@@ -38,7 +38,7 @@ mobile/
 │       └── types/           # API と共有 domain type
 ├── assets/
 ├── plugins/
-├── app.json
+├── app.json.example
 ├── eas.json
 ├── package.json
 └── tamagui.config.ts

--- a/.codex/rules/project-architecture-rule.md
+++ b/.codex/rules/project-architecture-rule.md
@@ -6,7 +6,7 @@ Puttokei で `backend/` `mobile/` `infra/` を触るときは、この構成と�
 
 - `backend/`: FastAPI / Python 3.12 の API。Cloud Run で動かす前提
 - `mobile/`: Expo / React Native / TypeScript のモバイルアプリ
-- `infra/`: Terraform + Google Cloud のインフラ定義
+- `infra/`: Terraform + Google Cloud のインフラ定義。現時点では未作成
 - `docs/requirements/`: 要件、API、DB、認証、CI/CD、構成の主資料
 - `AGENTS.md` / `CLAUDE.md`: エージェント向け運用ルール
 - `.codex/skills` / `.claude/skills`: 作業用 skill
@@ -19,8 +19,9 @@ Puttokei で `backend/` `mobile/` `infra/` を触るときは、この構成と�
 
 ## infra
 
-- Terraform + Google Cloud を前提にする
+- 現時点では `infra/` ディレクトリは存在しない
+- 新規作成する場合は Terraform + Google Cloud を前提にする
 - 再利用単位は `infra/modules`
 - 環境差分は `infra/environments/{staging,production}`
 - Cloud Run、Cloud SQL、Cloud Tasks、Secret Manager、Firebase / FCM 連携を想定する
-- `infra/` が空または未整備の場合は、`docs/requirements/requirements.md` に沿って module / environment の骨組みから作る
+- `infra/` を作る場合は、`docs/requirements/requirements.md` に沿って module / environment の骨組みから作る

--- a/.codex/skills/puttokei-project/SKILL.md
+++ b/.codex/skills/puttokei-project/SKILL.md
@@ -7,7 +7,7 @@ description: Puttokei リポジトリで作業するときの前提をまとめ�
 
 ## 概要
 
-このリポジトリは実装より設計書が先行している。トップレベルの `README` や `Taskfile.yaml`、各ディレクトリ内の実装が空のことがあるため、足りないものを作るときは `docs/requirements/requirements.md` を正として扱う。
+このリポジトリは backend と mobile の土台実装が進んでいる一方、infra は未作成。既存実装がある領域ではローカルの構成とテストを優先して確認し、未実装領域を作るときは `docs/requirements/requirements.md` を正として扱う。
 
 ## 使う場面
 
@@ -20,7 +20,7 @@ description: Puttokei リポジトリで作業するときの前提をまとめ�
 
 1. まず変更対象ディレクトリの現状を確認する
 2. 既存コードがある場合は、その周辺の流儀を崩さずに合わせる
-3. 空ディレクトリやプレースホルダーしかない場合は、設計書に沿って素直に土台を作る
+3. 未作成ディレクトリやプレースホルダーしかない領域は、設計書に沿って素直に土台を作る
 4. 実装と設計書が食い違う場合は、変更箇所の一貫性を優先しつつ、最終報告で差分を明示する
 5. 詳細が必要なときだけ `references/` と `.codex/rules/` を読む
 
@@ -33,6 +33,7 @@ description: Puttokei リポジトリで作業するときの前提をまとめ�
 - 依存方向は `domain <- application <- infrastructure / presentation`
 - `src.main` と `src.container` を Composition Root とし、依存の組み立てはここに集約する
 - リポジトリ IF と外部サービス IF は `domain`、ユースケースと DTO は `application`
+- Unit of Work IF は `application`、SQLAlchemy による実装は `infrastructure/persistence`
 - DB、認証、キュー、LLM、通知など外部依存の実装は `infrastructure`
 - HTTP 入出力、Pydantic schema、middleware、worker entrypoint は `presentation`
 
@@ -47,6 +48,7 @@ description: Puttokei リポジトリで作業するときの前提をまとめ�
 
 ### infra
 
+- 現時点では `infra/` ディレクトリは存在しない
 - Terraform + Google Cloud
 - 再利用単位は `infra/modules`
 - 環境差分は `infra/environments/{staging,production}`

--- a/.codex/skills/puttokei-project/references/architecture.md
+++ b/.codex/skills/puttokei-project/references/architecture.md
@@ -7,7 +7,7 @@
 - 全体構成と infra の規則は `.codex/rules/project-architecture-rule.md`
 - backend の詳細なディレクトリ構成とアーキテクチャ規則は `.codex/rules/backend-architecture-rule.md`
 - mobile の詳細なディレクトリ構成とアーキテクチャ規則は `.codex/rules/mobile-architecture-rule.md`
-- ルート直下の `README` `Taskfile.yaml` `workflow` 群は空のことがあるので、実装前に必ず中身を確認する
+- ルート直下の `README` `Taskfile.yaml` `workflow` 群は実装済み。変更前に必ず中身を確認する
 
 ## 全体構成
 
@@ -29,11 +29,14 @@
 - `src/main.py`: FastAPI エントリポイント
 - `src/domain`: エンティティ、値オブジェクト、リポジトリ IF、サービス IF
 - `src/application`: ユースケースと DTO
+- `src/application/unit_of_work.py`: use case 単位の Unit of Work 抽象 IF
 - `src/infrastructure`: DB、LLM、認証、キュー、通知の実装
+- `src/infrastructure/persistence/unit_of_work.py`: SQLAlchemy Unit of Work 実装
 - `src/presentation`: FastAPI ルーター、スキーマ、ヘルスチェック、ミドルウェア、ワーカー
 - `tests/unit` `tests/integration` `tests/e2e`: テスト種別ごとに分割
 
 依存方向は常に `domain <- application <- infrastructure / presentation` を維持する。
+Use Case は `UnitOfWorkFactory` を受け取り、成功時だけ commit、未 commit または例外時は rollback する。
 
 ## mobile の期待構成
 
@@ -45,6 +48,7 @@
 
 ## infra の期待構成
 
+- 現時点では `infra/` ディレクトリは存在しない
 - `infra/modules`: 再利用する Terraform モジュール
 - `infra/environments/staging`: ステージング環境
 - `infra/environments/production`: 本番環境

--- a/.codex/skills/puttokei-project/references/contracts.md
+++ b/.codex/skills/puttokei-project/references/contracts.md
@@ -6,26 +6,23 @@
 - `judgments.verdict`: `correct`, `partial`, `incorrect`, `rejected`
 - 1 セッションに対して output と judgment はそれぞれ 1 件を想定する
 
-## API 一覧
+## API 一覧（現状）
 
-- `POST /api/v1/auth/verify`
 - `POST /api/v1/sessions`
-- `GET /api/v1/sessions/{id}`
 - `PATCH /api/v1/sessions/{id}`
-- `GET /api/v1/sessions`
+- `GET /api/v1/sessions/outputs/today`
 - `POST /api/v1/sessions/{id}/output`
 - `GET /api/v1/sessions/{id}/judgment`
-- `GET /api/v1/judgments`
-- `GET /api/v1/judgments/{id}`
-- `GET /api/v1/stats/summary`
-- `GET /api/v1/stats/daily`
-- `GET /api/v1/stats/weekly`
-- `GET /api/v1/stats/monthly`
-- `GET /api/v1/users/me`
+- `GET /api/v1/users/me/profile`
+- `PATCH /api/v1/users/me/profile`
+- `GET /api/v1/users/me/settings`
 - `PATCH /api/v1/users/me/settings`
 - `DELETE /api/v1/users/me`
 - `GET /health`
 - `GET /health/ready`
+
+`auth` / `judgments` / `stats` の router ファイルはあるが、現時点では `api_v1_router` に未登録。
+mobile 側には `/judgments` と `/stats` の API client があるため、結合時は backend の公開状況を確認する。
 
 ## DB の期待値
 
@@ -40,7 +37,7 @@
 
 ## LLM の契約
 
-- LLM 応答は `verdict` `score` `items` `advice` を持つ JSON
+- LLM 応答は `verdict` `score` `advice` `corrections` を持つ JSON
 - 不明な内容は推測で断定しない
 - フィードバックは高校生でも読める平易な日本語
 - 学習と無関係な入力は拒否できるようにする

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# hourglass-backend
+# Puttokei backend
 
-Hourglass の backend API。FastAPI / SQLAlchemy / Alembic / Firebase Admin SDK を採用したクリーンアーキテクチャ実装。
+Puttokei の backend API。FastAPI / SQLAlchemy / Alembic / Firebase Admin SDK を採用したクリーンアーキテクチャ実装。
 
 ## 必要なツール
 
@@ -46,28 +46,44 @@ task backend:db:upgrade  # マイグレーション適用
 
 ルートから `task ci` を叩くと backend と mobile の両方を回せる。`task --list` で全コマンド一覧が見られる。
 
-## ディレクトリ構成
+## アーキテクチャ
 
 要件書 §8.2 に沿った 4 層クリーンアーキテクチャ。依存方向は常に `domain ← application ← infrastructure / presentation`。
+`src.main` と `src.container` を Composition Root とし、presentation 層は `app.state` 経由で依存物を受け取る。
+
+## ディレクトリ構成
 
 ```
 src/
 ├── main.py            FastAPI エントリポイント
 ├── config.py          pydantic-settings の Settings
 ├── container.py       DI 組み立て (Composition Root)
+├── common/            layer をまたいで使う最小限の共通基底
 ├── domain/            純粋 Python（外部依存なし）
-├── application/       Use Case と DTO
-├── infrastructure/    DB / LLM / 認証 / キュー / 通知 の実装
-└── presentation/      FastAPI ルーター / health / workers / schemas / middleware
+├── application/       Use Case / DTO / mapper / Unit of Work IF
+├── infrastructure/    DB / Unit of Work 実装 / LLM / 認証 / キュー / 通知 の実装
+└── presentation/      FastAPI ルーター / health / workers / schemas / middleware / mapper
 
 tests/
 ├── unit/              domain / use case の単体テスト
-├── integration/       repository / LLM の結合テスト
-└── e2e/               API の E2E テスト
+├── integration/       repository / API / LLM の結合テスト
+├── e2e/               API の E2E テスト
+└── fakes/             unit test 用 test double
 
 db/migrations/         Alembic マイグレーション
 ```
 
-## 後続 Epic で実装するもの
+## 実装状況
 
-各レイヤーのファイルは骨組みのみ。各 Epic の Story で具体実装を追加する。
+現在 `api_v1_router` に登録済みの API は `users` と `sessions`。`auth` / `judgments` / `stats` の router ファイルは存在するが、現時点ではプレースホルダーで router 登録されていない。
+
+- 公開済み: `GET /health`, `GET /health/ready`
+- 公開済み: `GET/PATCH /api/v1/users/me/profile`, `GET/PATCH /api/v1/users/me/settings`, `DELETE /api/v1/users/me`
+- 公開済み: `POST /api/v1/sessions`, `GET /api/v1/sessions/outputs/today`, `PATCH /api/v1/sessions/{session_id}`, `POST /api/v1/sessions/{session_id}/output`, `GET /api/v1/sessions/{session_id}/judgment`
+- 未実装: Cloud Tasks へのキューイングと worker 本体。開発環境では `local_judgment_enabled` により `submit_output` 内でローカル判定を実行できる。
+
+## トランザクション境界
+
+Use Case は `application.unit_of_work.ApplicationUnitOfWork` を通じて repository を利用する。`infrastructure.persistence.unit_of_work.SqlAlchemyUnitOfWork` が SQLAlchemy の `AsyncSession` と DB トランザクションを管理し、`container` が `UnitOfWorkFactory` として各 Use Case に注入する。
+
+Use Case 内では `async with self.unit_of_work_factory() as uow:` を単位に処理し、成功時だけ `uow.commit()` する。未 commit または例外発生時は `__aexit__` で rollback される。

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -110,34 +110,35 @@
 
 **3.2.1. 認証**
 
-| **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
-| --- | --- | --- | --- | --- |
-| POST | /api/v1/auth/verify | Firebase ID Tokenを検証し、ユーザが未登録なら作成 | 不要 | { user, is_new } |
+現行実装では専用の `/api/v1/auth/verify` は公開していない。認証が必要な endpoint では `auth_middleware` が `Authorization: Bearer <Firebase ID Token>` を検証し、未登録ユーザーなら backend 側で初期作成する。
 
 **3.2.2. セッション管理**
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
 | POST | /api/v1/sessions | 新規セッション作成 | 必須 | { session } |
-| GET | /api/v1/sessions/{id} | セッション詳細取得 | 必須 | { session } |
 | PATCH | /api/v1/sessions/{id} | セッションステータス更新 | 必須 | { session } |
-| GET | /api/v1/sessions | セッション履歴一覧 | 必須 | { sessions[], next_cursor } |
+| GET | /api/v1/sessions/outputs/today | 今日のアウトプット一覧取得 | 必須 | { items[] } |
 
 **3.2.3. アウトプット・判定**
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
-| POST | /api/v1/sessions/{id}/output | アウトプットテキスト送信。LLM判定ジョブをキューイング | 必須 | { output, status: judging } |
+| POST | /api/v1/sessions/{id}/output | アウトプットテキスト送信。セッションを judging に進め、開発環境ではローカル判定も可能 | 必須 | { output, status } |
 | GET | /api/v1/sessions/{id}/judgment | 判定結果取得。未完了なら202を返却 | 必須 | { judgment } or 202 |
 
-**3.2.4. 判定履歴**
+**3.2.4. 判定履歴（予定）**
+
+以下は mobile 側 API client が先行している。backend の router は現時点では未登録。
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
 | GET | /api/v1/judgments | 判定履歴一覧（フィルタ・ソート・ページネーション） | 必須 | { judgments[], next_cursor } |
 | GET | /api/v1/judgments/{id} | 判定詳細取得 | 必須 | { judgment } |
 
-**3.2.5. 統計**
+**3.2.5. 統計（予定）**
+
+以下は mobile 側 API client が先行している。backend の router は現時点では未登録。
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
@@ -150,7 +151,9 @@
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
-| GET | /api/v1/users/me | 自分のプロフィール取得 | 必須 | { user } |
+| GET | /api/v1/users/me/profile | 自分のプロフィール取得 | 必須 | { user } |
+| PATCH | /api/v1/users/me/profile | 自分のプロフィール更新 | 必須 | { user } |
+| GET | /api/v1/users/me/settings | タイマー / 通知設定取得 | 必須 | { settings } |
 | PATCH | /api/v1/users/me/settings | タイマー設定変更（時間カスタマイズ） | 必須 | { settings } |
 | DELETE | /api/v1/users/me | アカウント削除（GDPR/個人情報保護法対応） | 必須 | 204 No Content |
 
@@ -194,24 +197,19 @@ GET `/api/v1/sessions/{id}/judgment`
 
 ```basic
 {
-  "id": "jdg_xxxx",
-  "session_id": "ses_xxxx",
+  "id": "2b90f7d2-0e7f-4a5f-a5be-7f92c2a4b865",
+  "session_id": "0f7c5c61-8b2d-4a8c-a1df-6d79b9b6e8a8",
   "verdict": "partial",
   "score": 70,
-  "items": [
+  "advice": "全体的に良く理解できています。...",
+  "corrections": [
     {
-      "claim": "関係代名詞は先行詞を修飾する",
-      "correct": true,
-      "feedback": "正解です"
-    },
-    {
-      "claim": "whoは人以外にも使える",
-      "correct": false,
-      "feedback": "whoは人に対して使います。人以外にwhichを..."
+      "target_text": "whoは人以外にも使える",
+      "correct_text": "whoは人に対して使い、人以外には which を使う",
+      "explanation": "who は人を表す先行詞に使います。"
     }
   ],
-  "advice": "全体的に良く理解できています。...",
-  "created_at": "2026-04-10T15:30:15+09:00"
+  "judged_at": "2026-04-10T15:30:15+09:00"
 }
 ```
 
@@ -326,16 +324,11 @@ LLM による正誤判定結果
 | --- | --- | --- | --- |
 | id | UUID PK | NO | 判定ID |
 | session_id | UUID FK -> sessions UNIQUE | NO | セッションID |
-| output_id | UUID FK -> outputs | NO | アウトプットID |
-| verdict | VARCHAR(20) | NO | correct / partial / incorrect |
-| score | INTEGER | YES | スコア（0-100） |
-| items | JSONB | NO | 各項目の判定結果配列 |
-| advice | TEXT | YES | 総合アドバイス |
-| llm_provider | VARCHAR(30) | NO | 使用したLLMプロバイダー |
-| llm_model | VARCHAR(50) | NO | 使用したモデル名 |
-| llm_latency_ms | INTEGER | YES | LLM API レスポンス時間 |
-| token_usage | JSONB | YES | { prompt_tokens, completion_tokens } |
-| created_at | TIMESTAMPTZ | NO | 判定実行日時 |
+| verdict | VARCHAR(16) | NO | correct / partial / incorrect / rejected |
+| score | INTEGER | NO | スコア（0-100） |
+| advice | TEXT | NO | 総合アドバイス |
+| corrections | JSONB | NO | 誤り指摘配列（target_text / correct_text / explanation） |
+| judged_at | TIMESTAMPTZ | NO | 判定実行日時 |
 
 **4.3.6. rate_limit_logs**
 
@@ -383,24 +376,30 @@ LLM による正誤判定結果
 {
   "verdict": "correct" | "partial" | "incorrect" | "rejected",
   "score": 0-100,
-  "items": [{ "claim": "...", "correct": bool, "feedback": "..." }],
-  "advice": "総合アドバイス"
+  "advice": "総合アドバイス",
+  "corrections": [
+    {
+      "target_text": "誤りを含む本文中の抜粋",
+      "correct_text": "正しい内容",
+      "explanation": "誤りの理由"
+    }
+  ]
 }
 ```
 
 #### 5.3. Pydantic バリデーション
 
 ```python
-class JudgmentItem(BaseModel):
-    claim: str
-    correct: bool
-    feedback: str = Field(max_length=500)
+class JudgmentCorrection(BaseModel):
+    target_text: str
+    correct_text: str
+    explanation: str
 
 class LLMJudgmentResponse(BaseModel):
     verdict: Literal["correct","partial","incorrect","rejected"]
     score: int = Field(ge=0, le=100)
-    items: list[JudgmentItem]
     advice: str = Field(max_length=1000)
+    corrections: list[JudgmentCorrection]
 ```
 
 #### 5.4. LLM プロバイダー抽象化
@@ -538,15 +537,20 @@ App Storeガイドラインおよび個人情報保護法に準拠し、アカ�
 ```docker
 FROM python:3.12-slim AS builder
 WORKDIR /app
-RUN pip install uv
+RUN pip install --no-cache-dir uv==0.10.2
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.12-slim AS runner
 WORKDIR /app
-COPY --from=builder /app/.venv .venv
+COPY --from=builder /app/.venv /app/.venv
 COPY src/ src/
-ENV PATH="/app/.venv/bin:$PATH"
+COPY db/ db/
+COPY alembic.ini ./
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+EXPOSE 8080
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
@@ -555,22 +559,29 @@ CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 #### 8.1. リポジトリ構成
 
 ```markdown
-pomollm/
+puttokei/
 ├── .github/
 │   └── workflows/
-│       ├── backend-ci.yml
-│       ├── backend-cd.yml
-│       ├── frontend-ci.yml
-│       └── mobile-cd.yml
+│       ├── backend-ci.yaml
+│       ├── backend-cd.yaml
+│       ├── mobile-ci.yaml
+│       └── mobile-cd.yaml
 ├── backend/
 ├── mobile/
-├── infra/
-└── docs/
+├── docs/
+├── AGENTS.md
+├── CLAUDE.md
+├── README
+├── Taskfile.yaml
+└── puttokei.code-workspace
 ```
+
+`infra/` は現時点では未作成。Terraform を追加する場合は 8.4 の構成に沿って作成する。
 
 #### 8.2. バックエンド
 
-クリーンアーキテクチャの4層構造を採用する。依存方向は domain ← application ← infrastructure / presentation
+クリーンアーキテクチャの4層構造を採用する。依存方向は domain ← application ← infrastructure / presentation。
+Use Case は Unit of Work をトランザクション境界とし、`application` に抽象 IF、`infrastructure/persistence` に SQLAlchemy 実装を置く。
 
 ```markdown
 backend/
@@ -578,39 +589,57 @@ backend/
 │   ├── main.py                        # FastAPIエントリポイント + Composition Root
 │   ├── config.py                      # 環境変数・設定 (pydantic-settings)
 │   ├── container.py                   # DI組み立て（Composition Root）
+│   ├── common/                        # layer をまたいで使う最小限の共通基底
 │   │
 │   ├── domain/                        # ドメイン層 (外部依存なし・純粋Python)
 │   │   ├── entities/
 │   │   │   ├── user.py                # User エンティティ (dataclass)
 │   │   │   ├── session.py             # Session エンティティ
 │   │   │   ├── output.py              # Output エンティティ
-│   │   │   └── judgment.py            # Judgment エンティティ
+│   │   │   ├── judgment.py            # Judgment エンティティ
+│   │   │   └── user_settings.py       # UserSettings エンティティ
 │   │   ├── value_objects/
+│   │   │   ├── age_group.py           # AgeGroup 列挙型
+│   │   │   ├── auth_provider.py       # AuthProvider 列挙型
+│   │   │   ├── judgment_result.py     # LLM 判定の中間表現
 │   │   │   ├── verdict.py             # Verdict 列挙型 (correct/partial/incorrect/rejected)
 │   │   │   └── session_status.py      # SessionStatus 列挙型
 │   │   ├── repositories/              # リポジトリインターフェース (ABC)
 │   │   │   ├── user_repository.py
 │   │   │   ├── session_repository.py
+│   │   │   ├── output_repository.py
 │   │   │   └── judgment_repository.py
 │   │   └── services/                  # ドメインサービスインターフェース (ABC)
+│   │       ├── auth_verifier.py       # 認証検証インターフェース
 │   │       └── llm_judge_service.py   # LLM判定インターフェース
 │   │
 │   ├── application/                   # アプリケーション層 (Use Cases)
+│   │   ├── unit_of_work.py            # Unit of Work IF / transaction boundary
 │   │   ├── use_cases/
+│   │   │   ├── authenticate_user.py   # Bearer token 検証 + ユーザー初期作成
 │   │   │   ├── create_session.py      # セッション作成
+│   │   │   ├── update_session_status.py # セッション状態更新
 │   │   │   ├── submit_output.py       # アウトプット送信 + 判定キューイング
 │   │   │   ├── get_judgment.py        # 判定結果取得
+│   │   │   ├── list_today_outputs.py  # 今日のアウトプット一覧
 │   │   │   ├── list_judgments.py      # 判定履歴一覧
 │   │   │   ├── get_stats.py           # 統計取得
+│   │   │   ├── get_user_profile.py    # プロフィール取得
+│   │   │   ├── update_user_profile.py # プロフィール更新
+│   │   │   ├── get_user_settings.py   # 設定取得
+│   │   │   ├── update_user_settings.py # 設定更新
 │   │   │   └── delete_account.py      # アカウント削除
 │   │   └── dto/                       # Use Case 入出力 (dataclass or BaseModel)
 │   │       ├── session_dto.py         # CreateSessionInput / SessionOutput
 │   │       ├── judgment_dto.py        # JudgmentOutput / JudgmentListOutput
-│   │       └── stats_dto.py           # StatsOutput / DailyStatsOutput
+│   │       ├── stats_dto.py           # StatsOutput / DailyStatsOutput
+│   │       ├── user_dto.py            # UserProfileOutput など
+│   │       └── user_settings_dto.py   # UserSettingsOutput など
 │   │
 │   ├── infrastructure/                # インフラ層 (外部依存の実装)
 │   │   ├── persistence/
 │   │   │   ├── database.py            # DB接続管理 (async sessionmaker)
+│   │   │   ├── unit_of_work.py        # SQLAlchemy Unit of Work 実装
 │   │   │   ├── models/                # SQLAlchemy ORMモデル
 │   │   │   │   ├── user_model.py
 │   │   │   │   ├── session_model.py
@@ -620,6 +649,7 @@ backend/
 │   │   │   └── repositories/          # リポジトリ実装 (PostgreSQL)
 │   │   │       ├── pg_user_repository.py
 │   │   │       ├── pg_session_repository.py
+│   │   │       ├── pg_output_repository.py
 │   │   │       └── pg_judgment_repository.py
 │   │   ├── llm/                       # LLMプロバイダー実装
 │   │   │   ├── gemini_provider.py
@@ -650,7 +680,10 @@ backend/
 │       ├── schemas/                   # Pydantic リクエスト/レスポンス (HTTP境界)
 │       │   ├── session_schema.py
 │       │   ├── judgment_schema.py
-│       │   └── user_schema.py
+│       │   ├── user_schema.py
+│       │   ├── user_settings_schema.py
+│       │   └── problem_schema.py
+│       ├── mappers/                   # HTTP response mapper
 │       └── middleware/
 │           ├── auth_middleware.py      # 認証ミドルウェア
 │           └── rate_limit.py          # レートリミット
@@ -659,17 +692,19 @@ backend/
 │   ├── unit/                          # domain・use case の単体テスト
 │   │   ├── test_entities/
 │   │   └── test_use_cases/
-│   ├── integration/                   # リポジトリ・LLMの結合テスト
+│   ├── integration/                   # リポジトリ・API・LLMの結合テスト
 │   │   ├── test_repositories/
 │   │   └── test_llm/
-│   └── e2e/                           # APIエンドツーエンドテスト
-│       └── test_api/
+│   ├── e2e/                           # APIエンドツーエンドテスト
+│   │   └── test_api/
+│   └── fakes/                         # Unit test 用 test double
 ├── db/
 │   └── migrations/                    # Alembicマイグレーション
 ├── Dockerfile
 ├── pyproject.toml
 ├── uv.lock
-└── alembic.ini
+├── alembic.ini
+└── docker-compose.yml
 ```
 
 #### 8.3. フロントエンド
@@ -677,31 +712,44 @@ backend/
 ```markdown
 mobile/
 ├── app/                               # Expo Router (ルーティング定義のみ)
+│   ├── _layout.tsx                    # ルートレイアウト
 │   ├── (auth)/
-│   │   ├── sign-in.tsx                # -> features/auth/screens
-│   │   └── _layout.tsx
+│   │   ├── _layout.tsx
+│   │   ├── overview.tsx               # -> features/auth/screens
+│   │   ├── tutorial-step-one.tsx      # -> features/auth/screens
+│   │   ├── tutorial-step-two.tsx      # -> features/auth/screens
+│   │   ├── tutorial-step-three.tsx    # -> features/auth/screens
+│   │   └── sign-in.tsx                # -> features/auth/screens
 │   ├── (tabs)/
+│   │   ├── _layout.tsx
 │   │   ├── index.tsx                  # -> features/session/screens
 │   │   ├── history.tsx                # -> features/history/screens
 │   │   ├── stats.tsx                  # -> features/stats/screens
-│   │   └── settings.tsx               # -> features/settings/screens
-│   ├── session/
-│   │   └── [id]/
+│   │   ├── settings.tsx               # -> features/settings/screens
+│   │   └── session/[id]/
 │   │       ├── input.tsx              # -> features/session/screens
-│   │       ├── output.tsx
-│   │       ├── break.tsx
-│   │       └── result.tsx
-│   └── _layout.tsx                    # ルートレイアウト
+│   │       ├── output.tsx             # -> features/session/screens
+│   │       ├── break.tsx              # -> features/session/screens
+│   │       └── result.tsx             # -> features/session/screens
+│   ├── history/
+│   │   └── [id].tsx                   # -> features/history/screens
+│   └── profile/
+│       ├── _layout.tsx
+│       └── edit.tsx                   # -> features/profile/screens
 │
 ├── src/
 │   ├── features/                      # 機能単位モジュール
 │   │   ├── auth/
 │   │   │   ├── screens/
-│   │   │   │   └── SignInScreen.tsx    # サインイン画面の実装
+│   │   │   │   ├── OverviewScreen.tsx
+│   │   │   │   ├── TutorialStepOneScreen.tsx
+│   │   │   │   ├── TutorialStepTwoScreen.tsx
+│   │   │   │   ├── TutorialStepThreeScreen.tsx
+│   │   │   │   └── SignInScreen.tsx
 │   │   │   ├── hooks/
 │   │   │   │   └── useAuth.ts         # 認証ロジック
 │   │   │   └── api/
-│   │   │       └── authApi.ts         # POST /auth/verify
+│   │   │       └── authApi.ts         # 認証 API client（現状は placeholder）
 │   │   │
 │   │   ├── session/
 │   │   │   ├── screens/
@@ -711,9 +759,10 @@ mobile/
 │   │   │   │   ├── BreakScreen.tsx    # 休憩フェーズ
 │   │   │   │   └── ResultScreen.tsx   # 判定結果表示
 │   │   │   ├── components/
-│   │   │   │   ├── Timer.tsx          # ポモドーロタイマー
 │   │   │   │   ├── OutputEditor.tsx   # アウトプット入力エディター
-│   │   │   │   └── JudgmentCard.tsx   # 判定結果カード
+│   │   │   │   ├── JudgmentCard.tsx   # 判定結果カード
+│   │   │   │   ├── AnnotatedOutputText.tsx
+│   │   │   │   └── SessionPhaseChrome.tsx
 │   │   │   ├── hooks/
 │   │   │   │   ├── useTimer.ts        # タイマーロジック
 │   │   │   │   └── useSession.ts      # セッション管理
@@ -726,7 +775,8 @@ mobile/
 │   │   │   ├── components/
 │   │   │   │   └── JudgmentListItem.tsx
 │   │   │   ├── hooks/
-│   │   │   │   └── useJudgments.ts    # 履歴データ取得
+│   │   │   │   ├── useJudgments.ts    # 履歴データ取得
+│   │   │   │   └── useJudgmentDetail.ts
 │   │   │   └── api/
 │   │   │       └── judgmentApi.ts
 │   │   │
@@ -734,44 +784,68 @@ mobile/
 │   │   │   ├── screens/
 │   │   │   │   └── StatsScreen.tsx    # 統計ダッシュボード
 │   │   │   ├── components/
-│   │   │   │   └── StatsChart.tsx     # 統計グラフ
+│   │   │   │   ├── PeriodSelector.tsx
+│   │   │   │   ├── StatsChart.tsx
+│   │   │   │   └── StatsSummaryCards.tsx
 │   │   │   ├── hooks/
 │   │   │   │   └── useStats.ts
 │   │   │   └── api/
 │   │   │       └── statsApi.ts
 │   │   │
-│   │   └── settings/
+│   │   ├── settings/
+│   │   │   ├── screens/
+│   │   │   │   └── SettingsScreen.tsx  # 設定画面
+│   │   │   ├── hooks/
+│   │   │   │   ├── useSettings.ts
+│   │   │   │   ├── useUpdateSettings.ts
+│   │   │   │   └── useDeleteAccount.ts
+│   │   │   └── api/
+│   │   │       └── settingsApi.ts
+│   │   │
+│   │   └── profile/
 │   │       ├── screens/
-│   │       │   └── SettingsScreen.tsx  # 設定画面
+│   │       │   └── ProfileEditScreen.tsx
 │   │       ├── hooks/
-│   │       │   └── useSettings.ts
+│   │       │   ├── useProfile.ts
+│   │       │   └── useUpdateProfile.ts
 │   │       └── api/
-│   │           └── settingsApi.ts
+│   │           └── profileApi.ts
 │   │
 │   └── shared/                        # 機能横断の共有リソース
 │       ├── components/
-│       │   ├── Button.tsx             # 共通ボタン
+│       │   ├── AuthGate.tsx
+│       │   ├── BootScreen.tsx
 │       │   ├── Card.tsx               # 共通カード
 │       │   └── LoadingIndicator.tsx
 │       ├── hooks/
 │       │   └── useNotification.ts     # プッシュ通知
 │       ├── lib/
-│       │   ├── api.ts                 # kyインスタンス + 認証フック
+│       │   ├── api.ts                 # fetch wrapper + 認証フック
 │       │   ├── firebase.ts            # Firebase初期化
-│       │   └── notifications.ts       # プッシュ通知セットアップ
+│       │   ├── notifications.ts       # プッシュ通知セットアップ
+│       │   ├── queryClient.ts         # TanStack Query client
+│       │   ├── splash.ts
+│       │   ├── devMockAuth.ts
+│       │   └── judgmentPresentation.ts
 │       ├── stores/
 │       │   ├── authStore.ts           # Zustand 認証ストア
-│       │   └── timerStore.ts          # Zustand タイマーストア
+│       │   ├── timerStore.ts          # Zustand タイマーストア
+│       │   ├── loopStore.ts
+│       │   └── tutorialStore.ts
 │       └── types/
-│           └── api.ts                 # APIレスポンス型定義
+│           ├── api.ts                 # APIレスポンス型定義
+│           ├── user.ts
+│           └── userSettings.ts
 │
-├── app.json
+├── app.json.example
 ├── eas.json
 ├── tsconfig.json
 └── package.json
 ```
 
 #### 8.4. インフラ
+
+現時点では `infra/` は未作成。作成時は以下の module / environment 構成を基準にする。
 
 ```markdown
 infra/

--- a/docs/requirements/technical_book.md
+++ b/docs/requirements/technical_book.md
@@ -110,34 +110,35 @@
 
 **3.2.1. 認証**
 
-| **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
-| --- | --- | --- | --- | --- |
-| POST | /api/v1/auth/verify | Firebase ID Tokenを検証し、ユーザが未登録なら作成 | 不要 | { user, is_new } |
+現行実装では専用の `/api/v1/auth/verify` は公開していない。認証が必要な endpoint では `auth_middleware` が `Authorization: Bearer <Firebase ID Token>` を検証し、未登録ユーザーなら backend 側で初期作成する。
 
 **3.2.2. セッション管理**
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
 | POST | /api/v1/sessions | 新規セッション作成 | 必須 | { session } |
-| GET | /api/v1/sessions/{id} | セッション詳細取得 | 必須 | { session } |
 | PATCH | /api/v1/sessions/{id} | セッションステータス更新 | 必須 | { session } |
-| GET | /api/v1/sessions | セッション履歴一覧 | 必須 | { sessions[], next_cursor } |
+| GET | /api/v1/sessions/outputs/today | 今日のアウトプット一覧取得 | 必須 | { items[] } |
 
 **3.2.3. アウトプット・判定**
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
-| POST | /api/v1/sessions/{id}/output | アウトプットテキスト送信。LLM判定ジョブをキューイング | 必須 | { output, status: judging } |
+| POST | /api/v1/sessions/{id}/output | アウトプットテキスト送信。セッションを judging に進め、開発環境ではローカル判定も可能 | 必須 | { output, status } |
 | GET | /api/v1/sessions/{id}/judgment | 判定結果取得。未完了なら202を返却 | 必須 | { judgment } or 202 |
 
-**3.2.4. 判定履歴**
+**3.2.4. 判定履歴（予定）**
+
+以下は mobile 側 API client が先行している。backend の router は現時点では未登録。
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
 | GET | /api/v1/judgments | 判定履歴一覧（フィルタ・ソート・ページネーション） | 必須 | { judgments[], next_cursor } |
 | GET | /api/v1/judgments/{id} | 判定詳細取得 | 必須 | { judgment } |
 
-**3.2.5. 統計**
+**3.2.5. 統計（予定）**
+
+以下は mobile 側 API client が先行している。backend の router は現時点では未登録。
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
@@ -150,7 +151,9 @@
 
 | **Method** | **Path** | **概要** | **認証** | **レスポンス概要** |
 | --- | --- | --- | --- | --- |
-| GET | /api/v1/users/me | 自分のプロフィール取得 | 必須 | { user } |
+| GET | /api/v1/users/me/profile | 自分のプロフィール取得 | 必須 | { user } |
+| PATCH | /api/v1/users/me/profile | 自分のプロフィール更新 | 必須 | { user } |
+| GET | /api/v1/users/me/settings | タイマー / 通知設定取得 | 必須 | { settings } |
 | PATCH | /api/v1/users/me/settings | タイマー設定変更（時間カスタマイズ） | 必須 | { settings } |
 | DELETE | /api/v1/users/me | アカウント削除（GDPR/個人情報保護法対応） | 必須 | 204 No Content |
 
@@ -194,24 +197,19 @@ GET `/api/v1/sessions/{id}/judgment`
 
 ```basic
 {
-  "id": "jdg_xxxx",
-  "session_id": "ses_xxxx",
+  "id": "2b90f7d2-0e7f-4a5f-a5be-7f92c2a4b865",
+  "session_id": "0f7c5c61-8b2d-4a8c-a1df-6d79b9b6e8a8",
   "verdict": "partial",
   "score": 70,
-  "items": [
+  "advice": "全体的に良く理解できています。...",
+  "corrections": [
     {
-      "claim": "関係代名詞は先行詞を修飾する",
-      "correct": true,
-      "feedback": "正解です"
-    },
-    {
-      "claim": "whoは人以外にも使える",
-      "correct": false,
-      "feedback": "whoは人に対して使います。人以外にwhichを..."
+      "target_text": "whoは人以外にも使える",
+      "correct_text": "whoは人に対して使い、人以外には which を使う",
+      "explanation": "who は人を表す先行詞に使います。"
     }
   ],
-  "advice": "全体的に良く理解できています。...",
-  "created_at": "2026-04-10T15:30:15+09:00"
+  "judged_at": "2026-04-10T15:30:15+09:00"
 }
 ```
 
@@ -326,16 +324,11 @@ LLM による正誤判定結果
 | --- | --- | --- | --- |
 | id | UUID PK | NO | 判定ID |
 | session_id | UUID FK -> sessions UNIQUE | NO | セッションID |
-| output_id | UUID FK -> outputs | NO | アウトプットID |
-| verdict | VARCHAR(20) | NO | correct / partial / incorrect |
-| score | INTEGER | YES | スコア（0-100） |
-| items | JSONB | NO | 各項目の判定結果配列 |
-| advice | TEXT | YES | 総合アドバイス |
-| llm_provider | VARCHAR(30) | NO | 使用したLLMプロバイダー |
-| llm_model | VARCHAR(50) | NO | 使用したモデル名 |
-| llm_latency_ms | INTEGER | YES | LLM API レスポンス時間 |
-| token_usage | JSONB | YES | { prompt_tokens, completion_tokens } |
-| created_at | TIMESTAMPTZ | NO | 判定実行日時 |
+| verdict | VARCHAR(16) | NO | correct / partial / incorrect / rejected |
+| score | INTEGER | NO | スコア（0-100） |
+| advice | TEXT | NO | 総合アドバイス |
+| corrections | JSONB | NO | 誤り指摘配列（target_text / correct_text / explanation） |
+| judged_at | TIMESTAMPTZ | NO | 判定実行日時 |
 
 **4.3.6. rate_limit_logs**
 
@@ -383,24 +376,30 @@ LLM による正誤判定結果
 {
   "verdict": "correct" | "partial" | "incorrect" | "rejected",
   "score": 0-100,
-  "items": [{ "claim": "...", "correct": bool, "feedback": "..." }],
-  "advice": "総合アドバイス"
+  "advice": "総合アドバイス",
+  "corrections": [
+    {
+      "target_text": "誤りを含む本文中の抜粋",
+      "correct_text": "正しい内容",
+      "explanation": "誤りの理由"
+    }
+  ]
 }
 ```
 
 #### 5.3. Pydantic バリデーション
 
 ```python
-class JudgmentItem(BaseModel):
-    claim: str
-    correct: bool
-    feedback: str = Field(max_length=500)
+class JudgmentCorrection(BaseModel):
+    target_text: str
+    correct_text: str
+    explanation: str
 
 class LLMJudgmentResponse(BaseModel):
     verdict: Literal["correct","partial","incorrect","rejected"]
     score: int = Field(ge=0, le=100)
-    items: list[JudgmentItem]
     advice: str = Field(max_length=1000)
+    corrections: list[JudgmentCorrection]
 ```
 
 #### 5.4. LLM プロバイダー抽象化
@@ -538,15 +537,20 @@ App Storeガイドラインおよび個人情報保護法に準拠し、アカ�
 ```docker
 FROM python:3.12-slim AS builder
 WORKDIR /app
-RUN pip install uv
+RUN pip install --no-cache-dir uv==0.10.2
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.12-slim AS runner
 WORKDIR /app
-COPY --from=builder /app/.venv .venv
+COPY --from=builder /app/.venv /app/.venv
 COPY src/ src/
-ENV PATH="/app/.venv/bin:$PATH"
+COPY db/ db/
+COPY alembic.ini ./
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+EXPOSE 8080
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
@@ -555,22 +559,29 @@ CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 #### 8.1. リポジトリ構成
 
 ```markdown
-pomollm/
+puttokei/
 ├── .github/
 │   └── workflows/
-│       ├── backend-ci.yml
-│       ├── backend-cd.yml
-│       ├── frontend-ci.yml
-│       └── mobile-cd.yml
+│       ├── backend-ci.yaml
+│       ├── backend-cd.yaml
+│       ├── mobile-ci.yaml
+│       └── mobile-cd.yaml
 ├── backend/
 ├── mobile/
-├── infra/
-└── docs/
+├── docs/
+├── AGENTS.md
+├── CLAUDE.md
+├── README
+├── Taskfile.yaml
+└── puttokei.code-workspace
 ```
+
+`infra/` は現時点では未作成。Terraform を追加する場合は 8.4 の構成に沿って作成する。
 
 #### 8.2. バックエンド
 
-クリーンアーキテクチャの4層構造を採用する。依存方向は domain ← application ← infrastructure / presentation
+クリーンアーキテクチャの4層構造を採用する。依存方向は domain ← application ← infrastructure / presentation。
+Use Case は Unit of Work をトランザクション境界とし、`application` に抽象 IF、`infrastructure/persistence` に SQLAlchemy 実装を置く。
 
 ```markdown
 backend/
@@ -578,39 +589,57 @@ backend/
 │   ├── main.py                        # FastAPIエントリポイント + Composition Root
 │   ├── config.py                      # 環境変数・設定 (pydantic-settings)
 │   ├── container.py                   # DI組み立て（Composition Root）
+│   ├── common/                        # layer をまたいで使う最小限の共通基底
 │   │
 │   ├── domain/                        # ドメイン層 (外部依存なし・純粋Python)
 │   │   ├── entities/
 │   │   │   ├── user.py                # User エンティティ (dataclass)
 │   │   │   ├── session.py             # Session エンティティ
 │   │   │   ├── output.py              # Output エンティティ
-│   │   │   └── judgment.py            # Judgment エンティティ
+│   │   │   ├── judgment.py            # Judgment エンティティ
+│   │   │   └── user_settings.py       # UserSettings エンティティ
 │   │   ├── value_objects/
+│   │   │   ├── age_group.py           # AgeGroup 列挙型
+│   │   │   ├── auth_provider.py       # AuthProvider 列挙型
+│   │   │   ├── judgment_result.py     # LLM 判定の中間表現
 │   │   │   ├── verdict.py             # Verdict 列挙型 (correct/partial/incorrect/rejected)
 │   │   │   └── session_status.py      # SessionStatus 列挙型
 │   │   ├── repositories/              # リポジトリインターフェース (ABC)
 │   │   │   ├── user_repository.py
 │   │   │   ├── session_repository.py
+│   │   │   ├── output_repository.py
 │   │   │   └── judgment_repository.py
 │   │   └── services/                  # ドメインサービスインターフェース (ABC)
+│   │       ├── auth_verifier.py       # 認証検証インターフェース
 │   │       └── llm_judge_service.py   # LLM判定インターフェース
 │   │
 │   ├── application/                   # アプリケーション層 (Use Cases)
+│   │   ├── unit_of_work.py            # Unit of Work IF / transaction boundary
 │   │   ├── use_cases/
+│   │   │   ├── authenticate_user.py   # Bearer token 検証 + ユーザー初期作成
 │   │   │   ├── create_session.py      # セッション作成
+│   │   │   ├── update_session_status.py # セッション状態更新
 │   │   │   ├── submit_output.py       # アウトプット送信 + 判定キューイング
 │   │   │   ├── get_judgment.py        # 判定結果取得
+│   │   │   ├── list_today_outputs.py  # 今日のアウトプット一覧
 │   │   │   ├── list_judgments.py      # 判定履歴一覧
 │   │   │   ├── get_stats.py           # 統計取得
+│   │   │   ├── get_user_profile.py    # プロフィール取得
+│   │   │   ├── update_user_profile.py # プロフィール更新
+│   │   │   ├── get_user_settings.py   # 設定取得
+│   │   │   ├── update_user_settings.py # 設定更新
 │   │   │   └── delete_account.py      # アカウント削除
 │   │   └── dto/                       # Use Case 入出力 (dataclass or BaseModel)
 │   │       ├── session_dto.py         # CreateSessionInput / SessionOutput
 │   │       ├── judgment_dto.py        # JudgmentOutput / JudgmentListOutput
-│   │       └── stats_dto.py           # StatsOutput / DailyStatsOutput
+│   │       ├── stats_dto.py           # StatsOutput / DailyStatsOutput
+│   │       ├── user_dto.py            # UserProfileOutput など
+│   │       └── user_settings_dto.py   # UserSettingsOutput など
 │   │
 │   ├── infrastructure/                # インフラ層 (外部依存の実装)
 │   │   ├── persistence/
 │   │   │   ├── database.py            # DB接続管理 (async sessionmaker)
+│   │   │   ├── unit_of_work.py        # SQLAlchemy Unit of Work 実装
 │   │   │   ├── models/                # SQLAlchemy ORMモデル
 │   │   │   │   ├── user_model.py
 │   │   │   │   ├── session_model.py
@@ -620,6 +649,7 @@ backend/
 │   │   │   └── repositories/          # リポジトリ実装 (PostgreSQL)
 │   │   │       ├── pg_user_repository.py
 │   │   │       ├── pg_session_repository.py
+│   │   │       ├── pg_output_repository.py
 │   │   │       └── pg_judgment_repository.py
 │   │   ├── llm/                       # LLMプロバイダー実装
 │   │   │   ├── gemini_provider.py
@@ -650,7 +680,10 @@ backend/
 │       ├── schemas/                   # Pydantic リクエスト/レスポンス (HTTP境界)
 │       │   ├── session_schema.py
 │       │   ├── judgment_schema.py
-│       │   └── user_schema.py
+│       │   ├── user_schema.py
+│       │   ├── user_settings_schema.py
+│       │   └── problem_schema.py
+│       ├── mappers/                   # HTTP response mapper
 │       └── middleware/
 │           ├── auth_middleware.py      # 認証ミドルウェア
 │           └── rate_limit.py          # レートリミット
@@ -659,17 +692,19 @@ backend/
 │   ├── unit/                          # domain・use case の単体テスト
 │   │   ├── test_entities/
 │   │   └── test_use_cases/
-│   ├── integration/                   # リポジトリ・LLMの結合テスト
+│   ├── integration/                   # リポジトリ・API・LLMの結合テスト
 │   │   ├── test_repositories/
 │   │   └── test_llm/
-│   └── e2e/                           # APIエンドツーエンドテスト
-│       └── test_api/
+│   ├── e2e/                           # APIエンドツーエンドテスト
+│   │   └── test_api/
+│   └── fakes/                         # Unit test 用 test double
 ├── db/
 │   └── migrations/                    # Alembicマイグレーション
 ├── Dockerfile
 ├── pyproject.toml
 ├── uv.lock
-└── alembic.ini
+├── alembic.ini
+└── docker-compose.yml
 ```
 
 #### 8.3. フロントエンド
@@ -677,31 +712,44 @@ backend/
 ```markdown
 mobile/
 ├── app/                               # Expo Router (ルーティング定義のみ)
+│   ├── _layout.tsx                    # ルートレイアウト
 │   ├── (auth)/
-│   │   ├── sign-in.tsx                # -> features/auth/screens
-│   │   └── _layout.tsx
+│   │   ├── _layout.tsx
+│   │   ├── overview.tsx               # -> features/auth/screens
+│   │   ├── tutorial-step-one.tsx      # -> features/auth/screens
+│   │   ├── tutorial-step-two.tsx      # -> features/auth/screens
+│   │   ├── tutorial-step-three.tsx    # -> features/auth/screens
+│   │   └── sign-in.tsx                # -> features/auth/screens
 │   ├── (tabs)/
+│   │   ├── _layout.tsx
 │   │   ├── index.tsx                  # -> features/session/screens
 │   │   ├── history.tsx                # -> features/history/screens
 │   │   ├── stats.tsx                  # -> features/stats/screens
-│   │   └── settings.tsx               # -> features/settings/screens
-│   ├── session/
-│   │   └── [id]/
+│   │   ├── settings.tsx               # -> features/settings/screens
+│   │   └── session/[id]/
 │   │       ├── input.tsx              # -> features/session/screens
-│   │       ├── output.tsx
-│   │       ├── break.tsx
-│   │       └── result.tsx
-│   └── _layout.tsx                    # ルートレイアウト
+│   │       ├── output.tsx             # -> features/session/screens
+│   │       ├── break.tsx              # -> features/session/screens
+│   │       └── result.tsx             # -> features/session/screens
+│   ├── history/
+│   │   └── [id].tsx                   # -> features/history/screens
+│   └── profile/
+│       ├── _layout.tsx
+│       └── edit.tsx                   # -> features/profile/screens
 │
 ├── src/
 │   ├── features/                      # 機能単位モジュール
 │   │   ├── auth/
 │   │   │   ├── screens/
-│   │   │   │   └── SignInScreen.tsx    # サインイン画面の実装
+│   │   │   │   ├── OverviewScreen.tsx
+│   │   │   │   ├── TutorialStepOneScreen.tsx
+│   │   │   │   ├── TutorialStepTwoScreen.tsx
+│   │   │   │   ├── TutorialStepThreeScreen.tsx
+│   │   │   │   └── SignInScreen.tsx
 │   │   │   ├── hooks/
 │   │   │   │   └── useAuth.ts         # 認証ロジック
 │   │   │   └── api/
-│   │   │       └── authApi.ts         # POST /auth/verify
+│   │   │       └── authApi.ts         # 認証 API client（現状は placeholder）
 │   │   │
 │   │   ├── session/
 │   │   │   ├── screens/
@@ -711,9 +759,10 @@ mobile/
 │   │   │   │   ├── BreakScreen.tsx    # 休憩フェーズ
 │   │   │   │   └── ResultScreen.tsx   # 判定結果表示
 │   │   │   ├── components/
-│   │   │   │   ├── Timer.tsx          # ポモドーロタイマー
 │   │   │   │   ├── OutputEditor.tsx   # アウトプット入力エディター
-│   │   │   │   └── JudgmentCard.tsx   # 判定結果カード
+│   │   │   │   ├── JudgmentCard.tsx   # 判定結果カード
+│   │   │   │   ├── AnnotatedOutputText.tsx
+│   │   │   │   └── SessionPhaseChrome.tsx
 │   │   │   ├── hooks/
 │   │   │   │   ├── useTimer.ts        # タイマーロジック
 │   │   │   │   └── useSession.ts      # セッション管理
@@ -726,7 +775,8 @@ mobile/
 │   │   │   ├── components/
 │   │   │   │   └── JudgmentListItem.tsx
 │   │   │   ├── hooks/
-│   │   │   │   └── useJudgments.ts    # 履歴データ取得
+│   │   │   │   ├── useJudgments.ts    # 履歴データ取得
+│   │   │   │   └── useJudgmentDetail.ts
 │   │   │   └── api/
 │   │   │       └── judgmentApi.ts
 │   │   │
@@ -734,44 +784,68 @@ mobile/
 │   │   │   ├── screens/
 │   │   │   │   └── StatsScreen.tsx    # 統計ダッシュボード
 │   │   │   ├── components/
-│   │   │   │   └── StatsChart.tsx     # 統計グラフ
+│   │   │   │   ├── PeriodSelector.tsx
+│   │   │   │   ├── StatsChart.tsx
+│   │   │   │   └── StatsSummaryCards.tsx
 │   │   │   ├── hooks/
 │   │   │   │   └── useStats.ts
 │   │   │   └── api/
 │   │   │       └── statsApi.ts
 │   │   │
-│   │   └── settings/
+│   │   ├── settings/
+│   │   │   ├── screens/
+│   │   │   │   └── SettingsScreen.tsx  # 設定画面
+│   │   │   ├── hooks/
+│   │   │   │   ├── useSettings.ts
+│   │   │   │   ├── useUpdateSettings.ts
+│   │   │   │   └── useDeleteAccount.ts
+│   │   │   └── api/
+│   │   │       └── settingsApi.ts
+│   │   │
+│   │   └── profile/
 │   │       ├── screens/
-│   │       │   └── SettingsScreen.tsx  # 設定画面
+│   │       │   └── ProfileEditScreen.tsx
 │   │       ├── hooks/
-│   │       │   └── useSettings.ts
+│   │       │   ├── useProfile.ts
+│   │       │   └── useUpdateProfile.ts
 │   │       └── api/
-│   │           └── settingsApi.ts
+│   │           └── profileApi.ts
 │   │
 │   └── shared/                        # 機能横断の共有リソース
 │       ├── components/
-│       │   ├── Button.tsx             # 共通ボタン
+│       │   ├── AuthGate.tsx
+│       │   ├── BootScreen.tsx
 │       │   ├── Card.tsx               # 共通カード
 │       │   └── LoadingIndicator.tsx
 │       ├── hooks/
 │       │   └── useNotification.ts     # プッシュ通知
 │       ├── lib/
-│       │   ├── api.ts                 # kyインスタンス + 認証フック
+│       │   ├── api.ts                 # fetch wrapper + 認証フック
 │       │   ├── firebase.ts            # Firebase初期化
-│       │   └── notifications.ts       # プッシュ通知セットアップ
+│       │   ├── notifications.ts       # プッシュ通知セットアップ
+│       │   ├── queryClient.ts         # TanStack Query client
+│       │   ├── splash.ts
+│       │   ├── devMockAuth.ts
+│       │   └── judgmentPresentation.ts
 │       ├── stores/
 │       │   ├── authStore.ts           # Zustand 認証ストア
-│       │   └── timerStore.ts          # Zustand タイマーストア
+│       │   ├── timerStore.ts          # Zustand タイマーストア
+│       │   ├── loopStore.ts
+│       │   └── tutorialStore.ts
 │       └── types/
-│           └── api.ts                 # APIレスポンス型定義
+│           ├── api.ts                 # APIレスポンス型定義
+│           ├── user.ts
+│           └── userSettings.ts
 │
-├── app.json
+├── app.json.example
 ├── eas.json
 ├── tsconfig.json
 └── package.json
 ```
 
 #### 8.4. インフラ
+
+現時点では `infra/` は未作成。作成時は以下の module / environment 構成を基準にする。
 
 ```markdown
 infra/

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,6 +1,6 @@
-# hourglass-mobile
+# Puttokei mobile
 
-Hourglass の React Native / Expo アプリ。Expo Router / TypeScript / Tamagui / Zustand / TanStack Query / Fetch API を採用。
+Puttokei の React Native / Expo アプリ。Expo Router / TypeScript / Tamagui / Zustand / TanStack Query / Fetch API を採用。
 
 ## 必要なツール
 
@@ -38,24 +38,28 @@ task mobile:install   # npm ci
 
 ルートから `task ci` を叩くと backend と mobile の両方を回せる。`task --list` で全コマンド一覧が見られる。
 
-## ディレクトリ構成
+## アーキテクチャ
 
 要件書 §8.3 に沿う構成。`app/` は Expo Router の経路定義のみとし、画面実装は `src/features` に寄せる。
+共通初期化、HTTP client、Firebase、通知、Zustand store は `src/shared` に置く。
+
+## ディレクトリ構成
 
 ```
 app/                Expo Router 経路定義のみ
 ├── _layout.tsx     ルートレイアウト（Tamagui / TanStack Query Provider）
-├── (auth)/         認証スタック
-├── (tabs)/         タブナビゲーション
-└── session/[id]/   学習セッション内の各フェーズ
+├── (auth)/         概要、チュートリアル、サインイン
+├── (tabs)/         ホーム、統計、非表示 tab route、セッション内フェーズ
+├── history/[id].tsx
+└── profile/        プロフィール編集
 
 src/
-├── features/       機能単位モジュール（auth / session / history / stats / settings）
+├── features/       機能単位モジュール（auth / session / history / stats / settings / profile）
 │   └── <feature>/{screens,components,hooks,api}/
 └── shared/         機能横断の共有リソース
-    ├── components/  Button / Card / LoadingIndicator
+    ├── components/  AuthGate / BootScreen / Card / LoadingIndicator
     ├── lib/         api (fetch wrapper) / queryClient (TanStack Query) / firebase / notifications
-    ├── stores/      authStore / timerStore (Zustand)
+    ├── stores/      authStore / timerStore / loopStore / tutorialStore (Zustand)
     ├── hooks/
     └── types/
 ```
@@ -64,6 +68,6 @@ src/
 
 `src/shared/lib/api.ts` で **fetch ベースの共通クライアント** を提供し、認証トークンは `setTokenProvider` で差し込む。Bearer トークン付与と JSON 送受信はこのラッパーに集約する。
 
-## 後続 Epic で実装するもの
+## 実装状況
 
-各 feature の screens / hooks / api は placeholder。各 Epic の Story で具体実装を追加する。
+現在は auth / session / history / stats / settings / profile の screen・hook・API client が実装済み。`history` と `stats` の mobile 側 API client は存在するが、backend 側の `/judgments` と `/stats` router はまだ公開されていないため、結合時は backend の実装状況を確認する。


### PR DESCRIPTION
## Summary
- Updated backend, mobile, and repository documentation to reflect the current implementation instead of the earlier draft architecture.
- Added the backend Unit of Work boundary and aligned the architecture rules and references with the actual `application` / `infrastructure` split.
- Refreshed API, LLM judgment, and directory structure docs to match the current routes, models, and mobile feature layout.
- Synchronized the `.codex` and `.claude` guidance files so both agent toolchains point to the same rules.

## Testing
- Not run (not requested)
- Validation was done by checking the updated documentation against the current source tree and reviewing diff consistency