### PR TITLE
インプット・アウトプット・休憩画面からレポート画面に飛べないようにする

### DIFF
--- a/mobile/app/(tabs)/__tests__/_layout.test.tsx
+++ b/mobile/app/(tabs)/__tests__/_layout.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react-native';
+
+import { useTimerStore, type TimerPhase } from '@/shared/stores/timerStore';
+
+import TabsLayout, { isReportTabNavigationBlocked } from '../_layout';
+
+type TabPressEvent = {
+  preventDefault: jest.Mock;
+};
+
+type MockScreenProps = {
+  name?: string;
+  listeners?: {
+    tabPress?: (event: TabPressEvent) => void;
+  };
+};
+
+const mockTabScreens: MockScreenProps[] = [];
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  const Tabs = ({ children }: { children: unknown }) =>
+    React.createElement(React.Fragment, null, children);
+
+  function Screen(props: unknown) {
+    mockTabScreens.push(props as MockScreenProps);
+    return null;
+  }
+
+  Tabs.Screen = Screen;
+
+  return { Tabs };
+});
+
+function renderStatsTabScreen() {
+  render(<TabsLayout />);
+  const statsTab = mockTabScreens.find((screen) => screen.name === 'stats');
+  if (!statsTab) {
+    throw new Error('stats tab is not registered');
+  }
+  return statsTab;
+}
+
+describe('TabsLayout', () => {
+  beforeEach(() => {
+    mockTabScreens.length = 0;
+    useTimerStore.setState({
+      phase: 'idle',
+      status: 'idle',
+      totalSeconds: 0,
+      remainingSeconds: 0,
+      completionToken: 0,
+    });
+  });
+
+  it.each<TimerPhase>(['input', 'output', 'break'])(
+    '%s フェーズ中はレポートタブ押下を抑止する',
+    (phase) => {
+      useTimerStore.setState({ phase });
+      const statsTab = renderStatsTabScreen();
+      const event = { preventDefault: jest.fn() };
+
+      statsTab.listeners?.tabPress?.(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('idle 中はレポートタブへ遷移できる', () => {
+    const statsTab = renderStatsTabScreen();
+    const event = { preventDefault: jest.fn() };
+
+    statsTab.listeners?.tabPress?.(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['idle', false],
+    ['input', true],
+    ['output', true],
+    ['break', true],
+  ] as const)('isReportTabNavigationBlocked(%s) は %s を返す', (phase, expected) => {
+    expect(isReportTabNavigationBlocked(phase)).toBe(expected);
+  });
+});

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,8 +1,14 @@
 import { Tabs } from 'expo-router';
 import { Path, Svg } from 'react-native-svg';
 
+import { useTimerStore, type TimerPhase } from '@/shared/stores/timerStore';
+
 const ACTIVE_COLOR = '#4B5CFF';
 const INACTIVE_COLOR = '#9CA3AF';
+
+export function isReportTabNavigationBlocked(phase: TimerPhase) {
+  return phase === 'input' || phase === 'output' || phase === 'break';
+}
 
 function TimerTabIcon({ color, size = 24 }: { color: string; size?: number }) {
   return (
@@ -43,6 +49,9 @@ function ReportTabIcon({ color, size = 24 }: { color: string; size?: number }) {
 }
 
 export default function TabsLayout() {
+  const timerPhase = useTimerStore((s) => s.phase);
+  const shouldBlockReportTab = isReportTabNavigationBlocked(timerPhase);
+
   return (
     <Tabs
       screenOptions={{
@@ -67,6 +76,13 @@ export default function TabsLayout() {
         options={{
           title: 'レポート',
           tabBarIcon: ({ color }) => <ReportTabIcon color={color} size={39} />,
+        }}
+        listeners={{
+          tabPress: (event) => {
+            if (shouldBlockReportTab) {
+              event.preventDefault();
+            }
+          },
         }}
       />
       <Tabs.Screen name="history" options={{ href: null }} />

--- a/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/BreakScreen.test.tsx
@@ -134,8 +134,9 @@ describe('BreakScreen', () => {
   });
 
   it('マウントで phase=break のタイマーが開始され、主要 UI が表示される', () => {
-    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } =
-      renderWithProviders(<BreakScreen />);
+    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } = renderWithProviders(
+      <BreakScreen />,
+    );
     // 画面タイトル / フェーズタブ / タイマー中央ラベルで複数回「休憩」が出現する
     expect(getAllByText('休憩').length).toBeGreaterThan(0);
     expect(queryByTestId('break-settings-button')).toBeNull();

--- a/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/InputScreen.test.tsx
@@ -87,8 +87,9 @@ describe('InputScreen', () => {
   });
 
   it('マウント時にタイマーが start され、フェーズ表記とタイマー表示がレンダリングされる', () => {
-    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } =
-      renderWithProviders(<InputScreen />);
+    const { getAllByText, getByTestId, queryByLabelText, queryByTestId } = renderWithProviders(
+      <InputScreen />,
+    );
     // フェーズタブと円中央の 2 箇所に「インプット」が表示される。
     expect(getAllByText('インプット').length).toBeGreaterThanOrEqual(1);
     expect(getByTestId('timer-display')).toBeTruthy();

--- a/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
+++ b/mobile/src/features/session/screens/__tests__/OutputScreen.test.tsx
@@ -186,8 +186,9 @@ describe('OutputScreen', () => {
   });
 
   it('マウントで phase=output のタイマーが開始され、主要 UI が表示される', () => {
-    const { getByTestId, getAllByText, queryByLabelText, queryByTestId } =
-      renderWithProviders(<OutputScreen />);
+    const { getByTestId, getAllByText, queryByLabelText, queryByTestId } = renderWithProviders(
+      <OutputScreen />,
+    );
     // 画面タイトル・フェーズタブ・タイマー中央のラベルで複数回「アウトプット」が出現する
     expect(getAllByText('アウトプット').length).toBeGreaterThan(0);
     expect(queryByTestId('output-settings-button')).toBeNull();


### PR DESCRIPTION
## Summary
- `input` / `output` / `break` フェーズ中は、タブバーのレポートアイコン押下でレポート画面へ遷移しないようにしました。
- タブレイアウト側で `tabPress` を止める実装にして、タイマー系の画面だけに影響するようにしています。
- フェーズ判定を切り出して、遷移可否の条件をテストしやすくしました。

## Testing
- `TabsLayout` の単体テストを追加し、各学習フェーズ中は `preventDefault()` されることを確認しました。
- `idle` 時は通常どおりレポートタブへ遷移できることも確認しました。
- `lint` と `typecheck` は通過しました。