### PR TITLE
＃52judgments の一覧・詳細 API を実装

### DIFF
--- a/backend/src/application/dto/judgment_dto.py
+++ b/backend/src/application/dto/judgment_dto.py
@@ -9,6 +9,7 @@ from src.domain.value_objects.judgment_progress import (
     JudgmentProgressStage,
     JudgmentProgressStatus,
 )
+from src.domain.value_objects.judgment_query import JudgmentSort
 from src.domain.value_objects.judgment_result import BoundingBox
 from src.domain.value_objects.verdict import Verdict
 
@@ -32,6 +33,24 @@ class JudgmentView(FrozenModel):
     advice: str
     corrections: list[JudgmentCorrectionView]
     judged_at: datetime
+
+
+class ListJudgmentsQuery(FrozenModel):
+    """判定履歴一覧の検索条件。"""
+
+    cursor: str | None = None
+    limit: int
+    verdict: Verdict | None = None
+    judged_from: datetime | None = None
+    judged_to: datetime | None = None
+    sort: JudgmentSort = JudgmentSort.JUDGED_AT_DESC
+
+
+class JudgmentListView(FrozenModel):
+    """判定履歴一覧の取得結果。"""
+
+    judgments: list[JudgmentView]
+    next_cursor: str | None
 
 
 class JudgmentPendingView(FrozenModel):

--- a/backend/src/application/use_cases/get_judgment_detail.py
+++ b/backend/src/application/use_cases/get_judgment_detail.py
@@ -1,0 +1,39 @@
+"""判定詳細取得のユースケース。"""
+
+from uuid import UUID
+
+from src.application.dto.judgment_dto import JudgmentView
+from src.application.mappers.judgment_mapper import to_judgment_view
+from src.application.unit_of_work import UnitOfWorkFactory
+from src.domain.entities.user import User
+
+
+class JudgmentNotFoundError(Exception):
+    """当該 judgment が存在しない、または別ユーザーのため参照できない。"""
+
+
+class GetJudgmentDetail:
+    """ログインユーザーが参照できる判定詳細を返す。"""
+
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: UnitOfWorkFactory,
+    ) -> None:
+        self.unit_of_work_factory = unit_of_work_factory
+
+    async def execute(
+        self,
+        current_user: User,
+        judgment_id: UUID,
+    ) -> JudgmentView:
+        async with self.unit_of_work_factory() as uow:
+            judgment = await uow.judgments.find_by_id(judgment_id)
+            if judgment is None:
+                raise JudgmentNotFoundError("judgment not found")
+
+            session = await uow.sessions.find_by_id(judgment.session_id)
+            if session is None or session.user_id != current_user.id:
+                raise JudgmentNotFoundError("judgment not found")
+
+            return to_judgment_view(judgment)

