### PR TITLE
Feat/delete signin moc

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -24,7 +24,7 @@ import { getAuthIdToken, useAuthStore } from '@/shared/stores/authStore';
 
 // 開発ビルド (__DEV__) では Firebase Auth の代わりに dev mock を使い、サインイン画面を
 // 経由せずに固定 UID で API を叩く。バックエンドの DEV_MOCK_AUTH_ENABLED=true と対応。
-const USE_DEV_MOCK_AUTH = __DEV__;
+const USE_DEV_MOCK_AUTH = false;
 
 export default function RootLayout() {
   useEffect(() => {

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -22,8 +22,6 @@ import { setTokenProvider, setTokenRefresher } from '@/shared/lib/api';
 import { queryClient } from '@/shared/lib/queryClient';
 import { getAuthIdToken, useAuthStore } from '@/shared/stores/authStore';
 
-// 開発ビルド (__DEV__) では Firebase Auth の代わりに dev mock を使い、サインイン画面を
-// 経由せずに固定 UID で API を叩く。バックエンドの DEV_MOCK_AUTH_ENABLED=true と対応。
 const USE_DEV_MOCK_AUTH = false;
 
 export default function RootLayout() {

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.expo/', '/dist/'],
+  testTimeout: 15000,
 };

--- a/mobile/src/features/auth/lib/signOut.ts
+++ b/mobile/src/features/auth/lib/signOut.ts
@@ -1,11 +1,24 @@
 /**
  * Firebase Auth からのサインアウト。
  *
- * `auth().signOut()` で Firebase 側のセッションを破棄し、
- * onIdTokenChanged が発火して authStore が clear される経路に委ねる。
+ * 通常は `auth().signOut()` → onIdTokenChanged 経由で authStore が clear
+ * されるが、Keychain 永続化とメモリのみの authStore がねじれて
+ * `[auth/no-current-user]` で落ちるケースがある。その場合は握りつぶし、
+ * finally で authStore を明示 clear して詰みループを断つ。
  */
 import auth from '@react-native-firebase/auth';
 
+import { useAuthStore } from '@/shared/stores/authStore';
+
 export async function signOut(): Promise<void> {
-  await auth().signOut();
+  try {
+    await auth().signOut();
+  } catch (error: unknown) {
+    const code = (error as { code?: string } | null)?.code;
+    if (code !== 'auth/no-current-user') {
+      throw error;
+    }
+  } finally {
+    useAuthStore.getState().clear();
+  }
 }


### PR DESCRIPTION
<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

appleアカウントでのログイン動作確認で発覚した問題の改善



## 関連 Issue

- Refs #32
- - Refs #33

## 変更内容

- appleログイン時にモックデータを返すようになってたのを修正

-  ログインデータの物理削除が未実装のため、初回ログイン時の動作確認をする際に、firebaseコンソールから直接ユーザー情報を削除すると、デッドロックが発生するため、それの対応

- ciのtimeout防止で制限時間を変更



### スクリーンショット / 動画

スレッドにはっつけてある
https://tut-competition.slack.com/archives/C0AAR59AE8J/p1777620526323759

## チェックリスト

- [x] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [x] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
