### PR TITLE
設定アイコンをホームとレポート画面でしか表示しないようにする

### DIFF
--- a/mobile/src/features/session/screens/BreakScreen.tsx
+++ b/mobile/src/features/session/screens/BreakScreen.tsx
@@ -6,7 +6,7 @@
  */
 import { useIsFocused } from '@react-navigation/native';
 import { useMutation } from '@tanstack/react-query';
-import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -43,7 +43,6 @@ import {
   type HourglassSandLayer,
   PhaseTabs,
   type SessionPhase,
-  SessionSettingsButton,
   useHourglassBadgeXml,
 } from '@/features/session/components/SessionPhaseChrome';
 import { DEFAULT_TIMER } from '@/features/session/config';
@@ -58,7 +57,6 @@ const BREAK_COMPLETE_CARD_IMAGE = require('../../../../assets/images/illustratio
 // 画像本体 (1329x1857) のアスペクト比。card 全体をこの比率で配置する。
 const BREAK_COMPLETE_CARD_ASPECT_RATIO = 1329 / 1857;
 
-const SETTINGS_ROUTE = '/(tabs)/settings' as unknown as Href;
 // 中央表示用の砂時計は青枠 SVG を blue variant の baseHeight/baseWidth から比率を求める。
 const NEXT_CYCLE_HOURGLASS_ASPECT_RATIO =
   HOURGLASS_VARIANTS.blue.baseHeight / HOURGLASS_VARIANTS.blue.baseWidth;
@@ -1096,11 +1094,6 @@ export function BreakScreen() {
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <View style={styles.container} testID="break-root">
-        <SessionSettingsButton
-          onPress={() => router.push(SETTINGS_ROUTE)}
-          testID="break-settings-button"
-        />
-
         <View ref={badgeStackRef} style={styles.badgeStack} onLayout={handleBadgeStackLayout}>
           <HourglassBadge
             currentLoop={displayedLoop}

--- a/mobile/src/features/session/screens/InputScreen.tsx
+++ b/mobile/src/features/session/screens/InputScreen.tsx
@@ -9,7 +9,7 @@
  * 「5分延長」の 2 ボタンを配置する。
  */
 import { useIsFocused } from '@react-navigation/native';
-import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useMemo, useState } from 'react';
 import { Alert, Pressable, SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
@@ -23,7 +23,6 @@ import {
   type HourglassSandLayer,
   PhaseTabs,
   type SessionPhase,
-  SessionSettingsButton,
 } from '@/features/session/components/SessionPhaseChrome';
 import { DEFAULT_TIMER } from '@/features/session/config';
 import { useTodayOutputs } from '@/features/session/hooks/useTodayOutputs';
@@ -33,8 +32,6 @@ import type { OutputReviewItem } from '@/features/session/types';
 import { OUTPUT_HISTORY_ROW_HEIGHT, OutputHistoryRow } from '@/shared/components/OutputHistoryRow';
 import { useLoopStore } from '@/shared/stores/loopStore';
 import { useTimerStore } from '@/shared/stores/timerStore';
-
-const SETTINGS_ROUTE = '/(tabs)/settings' as unknown as Href;
 
 const CURRENT_PHASE: SessionPhase = 'input';
 const EXTEND_MINUTES = 5;
@@ -390,11 +387,6 @@ export function InputScreen() {
       <View style={styles.container} testID="input-root">
         {isDetailVisible ? null : (
           <>
-            <SessionSettingsButton
-              onPress={() => router.push(SETTINGS_ROUTE)}
-              testID="input-settings-button"
-            />
-
             <HourglassBadge
               currentLoop={currentLoop}
               testIDPrefix="input"

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -36,7 +36,6 @@ import {
   type HourglassSandLayer,
   PhaseTabs,
   type SessionPhase,
-  SessionSettingsButton,
 } from '@/features/session/components/SessionPhaseChrome';
 import { DEFAULT_TIMER } from '@/features/session/config';
 import { useThrottledRemainingSeconds, useTimer } from '@/features/session/hooks/useTimer';
@@ -790,11 +789,6 @@ export function OutputScreen() {
           >
             {showSessionChrome ? (
               <>
-                <SessionSettingsButton
-                  onPress={() => router.push('/(tabs)/settings')}
-                  testID="output-settings-button"
-                />
-
                 <HourglassBadge
                   currentLoop={currentLoop}
                   testIDPrefix="output"

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -134,10 +134,10 @@ describe('BreakScreen', () => {
   });
 
   it('マウントで phase=break のタイマーが開始され、主要 UI が表示される', () => {
-    const { getAllByText, getByTestId } = renderWithProviders(<BreakScreen />);
+    const { getAllByText, getByTestId, queryByTestId } = renderWithProviders(<BreakScreen />);
     // 画面タイトル / フェーズタブ / タイマー中央ラベルで複数回「休憩」が出現する
     expect(getAllByText('休憩').length).toBeGreaterThan(0);
-    expect(getByTestId('break-settings-button')).toBeTruthy();
+    expect(queryByTestId('break-settings-button')).toBeNull();
     expect(getByTestId('break-progress-card')).toBeTruthy();
     expect(useTimerStore.getState().phase).toBe('break');
     expect(useTimerStore.getState().totalSeconds).toBe(60);

--- a/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
@@ -87,13 +87,14 @@ describe('InputScreen', () => {
   });
 
   it('マウント時にタイマーが start され、フェーズ表記とタイマー表示がレンダリングされる', () => {
-    const { getAllByText, getByTestId } = renderWithProviders(<InputScreen />);
+    const { getAllByText, getByTestId, queryByTestId } = renderWithProviders(<InputScreen />);
     // フェーズタブと円中央の 2 箇所に「インプット」が表示される。
     expect(getAllByText('インプット').length).toBeGreaterThanOrEqual(1);
     expect(getByTestId('timer-display')).toBeTruthy();
     expect(getByTestId('input-circular-timer')).toBeTruthy();
     expect(getByTestId('input-cancel-button')).toBeTruthy();
     expect(getByTestId('input-extend-button')).toBeTruthy();
+    expect(queryByTestId('input-settings-button')).toBeNull();
     expect(useTimerStore.getState().phase).toBe('input');
     expect(useTimerStore.getState().totalSeconds).toBe(60);
   });

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -186,10 +186,10 @@ describe('OutputScreen', () => {
   });
 
   it('マウントで phase=output のタイマーが開始され、主要 UI が表示される', () => {
-    const { getByTestId, getAllByText } = renderWithProviders(<OutputScreen />);
+    const { getByTestId, getAllByText, queryByTestId } = renderWithProviders(<OutputScreen />);
     // 画面タイトル・フェーズタブ・タイマー中央のラベルで複数回「アウトプット」が出現する
     expect(getAllByText('アウトプット').length).toBeGreaterThan(0);
-    expect(getByTestId('output-settings-button')).toBeTruthy();
+    expect(queryByTestId('output-settings-button')).toBeNull();
     expect(getByTestId('output-composer-card')).toBeTruthy();
     expect(
       StyleSheet.flatten(getByTestId('output-phase-tab-input-dot').props.style).backgroundColor,


### PR DESCRIPTION
## Summary
- `input` / `output` / `break` の各セッション画面から設定アイコンを हटし、画面上部の操作を整理しました。
- それに合わせて各画面のテストを更新し、設定ボタンが表示されないことを確認するようにしました。

## Testing
- 画面テストを更新し、`InputScreen` / `OutputScreen` / `BreakScreen` で設定ボタンが出ないことを検証。
- `mobile` の対象テストを実行し、3 スイートすべて通過。
- `mobile` の型チェックを実行し、問題なし。