--- a/backend/src/application/use_cases/list_judgments.py
+++ b/backend/src/application/use_cases/list_judgments.py
@@ -1,4 +1,114 @@
-"""判定履歴一覧のユースケース。
+"""判定履歴一覧のユースケース。"""
 
-実装は Epic #5 で追加する。
-"""
+import base64
+import binascii
+import json
+from datetime import datetime
+from uuid import UUID
+
+from src.application.dto.judgment_dto import JudgmentListView, ListJudgmentsQuery
+from src.application.mappers.judgment_mapper import to_judgment_view
+from src.application.unit_of_work import UnitOfWorkFactory
+from src.domain.entities.user import User
+from src.domain.value_objects.judgment_query import JudgmentListCursor, JudgmentSort
+
+DEFAULT_JUDGMENT_LIST_LIMIT = 20
+MAX_JUDGMENT_LIST_LIMIT = 100
+_CURSOR_VERSION = 1
+
+
+class InvalidJudgmentCursorError(Exception):
+    """判定履歴一覧の cursor が不正。"""
+
+
+class InvalidJudgmentListFilterError(Exception):
+    """判定履歴一覧の検索条件が不正。"""
+
+
+class ListJudgments:
+    """ログインユーザーの判定履歴を一覧取得する。"""
+
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: UnitOfWorkFactory,
+    ) -> None:
+        self.unit_of_work_factory = unit_of_work_factory
+
+    async def execute(
+        self,
+        current_user: User,
+        query: ListJudgmentsQuery,
+    ) -> JudgmentListView:
+        _validate_query(query)
+        cursor = _decode_cursor(query.cursor, sort=query.sort)
+
+        async with self.unit_of_work_factory() as uow:
+            judgments, next_cursor = await uow.judgments.list_by_user(
+                user_id=current_user.id,
+                cursor=cursor,
+                limit=query.limit,
+                verdict=query.verdict,
+                judged_from=query.judged_from,
+                judged_to=query.judged_to,
+                sort=query.sort,
+            )
+
+        return JudgmentListView(
+            judgments=[to_judgment_view(judgment) for judgment in judgments],
+            next_cursor=_encode_cursor(next_cursor, sort=query.sort),
+        )
+
+
+def _validate_query(query: ListJudgmentsQuery) -> None:
+    if query.limit < 1 or query.limit > MAX_JUDGMENT_LIST_LIMIT:
+        raise InvalidJudgmentListFilterError(
+            f"limit must be between 1 and {MAX_JUDGMENT_LIST_LIMIT}"
+        )
+    judged_from = query.judged_from
+    judged_to = query.judged_to
+    if judged_from is not None and judged_to is not None and judged_from > judged_to:
+        raise InvalidJudgmentListFilterError("judged_from must be before judged_to")
+
+
+def _encode_cursor(cursor: JudgmentListCursor | None, *, sort: JudgmentSort) -> str | None:
+    if cursor is None:
+        return None
+
+    payload = {
+        "v": _CURSOR_VERSION,
+        "judged_at": cursor.judged_at.isoformat(),
+        "judgment_id": str(cursor.judgment_id),
+        "sort": sort.value,
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_cursor(raw_cursor: str | None, *, sort: JudgmentSort) -> JudgmentListCursor | None:
+    if raw_cursor is None:
+        return None
+
+    try:
+        padding = "=" * (-len(raw_cursor) % 4)
+        decoded = base64.urlsafe_b64decode((raw_cursor + padding).encode()).decode()
+        payload = json.loads(decoded)
+        if not isinstance(payload, dict):
+            raise ValueError("cursor payload must be an object")
+        if payload.get("v") != _CURSOR_VERSION:
+            raise ValueError("unsupported cursor version")
+        if payload.get("sort") != sort.value:
+            raise ValueError("cursor sort does not match request sort")
+        return JudgmentListCursor(
+            judged_at=datetime.fromisoformat(str(payload["judged_at"])),
+            judgment_id=UUID(str(payload["judgment_id"])),
+        )
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        binascii.Error,
+    ) as exc:
+        raise InvalidJudgmentCursorError("cursor is invalid") from exc

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -7,6 +7,7 @@ from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
+from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
@@ -14,6 +15,7 @@ from src.application.use_cases.get_weekly_report import GetWeeklyReport
 from src.application.use_cases.issue_output_image_upload_url import (
     IssueOutputImageUploadUrl,
 )
+from src.application.use_cases.list_judgments import ListJudgments
 from src.application.use_cases.list_today_outputs import ListTodayOutputs
 from src.application.use_cases.run_image_judgment import RunImageJudgment
 from src.application.use_cases.run_text_judgment import RunTextJudgment
@@ -56,7 +58,9 @@ class Container(BaseModel):
     run_text_judgment: RunTextJudgment | None
     run_image_judgment: RunImageJudgment | None
     get_judgment: GetJudgment
+    get_judgment_detail: GetJudgmentDetail
     get_judgment_progress: GetJudgmentProgress
+    list_judgments: ListJudgments
     list_today_outputs: ListTodayOutputs
     get_weekly_report: GetWeeklyReport
     get_daily_report: GetDailyReport
@@ -126,7 +130,9 @@ def build_container(settings: Settings) -> Container:
         run_text_judgment=run_text_judgment,
         run_image_judgment=run_image_judgment,
         get_judgment=GetJudgment(unit_of_work_factory=unit_of_work_factory),
+        get_judgment_detail=GetJudgmentDetail(unit_of_work_factory=unit_of_work_factory),
         get_judgment_progress=GetJudgmentProgress(unit_of_work_factory=unit_of_work_factory),
+        list_judgments=ListJudgments(unit_of_work_factory=unit_of_work_factory),
         list_today_outputs=ListTodayOutputs(
             unit_of_work_factory=unit_of_work_factory,
             image_storage=image_storage,

--- a/backend/src/domain/repositories/judgment_repository.py
+++ b/backend/src/domain/repositories/judgment_repository.py
@@ -5,9 +5,12 @@ Epic #4 / Epic #5 に組み込む。
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from uuid import UUID
 
 from src.domain.entities.judgment import Judgment
+from src.domain.value_objects.judgment_query import JudgmentListCursor, JudgmentSort
+from src.domain.value_objects.verdict import Verdict
 
 
 class JudgmentRepository(ABC):
@@ -29,7 +32,12 @@ class JudgmentRepository(ABC):
     async def list_by_user(
         self,
         user_id: UUID,
-        cursor: str | None,
+        cursor: JudgmentListCursor | None,
         limit: int,
-    ) -> tuple[list[Judgment], str | None]:
+        *,
+        verdict: Verdict | None = None,
+        judged_from: datetime | None = None,
+        judged_to: datetime | None = None,
+        sort: JudgmentSort = JudgmentSort.JUDGED_AT_DESC,
+    ) -> tuple[list[Judgment], JudgmentListCursor | None]:
         """ユーザー単位で判定履歴をカーソル付きで返す。"""

