### PR TITLE
タイマー利用画面でタイマーアイコンを青く表示

### DIFF
--- a/mobile/app/(tabs)/__tests__/_layout.test.tsx
+++ b/mobile/app/(tabs)/__tests__/_layout.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 
 import { useTimerStore, type TimerPhase } from '@/shared/stores/timerStore';
 
-import TabsLayout, { isReportTabNavigationBlocked } from '../_layout';
+import TabsLayout, { isReportTabNavigationBlocked, isTimerTabIconHighlighted } from '../_layout';
 
 type TabPressEvent = {
   preventDefault: jest.Mock;
@@ -10,12 +10,16 @@ type TabPressEvent = {
 
 type MockScreenProps = {
   name?: string;
+  options?: {
+    tabBarIcon?: (props: { color: string }) => unknown;
+  };
   listeners?: {
     tabPress?: (event: TabPressEvent) => void;
   };
 };
 
 const mockTabScreens: MockScreenProps[] = [];
+let mockSegments: string[] = ['(tabs)'];
 
 jest.mock('expo-router', () => {
   const React = require('react');
@@ -29,7 +33,10 @@ jest.mock('expo-router', () => {
 
   Tabs.Screen = Screen;
 
-  return { Tabs };
+  return {
+    Tabs,
+    useSegments: () => mockSegments,
+  };
 });
 
 function renderStatsTabScreen() {
@@ -41,9 +48,19 @@ function renderStatsTabScreen() {
   return { ...result, statsTab };
 }
 
+function renderTimerTabScreen() {
+  const result = render(<TabsLayout />);
+  const timerTab = mockTabScreens.find((screen) => screen.name === 'index');
+  if (!timerTab) {
+    throw new Error('timer tab is not registered');
+  }
+  return { ...result, timerTab };
+}
+
 describe('TabsLayout', () => {
   beforeEach(() => {
     mockTabScreens.length = 0;
+    mockSegments = ['(tabs)'];
     useTimerStore.setState({
       phase: 'idle',
       status: 'idle',
@@ -121,5 +138,31 @@ describe('TabsLayout', () => {
     ['break', true],
   ] as const)('isReportTabNavigationBlocked(%s) は %s を返す', (phase, expected) => {
     expect(isReportTabNavigationBlocked(phase)).toBe(expected);
+  });
+
+  it.each([
+    [['(tabs)'], true],
+    [['(tabs)', 'index'], true],
+    [['(tabs)', 'session', '[id]', 'input'], true],
+    [['(tabs)', 'session', '[id]', 'output'], true],
+    [['(tabs)', 'session', '[id]', 'break'], true],
+    [['(tabs)', 'session', '[id]', 'result'], false],
+    [['(tabs)', 'stats'], false],
+  ] as const)('isTimerTabIconHighlighted(%j) は %s を返す', (segments, expected) => {
+    expect(isTimerTabIconHighlighted(segments)).toBe(expected);
+  });
+
+  it.each([
+    ['ホーム', ['(tabs)']],
+    ['インプット', ['(tabs)', 'session', '[id]', 'input']],
+    ['アウトプット', ['(tabs)', 'session', '[id]', 'output']],
+    ['休憩', ['(tabs)', 'session', '[id]', 'break']],
+  ] as const)('%s画面ではタイマーアイコンを青にする', (_screen, segments) => {
+    mockSegments = [...segments];
+    const { timerTab } = renderTimerTabScreen();
+
+    const icon = timerTab.options?.tabBarIcon?.({ color: '#9CA3AF' });
+
+    expect((icon as { props?: { color?: string } }).props?.color).toBe('#4B5CFF');
   });
 });

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from 'expo-router';
+import { Tabs, useSegments } from 'expo-router';
 import { Fragment, useState } from 'react';
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Path, Svg } from 'react-native-svg';
@@ -7,6 +7,8 @@ import { useTimerStore, type TimerPhase } from '@/shared/stores/timerStore';
 
 const ACTIVE_COLOR = '#4B5CFF';
 const INACTIVE_COLOR = '#9CA3AF';
+const TABS_SEGMENT = '(tabs)';
+const TIMER_TAB_ACTIVE_SESSION_PHASES = new Set(['input', 'output', 'break']);
 const REPORT_BLOCKED_MESSAGE_LINES = [
   'タイマー起動中はレポート機能を見ることができ',
   'ません。休憩終了後に見ることができます。',
@@ -14,6 +16,19 @@ const REPORT_BLOCKED_MESSAGE_LINES = [
 
 export function isReportTabNavigationBlocked(phase: TimerPhase) {
   return phase === 'input' || phase === 'output' || phase === 'break';
+}
+
+export function isTimerTabIconHighlighted(segments: readonly string[]) {
+  const routeSegments = segments[0] === TABS_SEGMENT ? segments.slice(1) : segments;
+  const currentRouteSegment = routeSegments[0];
+
+  if (currentRouteSegment === undefined || currentRouteSegment === 'index') {
+    return true;
+  }
+
+  return (
+    currentRouteSegment === 'session' && TIMER_TAB_ACTIVE_SESSION_PHASES.has(routeSegments[2] ?? '')
+  );
 }
 
 function TimerTabIcon({ color, size = 24 }: { color: string; size?: number }) {
@@ -98,7 +113,9 @@ function ReportBlockedDialog({ visible, onDismiss }: { visible: boolean; onDismi
 
 export default function TabsLayout() {
   const timerPhase = useTimerStore((s) => s.phase);
+  const segments = useSegments() as string[];
   const shouldBlockReportTab = isReportTabNavigationBlocked(timerPhase);
+  const shouldHighlightTimerTabIcon = isTimerTabIconHighlighted(segments);
   const [isReportBlockedDialogVisible, setReportBlockedDialogVisible] = useState(false);
 
   return (
@@ -118,7 +135,9 @@ export default function TabsLayout() {
           name="index"
           options={{
             title: 'タイマー',
-            tabBarIcon: ({ color }) => <TimerTabIcon color={color} size={39} />,
+            tabBarIcon: ({ color }) => (
+              <TimerTabIcon color={shouldHighlightTimerTabIcon ? ACTIVE_COLOR : color} size={39} />
+            ),
           }}
         />
         <Tabs.Screen


### PR DESCRIPTION
ホーム / タイマー / セッション中（input・output・break）のときに
タイマータブのアイコンを active color で強調することで、
ユーザーが現在タイマー機能内にいることを視覚的にわかりやすくする。

<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->

## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #
- Refs #

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

-

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

-

## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

### スクリーンショット / 動画

<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [ ] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [ ] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [ ] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [ ] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
