### PR TITLE
fix(mobile): セッション画面の設定ボタンを確実に非表示化

### DIFF
--- a/mobile/src/features/session/components/SessionPhaseChrome.tsx
+++ b/mobile/src/features/session/components/SessionPhaseChrome.tsx
@@ -1160,10 +1160,8 @@ export function PhaseTabs({
  * 4 画面 (Home / Input / Output / Break) で共通利用する画面上部の固定 chrome。
  *
  * Home の絶対配置座標 (`top: 7.9%` / `top: 18.6%`) を 4 画面で揃えるための wrapper。
- * 設定ボタン・砂時計バッジ・PhaseTabs を SafeAreaView 配下の親 View に対して
- * 絶対配置する想定。`showHeader` が `false` のときは設定ボタンと砂時計バッジを
- * 非表示にし、PhaseTabs だけ常に表示する。`showSettingsButton` はヘッダーを維持したまま
- * 設定ボタンだけを消したい画面で使う。
+ * 砂時計バッジ・PhaseTabs を SafeAreaView 配下の親 View に対して絶対配置する想定。
+ * `showHeader` が `false` のときは砂時計バッジを非表示にし、PhaseTabs だけ常に表示する。
  *
  * 画面側のメインコンテンツは `SESSION_TOP_CHROME_CONTENT_TOP` を `top` に当てた
  * 絶対配置 View でラップして、chrome と重ならない位置から始める。
@@ -1172,11 +1170,8 @@ export const SESSION_TOP_CHROME_CONTENT_TOP = '26.1%' as const;
 
 type SessionTopChromeProps = {
   testIDPrefix: string;
-  /** 設定ボタンと砂時計バッジを表示するか。`false` でも PhaseTabs は表示される。 */
+  /** 砂時計バッジを表示するか。`false` でも PhaseTabs は表示される。 */
   showHeader?: boolean;
-  /** 設定ボタンを表示するか。 */
-  showSettingsButton?: boolean;
-  onSettingsPress?: () => void;
   hourglass: Omit<HourglassBadgeProps, 'testIDPrefix' | 'rowStyle' | 'marginBottom'>;
   phaseTabs: Omit<PhaseTabsProps, 'testIDPrefix' | 'marginBottom'>;
   /** 砂時計バッジ wrapper の View ref。Break 画面のエントランスアニメ用。 */
@@ -1187,8 +1182,6 @@ type SessionTopChromeProps = {
 export function SessionTopChrome({
   testIDPrefix,
   showHeader = true,
-  showSettingsButton = true,
-  onSettingsPress,
   hourglass,
   phaseTabs,
   hourglassWrapperRef,
@@ -1196,12 +1189,6 @@ export function SessionTopChrome({
 }: SessionTopChromeProps) {
   return (
     <>
-      {showHeader && showSettingsButton && onSettingsPress ? (
-        <SessionSettingsButton
-          onPress={onSettingsPress}
-          testID={`${testIDPrefix}-settings-button`}
-        />
-      ) : null}
       {showHeader ? (
         <View
           ref={hourglassWrapperRef}

--- a/mobile/src/features/session/screens/BreakScreen.tsx
+++ b/mobile/src/features/session/screens/BreakScreen.tsx
@@ -1096,7 +1096,6 @@ export function BreakScreen() {
       <View style={styles.container} testID="break-root">
         <SessionTopChrome
           testIDPrefix="break"
-          showSettingsButton={false}
           hourglassWrapperRef={badgeStackRef}
           onHourglassWrapperLayout={handleBadgeStackLayout}
           hourglass={{

--- a/mobile/src/features/session/screens/HomeScreen.tsx
+++ b/mobile/src/features/session/screens/HomeScreen.tsx
@@ -15,6 +15,7 @@ import { SizableText, Spinner } from 'tamagui';
 
 import {
   type SessionPhase,
+  SessionSettingsButton,
   SessionTopChrome,
 } from '@/features/session/components/SessionPhaseChrome';
 import { DEFAULT_TIMER } from '@/features/session/config';
@@ -64,9 +65,12 @@ export function HomeScreen() {
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <View style={styles.container} testID="home-root">
+        <SessionSettingsButton
+          onPress={() => router.push(SETTINGS_ROUTE)}
+          testID="home-settings-button"
+        />
         <SessionTopChrome
           testIDPrefix="home"
-          onSettingsPress={() => router.push(SETTINGS_ROUTE)}
           hourglass={{ currentLoop }}
           phaseTabs={{
             activePhase: phase,

--- a/mobile/src/features/session/screens/InputScreen.tsx
+++ b/mobile/src/features/session/screens/InputScreen.tsx
@@ -388,7 +388,6 @@ export function InputScreen() {
         <SessionTopChrome
           testIDPrefix="input"
           showHeader={!isDetailVisible}
-          showSettingsButton={false}
           hourglass={{
             currentLoop,
             borderColor: BORDER_COLOR,

--- a/mobile/src/features/session/screens/OutputScreen.tsx
+++ b/mobile/src/features/session/screens/OutputScreen.tsx
@@ -771,7 +771,6 @@ export function OutputScreen() {
       {showSessionChrome ? (
         <SessionTopChrome
           testIDPrefix="output"
-          showSettingsButton={false}
           hourglass={{
             currentLoop,
             borderColor: BORDER_COLOR,

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -134,10 +134,12 @@ describe('BreakScreen', () => {
   });
 
   it('マウントで phase=break のタイマーが開始され、主要 UI が表示される', () => {
-    const { getAllByText, getByTestId, queryByTestId } = renderWithProviders(<BreakScreen />);
+    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } =
+      renderWithProviders(<BreakScreen />);
     // 画面タイトル / フェーズタブ / タイマー中央ラベルで複数回「休憩」が出現する
     expect(getAllByText('休憩').length).toBeGreaterThan(0);
     expect(queryByTestId('break-settings-button')).toBeNull();
+    expect(queryByLabelText('設定')).toBeNull();
     expect(getByTestId('break-progress-card')).toBeTruthy();
     expect(useTimerStore.getState().phase).toBe('break');
     expect(useTimerStore.getState().totalSeconds).toBe(60);

--- a/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/HomeScreen.test.tsx
@@ -51,7 +51,9 @@ describe('HomeScreen', () => {
   });
 
   it('初期表示はインプットの時間を表示する', () => {
-    const { getByTestId } = renderWithProviders(<HomeScreen />);
+    const { getByLabelText, getByTestId } = renderWithProviders(<HomeScreen />);
+    expect(getByLabelText('設定')).toBeTruthy();
+    expect(getByTestId('home-settings-button')).toBeTruthy();
     expect(getByTestId('home-timer-text').props.children).toBe(
       `${String(DEFAULT_TIMER.input_minutes).padStart(2, '0')}:00`,
     );

--- a/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
@@ -87,7 +87,8 @@ describe('InputScreen', () => {
   });
 
   it('マウント時にタイマーが start され、フェーズ表記とタイマー表示がレンダリングされる', () => {
-    const { getAllByText, getByTestId, queryByTestId } = renderWithProviders(<InputScreen />);
+    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } =
+      renderWithProviders(<InputScreen />);
     // フェーズタブと円中央の 2 箇所に「インプット」が表示される。
     expect(getAllByText('インプット').length).toBeGreaterThanOrEqual(1);
     expect(getByTestId('timer-display')).toBeTruthy();
@@ -95,6 +96,7 @@ describe('InputScreen', () => {
     expect(getByTestId('input-cancel-button')).toBeTruthy();
     expect(getByTestId('input-extend-button')).toBeTruthy();
     expect(queryByTestId('input-settings-button')).toBeNull();
+    expect(queryByLabelText('設定')).toBeNull();
     expect(useTimerStore.getState().phase).toBe('input');
     expect(useTimerStore.getState().totalSeconds).toBe(60);
   });

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -186,10 +186,12 @@ describe('OutputScreen', () => {
   });
 
   it('マウントで phase=output のタイマーが開始され、主要 UI が表示される', () => {
-    const { getByTestId, getAllByText, queryByTestId } = renderWithProviders(<OutputScreen />);
+    const { getByTestId, getAllByText, queryByLabelText, queryByTestId } =
+      renderWithProviders(<OutputScreen />);
     // 画面タイトル・フェーズタブ・タイマー中央のラベルで複数回「アウトプット」が出現する
     expect(getAllByText('アウトプット').length).toBeGreaterThan(0);
     expect(queryByTestId('output-settings-button')).toBeNull();
+    expect(queryByLabelText('設定')).toBeNull();
     expect(getByTestId('output-composer-card')).toBeTruthy();
     expect(
       StyleSheet.flatten(getByTestId('output-phase-tab-input-dot').props.style).backgroundColor,


### PR DESCRIPTION
共通上部 chrome が設定ボタンも内包していたため、セッション画面側で非表示指定しても実機確認で残って見える余地があった。設定ボタンは HomeScreen 側でのみ直接描画し、インプット・アウトプット・休憩画面から描画経路を完全に切り離す。

<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->

## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #
- Refs #

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

-

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

-

## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

### スクリーンショット / 動画

<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [ ] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [ ] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [ ] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [ ] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