--- a/backend/src/domain/value_objects/judgment_query.py
+++ b/backend/src/domain/value_objects/judgment_query.py
@@ -1,0 +1,21 @@
+"""判定履歴取得で使う検索条件の値オブジェクト。"""
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from src.common.models import FrozenModel
+
+
+class JudgmentSort(str, Enum):
+    """判定履歴一覧の並び順。"""
+
+    JUDGED_AT_DESC = "judged_at_desc"
+    JUDGED_AT_ASC = "judged_at_asc"
+
+
+class JudgmentListCursor(FrozenModel):
+    """判定履歴一覧の keyset pagination カーソル。"""
+
+    judged_at: datetime
+    judgment_id: UUID

--- a/backend/src/infrastructure/persistence/repositories/pg_judgment_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_judgment_repository.py
@@ -1,16 +1,20 @@
 """Judgment リポジトリの PostgreSQL 実装。"""
 
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from src.domain.entities.judgment import Judgment, JudgmentCorrection
 from src.domain.repositories.judgment_repository import JudgmentRepository
+from src.domain.value_objects.judgment_query import JudgmentListCursor, JudgmentSort
 from src.domain.value_objects.judgment_result import BoundingBox
 from src.domain.value_objects.verdict import Verdict
 from src.infrastructure.persistence.models.judgment_model import JudgmentModel
+from src.infrastructure.persistence.models.session_model import SessionModel
 
 
 class PgJudgmentRepository(JudgmentRepository):
@@ -50,11 +54,58 @@ class PgJudgmentRepository(JudgmentRepository):
     async def list_by_user(
         self,
         user_id: UUID,
-        cursor: str | None,
+        cursor: JudgmentListCursor | None,
         limit: int,
-    ) -> tuple[list[Judgment], str | None]:
-        del user_id, cursor, limit
-        raise NotImplementedError("履歴一覧エンドポイントの Task で実装する")
+        *,
+        verdict: Verdict | None = None,
+        judged_from: datetime | None = None,
+        judged_to: datetime | None = None,
+        sort: JudgmentSort = JudgmentSort.JUDGED_AT_DESC,
+    ) -> tuple[list[Judgment], JudgmentListCursor | None]:
+        stmt = (
+            select(JudgmentModel)
+            .join(SessionModel, JudgmentModel.session_id == SessionModel.id)
+            .where(SessionModel.user_id == user_id)
+            .limit(limit + 1)
+        )
+        if verdict is not None:
+            stmt = stmt.where(JudgmentModel.verdict == verdict.value)
+        if judged_from is not None:
+            stmt = stmt.where(JudgmentModel.judged_at >= judged_from)
+        if judged_to is not None:
+            stmt = stmt.where(JudgmentModel.judged_at <= judged_to)
+        if cursor is not None:
+            stmt = stmt.where(_cursor_condition(cursor, sort=sort))
+
+        if sort is JudgmentSort.JUDGED_AT_ASC:
+            stmt = stmt.order_by(JudgmentModel.judged_at.asc(), JudgmentModel.id.asc())
+        else:
+            stmt = stmt.order_by(JudgmentModel.judged_at.desc(), JudgmentModel.id.desc())
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+        next_cursor = None
+        if len(models) > limit:
+            cursor_model = models[limit - 1]
+            next_cursor = JudgmentListCursor(
+                judged_at=cursor_model.judged_at,
+                judgment_id=cursor_model.id,
+            )
+            models = models[:limit]
+
+        return [_to_judgment(model) for model in models], next_cursor
+
+
+def _cursor_condition(cursor: JudgmentListCursor, *, sort: JudgmentSort) -> ColumnElement[bool]:
+    if sort is JudgmentSort.JUDGED_AT_ASC:
+        return or_(
+            JudgmentModel.judged_at > cursor.judged_at,
+            (JudgmentModel.judged_at == cursor.judged_at) & (JudgmentModel.id > cursor.judgment_id),
+        )
+    return or_(
+        JudgmentModel.judged_at < cursor.judged_at,
+        (JudgmentModel.judged_at == cursor.judged_at) & (JudgmentModel.id < cursor.judgment_id),
+    )
 
 
 def _correction_to_jsonb(correction: JudgmentCorrection) -> dict[str, Any]:

--- a/backend/src/presentation/api/v1/judgments.py
+++ b/backend/src/presentation/api/v1/judgments.py
@@ -1,5 +1,101 @@
-"""判定エンドポイント。Epic #5 で実装する。
+"""判定履歴エンドポイント。
 
 - GET /api/v1/judgments
 - GET /api/v1/judgments/{id}
 """
+
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request, status
+
+from src.application.dto.judgment_dto import ListJudgmentsQuery
+from src.application.use_cases.get_judgment_detail import JudgmentNotFoundError
+from src.application.use_cases.list_judgments import (
+    DEFAULT_JUDGMENT_LIST_LIMIT,
+    MAX_JUDGMENT_LIST_LIMIT,
+    InvalidJudgmentCursorError,
+    InvalidJudgmentListFilterError,
+)
+from src.domain.entities.user import User
+from src.domain.value_objects.judgment_query import JudgmentSort
+from src.domain.value_objects.verdict import Verdict
+from src.presentation.container_access import get_presentation_container
+from src.presentation.mappers.response_mapper import (
+    to_judgment_detail_response,
+    to_judgment_list_response,
+)
+from src.presentation.middleware.auth_middleware import get_current_user
+from src.presentation.problem_details import ProblemDetailsError
+from src.presentation.schemas.judgment_schema import (
+    JudgmentDetailResponse,
+    JudgmentListResponse,
+)
+
+judgments_router = APIRouter(prefix="/judgments", tags=["judgments"])
+
+
+@judgments_router.get("", response_model=JudgmentListResponse)
+async def list_judgments(
+    request: Request,
+    current_user: Annotated[User, Depends(get_current_user)],
+    cursor: Annotated[str | None, Query()] = None,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_JUDGMENT_LIST_LIMIT),
+    ] = DEFAULT_JUDGMENT_LIST_LIMIT,
+    verdict: Annotated[Verdict | None, Query()] = None,
+    judged_from: Annotated[datetime | None, Query()] = None,
+    judged_to: Annotated[datetime | None, Query()] = None,
+    sort: Annotated[JudgmentSort, Query()] = JudgmentSort.JUDGED_AT_DESC,
+) -> JudgmentListResponse:
+    """判定履歴一覧を filter / sort / pagination 付きで取得する。"""
+    container = get_presentation_container(request)
+    query = ListJudgmentsQuery(
+        cursor=cursor,
+        limit=limit,
+        verdict=verdict,
+        judged_from=judged_from,
+        judged_to=judged_to,
+        sort=sort,
+    )
+    try:
+        view = await container.list_judgments.execute(current_user, query)
+    except InvalidJudgmentCursorError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            problem_type="invalid_cursor",
+            title="Invalid Cursor",
+            detail="cursor が不正です。",
+        ) from exc
+    except InvalidJudgmentListFilterError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            problem_type="invalid_judgment_filter",
+            title="Invalid Judgment Filter",
+            detail=str(exc),
+        ) from exc
+
+    return to_judgment_list_response(view)
+
+
+@judgments_router.get("/{judgment_id}", response_model=JudgmentDetailResponse)
+async def get_judgment_detail(
+    request: Request,
+    current_user: Annotated[User, Depends(get_current_user)],
+    judgment_id: UUID,
+) -> JudgmentDetailResponse:
+    """判定 ID から判定詳細を取得する。"""
+    container = get_presentation_container(request)
+    try:
+        view = await container.get_judgment_detail.execute(current_user, judgment_id)
+    except JudgmentNotFoundError as exc:
+        raise ProblemDetailsError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            problem_type="judgment_not_found",
+            title="Judgment Not Found",
+            detail="指定された判定が見つかりません。",
+        ) from exc
+
+    return to_judgment_detail_response(view)

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -6,6 +6,7 @@
 from fastapi import APIRouter
 
 from src.presentation.api.v1.auth import auth_router
+from src.presentation.api.v1.judgments import judgments_router
 from src.presentation.api.v1.sessions import sessions_router
 from src.presentation.api.v1.stats import stats_router
 from src.presentation.api.v1.users import users_router
@@ -14,4 +15,5 @@ api_v1_router = APIRouter()
 api_v1_router.include_router(auth_router)
 api_v1_router.include_router(users_router)
 api_v1_router.include_router(sessions_router)
+api_v1_router.include_router(judgments_router)
 api_v1_router.include_router(stats_router)

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -10,6 +10,7 @@ from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
+from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
@@ -17,6 +18,7 @@ from src.application.use_cases.get_weekly_report import GetWeeklyReport
 from src.application.use_cases.issue_output_image_upload_url import (
     IssueOutputImageUploadUrl,
 )
+from src.application.use_cases.list_judgments import ListJudgments
 from src.application.use_cases.list_today_outputs import ListTodayOutputs
 from src.application.use_cases.run_image_judgment import RunImageJudgment
 from src.application.use_cases.run_text_judgment import RunTextJudgment
@@ -53,7 +55,9 @@ class PresentationContainer(ABC):
     run_text_judgment: RunTextJudgment | None
     run_image_judgment: RunImageJudgment | None
     get_judgment: GetJudgment
+    get_judgment_detail: GetJudgmentDetail
     get_judgment_progress: GetJudgmentProgress
+    list_judgments: ListJudgments
     list_today_outputs: ListTodayOutputs
     get_weekly_report: GetWeeklyReport
     get_daily_report: GetDailyReport

--- a/backend/src/presentation/mappers/response_mapper.py
+++ b/backend/src/presentation/mappers/response_mapper.py
@@ -1,6 +1,7 @@
 """Application DTO を HTTP response schema に変換する。"""
 
 from src.application.dto.judgment_dto import (
+    JudgmentListView,
     JudgmentPendingView,
     JudgmentProgressView,
     JudgmentView,
@@ -16,6 +17,8 @@ from src.application.dto.user_dto import UserProfileView
 from src.application.dto.user_settings_dto import UserSettingsView
 from src.presentation.schemas.judgment_schema import (
     JudgmentCorrectionResponse,
+    JudgmentDetailResponse,
+    JudgmentListResponse,
     JudgmentPendingResponse,
     JudgmentProgressResponse,
     JudgmentResponse,
@@ -214,3 +217,14 @@ def to_judgment_response(view: JudgmentView) -> JudgmentResponse:
         ],
         judged_at=view.judged_at,
     )
+
+
+def to_judgment_list_response(view: JudgmentListView) -> JudgmentListResponse:
+    return JudgmentListResponse(
+        judgments=[to_judgment_response(judgment) for judgment in view.judgments],
+        next_cursor=view.next_cursor,
+    )
+
+
+def to_judgment_detail_response(view: JudgmentView) -> JudgmentDetailResponse:
+    return JudgmentDetailResponse(judgment=to_judgment_response(view))

--- a/backend/src/presentation/schemas/judgment_schema.py
+++ b/backend/src/presentation/schemas/judgment_schema.py
@@ -38,6 +38,19 @@ class JudgmentResponse(FrozenModel):
     judged_at: datetime
 
 
+class JudgmentListResponse(FrozenModel):
+    """判定履歴一覧レスポンス。"""
+
+    judgments: list[JudgmentResponse]
+    next_cursor: str | None
+
+
+class JudgmentDetailResponse(FrozenModel):
+    """判定詳細レスポンス。"""
+
+    judgment: JudgmentResponse
+
+
 class JudgmentPendingResponse(FrozenModel):
     """判定未完了レスポンス。"""
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,10 +19,12 @@ from src.application.use_cases.create_session import CreateSession
 from src.application.use_cases.delete_account import DeleteAccount
 from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
+from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.get_weekly_report import GetWeeklyReport
+from src.application.use_cases.list_judgments import ListJudgments
 from src.application.use_cases.list_today_outputs import ListTodayOutputs
 from src.application.use_cases.submit_image_output import SubmitImageOutput
 from src.application.use_cases.submit_text_output import SubmitTextOutput
@@ -126,7 +128,9 @@ def container(
         run_text_judgment=None,
         run_image_judgment=None,
         get_judgment=GetJudgment(unit_of_work_factory=unit_of_work_factory),
+        get_judgment_detail=GetJudgmentDetail(unit_of_work_factory=unit_of_work_factory),
         get_judgment_progress=GetJudgmentProgress(unit_of_work_factory=unit_of_work_factory),
+        list_judgments=ListJudgments(unit_of_work_factory=unit_of_work_factory),
         list_today_outputs=ListTodayOutputs(unit_of_work_factory=unit_of_work_factory),
         get_weekly_report=GetWeeklyReport(unit_of_work_factory=unit_of_work_factory),
         get_daily_report=GetDailyReport(unit_of_work_factory=unit_of_work_factory),

--- a/backend/tests/fakes/fake_judgment_repository.py
+++ b/backend/tests/fakes/fake_judgment_repository.py
@@ -1,9 +1,18 @@
 """インメモリな JudgmentRepository 実装。"""
 
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from src.domain.entities.judgment import Judgment
 from src.domain.repositories.judgment_repository import JudgmentRepository
+from src.domain.value_objects.judgment_query import JudgmentListCursor, JudgmentSort
+from src.domain.value_objects.verdict import Verdict
+
+if TYPE_CHECKING:
+    from tests.fakes.fake_session_repository import FakeSessionRepository
 
 
 class FakeJudgmentRepository(JudgmentRepository):
@@ -12,6 +21,10 @@ class FakeJudgmentRepository(JudgmentRepository):
     def __init__(self) -> None:
         self.judgments_by_id: dict[UUID, Judgment] = {}
         self.judgments_by_session_id: dict[UUID, Judgment] = {}
+        self._sessions: FakeSessionRepository | None = None
+
+    def bind_sessions(self, sessions: FakeSessionRepository) -> None:
+        self._sessions = sessions
 
     async def add(self, judgment: Judgment) -> None:
         self.judgments_by_id[judgment.id] = judgment
@@ -25,9 +38,62 @@ class FakeJudgmentRepository(JudgmentRepository):
 
     async def list_by_user(
         self,
-        user_id: UUID,  # noqa: ARG002
-        cursor: str | None,  # noqa: ARG002
+        user_id: UUID,
+        cursor: JudgmentListCursor | None,
         limit: int,
-    ) -> tuple[list[Judgment], str | None]:
-        items = list(self.judgments_by_id.values())
-        return items[:limit], None
+        *,
+        verdict: Verdict | None = None,
+        judged_from: datetime | None = None,
+        judged_to: datetime | None = None,
+        sort: JudgmentSort = JudgmentSort.JUDGED_AT_DESC,
+    ) -> tuple[list[Judgment], JudgmentListCursor | None]:
+        items = [
+            judgment
+            for judgment in self.judgments_by_id.values()
+            if self._belongs_to_user(judgment, user_id)
+        ]
+        if verdict is not None:
+            items = [judgment for judgment in items if judgment.verdict is verdict]
+        if judged_from is not None:
+            items = [judgment for judgment in items if judgment.judged_at >= judged_from]
+        if judged_to is not None:
+            items = [judgment for judgment in items if judgment.judged_at <= judged_to]
+        if cursor is not None:
+            items = [
+                judgment
+                for judgment in items
+                if _is_after_cursor(judgment, cursor=cursor, sort=sort)
+            ]
+
+        reverse = sort is JudgmentSort.JUDGED_AT_DESC
+        items.sort(key=lambda judgment: (judgment.judged_at, judgment.id.int), reverse=reverse)
+
+        next_cursor = None
+        if len(items) > limit:
+            cursor_item = items[limit - 1]
+            next_cursor = JudgmentListCursor(
+                judged_at=cursor_item.judged_at,
+                judgment_id=cursor_item.id,
+            )
+            items = items[:limit]
+
+        return items, next_cursor
+
+    def _belongs_to_user(self, judgment: Judgment, user_id: UUID) -> bool:
+        if self._sessions is None:
+            return True
+        session = self._sessions.sessions.get(judgment.session_id)
+        return session is not None and session.user_id == user_id
+
+
+def _is_after_cursor(
+    judgment: Judgment,
+    *,
+    cursor: JudgmentListCursor,
+    sort: JudgmentSort,
+) -> bool:
+    judgment_key = (judgment.judged_at, judgment.id.int)
+    cursor_key = (cursor.judged_at, cursor.judgment_id.int)
+    if sort is JudgmentSort.JUDGED_AT_ASC:
+        return judgment_key > cursor_key
+    return judgment_key < cursor_key

--- a/backend/tests/fakes/fake_unit_of_work.py
+++ b/backend/tests/fakes/fake_unit_of_work.py
@@ -30,6 +30,7 @@ class FakeUnitOfWork(ApplicationUnitOfWork):
         self.outputs = outputs or FakeOutputRepository()
         self.judgments = judgments or FakeJudgmentRepository()
         self.judgment_progresses = judgment_progresses or FakeJudgmentProgressRepository()
+        self.judgments.bind_sessions(self.sessions)
         self.commit_count = 0
         self.rollback_count = 0
         self.enter_count = 0

--- a/backend/tests/integration/test_api_judgments.py
+++ b/backend/tests/integration/test_api_judgments.py
@@ -1,0 +1,287 @@
+"""`/api/v1/judgments` の API integration test。"""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from src.domain.entities.judgment import Judgment, JudgmentCorrection
+from src.domain.value_objects.verdict import Verdict
+from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
+
+
+def _valid_session_body() -> dict[str, object]:
+    return {
+        "subject": "英語",
+        "topic": "関係代名詞",
+        "input_minutes": 20,
+        "output_minutes": 5,
+        "break_minutes": 5,
+    }
+
+
+async def _create_session(client: AsyncClient, auth_uid: str) -> str:
+    response = await client.post(
+        "/api/v1/sessions",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        json=_valid_session_body(),
+    )
+    assert response.status_code == 201
+    return str(response.json()["id"])
+
+
+async def _add_judgment(
+    judgments: FakeJudgmentRepository,
+    *,
+    session_id: str,
+    verdict: Verdict,
+    score: int,
+    judged_at: datetime,
+    advice: str = "保存済みの判定結果です。",
+) -> UUID:
+    judgment_id = uuid4()
+    await judgments.add(
+        Judgment(
+            id=judgment_id,
+            session_id=UUID(session_id),
+            verdict=verdict,
+            score=score,
+            advice=advice,
+            corrections=[
+                JudgmentCorrection(
+                    target_text="whoは人以外にも使える",
+                    correct_text="who は人に対して使い、人以外には which を使う",
+                    explanation="who は人を表す先行詞に使います。",
+                )
+            ],
+            judged_at=judged_at,
+        )
+    )
+    return judgment_id
+
+
+def _assert_problem_details(
+    body: dict[str, object],
+    *,
+    expected_status: int,
+    expected_type: str,
+) -> None:
+    assert body["status"] == expected_status
+    assert body["type"] == expected_type
+    assert body["title"]
+    assert body["instance"]
+
+
+@pytest.mark.asyncio
+async def test_list_judgments_returns_authenticated_users_items_sorted_desc(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    owner_auth = "judgment-list-owner"
+    old_session_id = await _create_session(client, owner_auth)
+    latest_session_id = await _create_session(client, owner_auth)
+    other_session_id = await _create_session(client, "judgment-list-other")
+
+    old_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=old_session_id,
+        verdict=Verdict.PARTIAL,
+        score=72,
+        judged_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+    )
+    latest_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=latest_session_id,
+        verdict=Verdict.CORRECT,
+        score=96,
+        judged_at=datetime(2026, 5, 2, 9, 0, tzinfo=UTC),
+    )
+    await _add_judgment(
+        fake_judgment_repository,
+        session_id=other_session_id,
+        verdict=Verdict.INCORRECT,
+        score=30,
+        judged_at=datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
+    )
+
+    response = await client.get(
+        "/api/v1/judgments",
+        headers={"Authorization": f"Bearer {owner_auth}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["id"] for item in body["judgments"]] == [str(latest_id), str(old_id)]
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_judgments_filters_verdict_and_date_then_sorts_asc(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    auth_uid = "judgment-filter-owner"
+    first_session_id = await _create_session(client, auth_uid)
+    second_session_id = await _create_session(client, auth_uid)
+    ignored_verdict_session_id = await _create_session(client, auth_uid)
+    ignored_date_session_id = await _create_session(client, auth_uid)
+
+    first_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=first_session_id,
+        verdict=Verdict.PARTIAL,
+        score=70,
+        judged_at=datetime(2026, 5, 2, 9, 0, tzinfo=UTC),
+    )
+    second_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=second_session_id,
+        verdict=Verdict.PARTIAL,
+        score=82,
+        judged_at=datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
+    )
+    await _add_judgment(
+        fake_judgment_repository,
+        session_id=ignored_verdict_session_id,
+        verdict=Verdict.CORRECT,
+        score=100,
+        judged_at=datetime(2026, 5, 2, 12, 0, tzinfo=UTC),
+    )
+    await _add_judgment(
+        fake_judgment_repository,
+        session_id=ignored_date_session_id,
+        verdict=Verdict.PARTIAL,
+        score=65,
+        judged_at=datetime(2026, 5, 5, 9, 0, tzinfo=UTC),
+    )
+
+    response = await client.get(
+        "/api/v1/judgments",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        params={
+            "verdict": "partial",
+            "judged_from": "2026-05-02T00:00:00+00:00",
+            "judged_to": "2026-05-04T00:00:00+00:00",
+            "sort": "judged_at_asc",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["id"] for item in body["judgments"]] == [str(first_id), str(second_id)]
+
+
+@pytest.mark.asyncio
+async def test_list_judgments_paginates_with_next_cursor(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    auth_uid = "judgment-pagination-owner"
+    session_ids = [await _create_session(client, auth_uid) for _ in range(3)]
+    judgment_ids = []
+    for index, session_id in enumerate(session_ids, start=1):
+        judgment_ids.append(
+            await _add_judgment(
+                fake_judgment_repository,
+                session_id=session_id,
+                verdict=Verdict.PARTIAL,
+                score=60 + index,
+                judged_at=datetime(2026, 5, index, 9, 0, tzinfo=UTC),
+            )
+        )
+
+    first_response = await client.get(
+        "/api/v1/judgments",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        params={"limit": "2"},
+    )
+
+    assert first_response.status_code == 200
+    first_body = first_response.json()
+    assert [item["id"] for item in first_body["judgments"]] == [
+        str(judgment_ids[2]),
+        str(judgment_ids[1]),
+    ]
+    assert first_body["next_cursor"]
+
+    second_response = await client.get(
+        "/api/v1/judgments",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+        params={"limit": "2", "cursor": first_body["next_cursor"]},
+    )
+
+    assert second_response.status_code == 200
+    second_body = second_response.json()
+    assert [item["id"] for item in second_body["judgments"]] == [str(judgment_ids[0])]
+    assert second_body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_judgments_rejects_invalid_cursor(client: AsyncClient):
+    response = await client.get(
+        "/api/v1/judgments",
+        headers={"Authorization": "Bearer judgment-invalid-cursor"},
+        params={"cursor": "not-a-cursor"},
+    )
+
+    assert response.status_code == 400
+    _assert_problem_details(
+        response.json(),
+        expected_status=400,
+        expected_type="invalid_cursor",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_detail_returns_wrapped_judgment(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    auth_uid = "judgment-detail-owner"
+    session_id = await _create_session(client, auth_uid)
+    judgment_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=session_id,
+        verdict=Verdict.CORRECT,
+        score=95,
+        judged_at=datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
+    )
+
+    response = await client.get(
+        f"/api/v1/judgments/{judgment_id}",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["judgment"]["id"] == str(judgment_id)
+    assert body["judgment"]["score"] == 95
+
+
+@pytest.mark.asyncio
+async def test_get_judgment_detail_returns_404_for_other_user(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    owner_auth = "judgment-detail-owner-private"
+    session_id = await _create_session(client, owner_auth)
+    judgment_id = await _add_judgment(
+        fake_judgment_repository,
+        session_id=session_id,
+        verdict=Verdict.PARTIAL,
+        score=72,
+        judged_at=datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
+    )
+
+    response = await client.get(
+        f"/api/v1/judgments/{judgment_id}",
+        headers={"Authorization": "Bearer judgment-detail-other"},
+    )
+
+    assert response.status_code == 404
+    _assert_problem_details(
+        response.json(),
+        expected_status=404,
+        expected_type="judgment_not_found",
+    )


### PR DESCRIPTION
<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要
前回の振り返りとして、採点結果を見れるようにした。また、詳細なAPIを実装した


<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->

## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #52 
- Refs #5 

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->
-
GET /api/v1/judgments を追加してcursor / limit / verdict / judged_from / judged_to / sort を実装した
GET /api/v1/judgments/{judgment_id} を追加して{ judgment } 形式で値を返すようにした
sessions と join して current_user.id でフィルターしたので、他ユーザーの判定履歴は取得できないようにした
router / schema / mapper / DI / fake repository / integration test を接続sした。
テストファイルを実装した網羅に関しては下に記述
　GET /api/v1/judgments がログインユーザー本人の判定だけ返すこと
　一覧がデフォルトで judged_at 降順になること
　他ユーザーの判定が一覧に混ざらないこと
　verdict で filter できること
　judged_from / judged_to で日付範囲 filter できること
　sort=judged_at_asc で昇順取得できること
　limit と next_cursor による pagination が動くこと
　不正な cursor は 400 invalid_cursor になること
　GET /api/v1/judgments/{id} が { judgment } 形式で詳細を返すこと
　他ユーザーの判定詳細は 404 judgment_not_found になること

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

-

## 動作確認
uv run ruff check
uv run ruff format --check
uv run python -c 'from importlinter.cli import lint_imports_command; lint_imports_command()'
uv run ty check
uv run python -m pytest
結果: 141 passed

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

### スクリーンショット / 動画
ビフォー
<img width="1170" height="2532" alt="IMG_0023" src="https://github.com/user-attachments/assets/7a3ae234-c785-4d05-982e-aa6fe1261238" />
<img width="1170" height="2532" alt="IMG_0022 2" src="https://github.com/user-attachments/assets/e53a8b9f-a6a0-49df-80e6-1a3cb5657d3e" />
アフター
<img width="1170" height="2532" alt="IMG_0025" src="https://github.com/user-attachments/assets/1ccc1c1b-3c4c-4bac-b3ca-d9c17f3ca08c" />
<img width="1170" height="2532" alt="IMG_0024" src="https://github.com/user-attachments/assets/436bd8b9-215b-4801-a2cb-7d4dd30614a5" />
<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [x] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [x] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
