### PR TITLE
Feature/54 stats summary daily weekly monthly api　統計集計 API とレポート画面の日付遷移を追加

### DIFF
--- a/backend/src/application/dto/stats_dto.py
+++ b/backend/src/application/dto/stats_dto.py
@@ -4,6 +4,37 @@ from datetime import date
 
 from src.application.dto.session_dto import OutputReviewItemView
 from src.common.models import FrozenModel
+from src.domain.value_objects.stats_period import StatsPeriod
+
+
+class StatsSummaryView(FrozenModel):
+    """代表指標のサマリー。"""
+
+    total_sessions: int
+    total_study_minutes: int
+    correct_rate: float
+    streak_days: int
+    period: StatsPeriod
+    from_date: date
+    to_date: date
+
+
+class StatsDataPointView(FrozenModel):
+    """期間別統計の 1 点。"""
+
+    bucket: str
+    label: str
+    sessions: int
+    study_minutes: int
+    correct_rate: float
+
+
+class StatsPeriodView(FrozenModel):
+    """日 / 週 / 月単位の統計レスポンス。"""
+
+    period: StatsPeriod
+    points: list[StatsDataPointView]
+    summary: StatsSummaryView
 
 
 class WeeklyReportSummaryView(FrozenModel):

--- a/backend/src/application/unit_of_work.py
+++ b/backend/src/application/unit_of_work.py
@@ -13,6 +13,7 @@ from src.domain.repositories.judgment_progress_repository import (
 from src.domain.repositories.judgment_repository import JudgmentRepository
 from src.domain.repositories.output_repository import OutputRepository
 from src.domain.repositories.session_repository import SessionRepository
+from src.domain.repositories.stats_repository import StatsRepository
 from src.domain.repositories.study_subject_repository import StudySubjectRepository
 from src.domain.repositories.user_repository import UserRepository
 
@@ -26,6 +27,7 @@ class ApplicationUnitOfWork(ABC):
     study_subjects: StudySubjectRepository
     judgments: JudgmentRepository
     judgment_progresses: JudgmentProgressRepository
+    stats: StatsRepository
 
     @abstractmethod
     async def __aenter__(self) -> Self:

--- a/backend/src/application/use_cases/get_stats.py
+++ b/backend/src/application/use_cases/get_stats.py
@@ -1,4 +1,241 @@
-"""統計取得のユースケース。
+"""統計取得のユースケース。"""
 
-実装は Epic #5 で追加する。
-"""
+from collections import defaultdict
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from src.application.dto.stats_dto import (
+    StatsDataPointView,
+    StatsPeriodView,
+    StatsSummaryView,
+)
+from src.application.unit_of_work import UnitOfWorkFactory
+from src.domain.entities.user import User
+from src.domain.repositories.stats_repository import StatsAggregationRow
+from src.domain.value_objects.stats_period import StatsPeriod
+from src.domain.value_objects.verdict import Verdict
+
+_DEFAULT_TIMEZONE = ZoneInfo("Asia/Tokyo")
+
+
+class GetStatsSummary:
+    """認証済みユーザーの全期間サマリーを返す。"""
+
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: UnitOfWorkFactory,
+        timezone: ZoneInfo = _DEFAULT_TIMEZONE,
+    ) -> None:
+        self.unit_of_work_factory = unit_of_work_factory
+        self.timezone = timezone
+
+    async def execute(self, current_user: User) -> StatsSummaryView:
+        async with self.unit_of_work_factory() as uow:
+            rows = await uow.stats.list_aggregation_rows(user_id=current_user.id)
+
+        bounds = _summary_bounds(rows, timezone=self.timezone)
+        return _build_summary(
+            rows,
+            period=StatsPeriod.DAILY,
+            from_date=bounds[0],
+            to_date=bounds[1],
+            timezone=self.timezone,
+        )
+
+
+class GetStatsPeriod:
+    """認証済みユーザーの期間別統計を返す。"""
+
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: UnitOfWorkFactory,
+        timezone: ZoneInfo = _DEFAULT_TIMEZONE,
+    ) -> None:
+        self.unit_of_work_factory = unit_of_work_factory
+        self.timezone = timezone
+
+    async def execute(self, current_user: User, period: StatsPeriod) -> StatsPeriodView:
+        async with self.unit_of_work_factory() as uow:
+            rows = await uow.stats.list_aggregation_rows(user_id=current_user.id)
+
+        points = _build_points(rows, period=period, timezone=self.timezone)
+        from_date, to_date = _period_bounds(points, period=period, timezone=self.timezone)
+        return StatsPeriodView(
+            period=period,
+            points=points,
+            summary=_build_summary(
+                rows,
+                period=period,
+                from_date=from_date,
+                to_date=to_date,
+                timezone=self.timezone,
+            ),
+        )
+
+
+def _build_summary(
+    rows: list[StatsAggregationRow],
+    *,
+    period: StatsPeriod,
+    from_date: date,
+    to_date: date,
+    timezone: ZoneInfo,
+) -> StatsSummaryView:
+    total_sessions = len(rows)
+    total_study_minutes = sum(row.input_minutes + row.output_minutes for row in rows)
+    judged_count = sum(1 for row in rows if row.verdict is not None)
+    correct_count = sum(1 for row in rows if row.verdict is Verdict.CORRECT)
+    correct_rate = correct_count / judged_count if judged_count > 0 else 0.0
+    active_dates = {
+        _as_aware_datetime(row.submitted_at).astimezone(timezone).date() for row in rows
+    }
+    return StatsSummaryView(
+        total_sessions=total_sessions,
+        total_study_minutes=total_study_minutes,
+        correct_rate=correct_rate,
+        streak_days=_count_streak_days(active_dates),
+        period=period,
+        from_date=from_date,
+        to_date=to_date,
+    )
+
+
+def _build_points(
+    rows: list[StatsAggregationRow],
+    *,
+    period: StatsPeriod,
+    timezone: ZoneInfo,
+) -> list[StatsDataPointView]:
+    if not rows:
+        current = datetime.now(UTC).astimezone(timezone).date()
+        bucket = _bucket_start(current, period)
+        return [_build_point(bucket, [], period=period)]
+
+    rows_by_bucket: dict[date, list[StatsAggregationRow]] = defaultdict(list)
+    for row in rows:
+        submitted_date = _as_aware_datetime(row.submitted_at).astimezone(timezone).date()
+        rows_by_bucket[_bucket_start(submitted_date, period)].append(row)
+
+    start = min(rows_by_bucket)
+    end = max(rows_by_bucket)
+    buckets = _iter_buckets(start, end, period)
+    return [
+        _build_point(bucket, rows_by_bucket.get(bucket, []), period=period) for bucket in buckets
+    ]
+
+
+def _build_point(
+    bucket: date,
+    rows: list[StatsAggregationRow],
+    *,
+    period: StatsPeriod,
+) -> StatsDataPointView:
+    judged_count = sum(1 for row in rows if row.verdict is not None)
+    correct_count = sum(1 for row in rows if row.verdict is Verdict.CORRECT)
+    correct_rate = correct_count / judged_count if judged_count > 0 else 0.0
+    return StatsDataPointView(
+        bucket=_bucket_key(bucket, period),
+        label=_bucket_label(bucket, period),
+        sessions=len(rows),
+        study_minutes=sum(row.input_minutes + row.output_minutes for row in rows),
+        correct_rate=correct_rate,
+    )
+
+
+def _summary_bounds(rows: list[StatsAggregationRow], *, timezone: ZoneInfo) -> tuple[date, date]:
+    if not rows:
+        current = datetime.now(UTC).astimezone(timezone).date()
+        return current, current
+    dates = [_as_aware_datetime(row.submitted_at).astimezone(timezone).date() for row in rows]
+    return min(dates), max(dates)
+
+
+def _period_bounds(
+    points: list[StatsDataPointView],
+    *,
+    period: StatsPeriod,
+    timezone: ZoneInfo,
+) -> tuple[date, date]:
+    if not points:
+        current = datetime.now(UTC).astimezone(timezone).date()
+        return current, current
+    start = _parse_bucket_key(points[0].bucket, period)
+    end = _bucket_end(_parse_bucket_key(points[-1].bucket, period), period)
+    return start, end
+
+
+def _bucket_start(value: date, period: StatsPeriod) -> date:
+    if period is StatsPeriod.WEEKLY:
+        days_since_sunday = (value.weekday() + 1) % 7
+        return value - timedelta(days=days_since_sunday)
+    if period is StatsPeriod.MONTHLY:
+        return value.replace(day=1)
+    return value
+
+
+def _bucket_end(value: date, period: StatsPeriod) -> date:
+    if period is StatsPeriod.WEEKLY:
+        return value + timedelta(days=6)
+    if period is StatsPeriod.MONTHLY:
+        return _add_month(value) - timedelta(days=1)
+    return value
+
+
+def _iter_buckets(start: date, end: date, period: StatsPeriod) -> list[date]:
+    buckets = []
+    current = start
+    while current <= end:
+        buckets.append(current)
+        current = _next_bucket(current, period)
+    return buckets
+
+
+def _next_bucket(value: date, period: StatsPeriod) -> date:
+    if period is StatsPeriod.WEEKLY:
+        return value + timedelta(days=7)
+    if period is StatsPeriod.MONTHLY:
+        return _add_month(value)
+    return value + timedelta(days=1)
+
+
+def _add_month(value: date) -> date:
+    if value.month == 12:
+        return value.replace(year=value.year + 1, month=1, day=1)
+    return value.replace(month=value.month + 1, day=1)
+
+
+def _bucket_key(value: date, period: StatsPeriod) -> str:
+    if period is StatsPeriod.MONTHLY:
+        return value.strftime("%Y-%m")
+    return value.isoformat()
+
+
+def _parse_bucket_key(value: str, period: StatsPeriod) -> date:
+    if period is StatsPeriod.MONTHLY:
+        return date.fromisoformat(f"{value}-01")
+    return date.fromisoformat(value)
+
+
+def _bucket_label(value: date, period: StatsPeriod) -> str:
+    if period is StatsPeriod.MONTHLY:
+        return f"{value.month}月"
+    return f"{value.month}/{value.day}"
+
+
+def _count_streak_days(active_dates: set[date]) -> int:
+    if not active_dates:
+        return 0
+    current = max(active_dates)
+    streak = 0
+    while current in active_dates:
+        streak += 1
+        current -= timedelta(days=1)
+    return streak
+
+
+def _as_aware_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -9,6 +9,7 @@ from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
+from src.application.use_cases.get_stats import GetStatsPeriod, GetStatsSummary
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.get_weekly_report import GetWeeklyReport
@@ -64,6 +65,8 @@ class Container(BaseModel):
     get_judgment_progress: GetJudgmentProgress
     list_judgments: ListJudgments
     list_today_outputs: ListTodayOutputs
+    get_stats_summary: GetStatsSummary
+    get_stats_period: GetStatsPeriod
     get_weekly_report: GetWeeklyReport
     get_daily_report: GetDailyReport
 
@@ -141,6 +144,8 @@ def build_container(settings: Settings) -> Container:
             image_storage=image_storage,
             download_url_ttl_seconds=settings.gcs_signed_download_url_ttl_seconds,
         ),
+        get_stats_summary=GetStatsSummary(unit_of_work_factory=unit_of_work_factory),
+        get_stats_period=GetStatsPeriod(unit_of_work_factory=unit_of_work_factory),
         get_weekly_report=GetWeeklyReport(
             unit_of_work_factory=unit_of_work_factory,
             image_storage=image_storage,

--- a/backend/src/domain/repositories/stats_repository.py
+++ b/backend/src/domain/repositories/stats_repository.py
@@ -1,0 +1,33 @@
+"""Stats リポジトリの抽象 IF。"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from uuid import UUID
+
+from src.common.models import FrozenModel
+from src.domain.value_objects.verdict import Verdict
+
+
+class StatsAggregationRow(FrozenModel):
+    """統計集計に必要な最小限の永続化データ。"""
+
+    session_id: UUID
+    submitted_at: datetime
+    input_minutes: int
+    output_minutes: int
+    break_minutes: int
+    verdict: Verdict | None
+
+
+class StatsRepository(ABC):
+    """統計集計用の読み取りリポジトリ。"""
+
+    @abstractmethod
+    async def list_aggregation_rows(
+        self,
+        *,
+        user_id: UUID,
+        start_at: datetime | None = None,
+        end_at: datetime | None = None,
+    ) -> list[StatsAggregationRow]:
+        """ユーザー単位で、アウトプット送信済みセッションの集計行を返す。"""

--- a/backend/src/domain/value_objects/stats_period.py
+++ b/backend/src/domain/value_objects/stats_period.py
@@ -1,0 +1,11 @@
+"""統計 API の期間種別。"""
+
+from enum import Enum
+
+
+class StatsPeriod(str, Enum):
+    """統計点をまとめる期間単位。"""
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"

--- a/backend/src/infrastructure/persistence/repositories/pg_stats_repository.py
+++ b/backend/src/infrastructure/persistence/repositories/pg_stats_repository.py
@@ -1,0 +1,59 @@
+"""Stats リポジトリの PostgreSQL 実装。"""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.repositories.stats_repository import StatsAggregationRow, StatsRepository
+from src.domain.value_objects.verdict import Verdict
+from src.infrastructure.persistence.models.judgment_model import JudgmentModel
+from src.infrastructure.persistence.models.output_model import OutputModel
+from src.infrastructure.persistence.models.session_model import SessionModel
+
+
+class PgStatsRepository(StatsRepository):
+    """PostgreSQL から統計集計用の行を取得する。"""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_aggregation_rows(
+        self,
+        *,
+        user_id: UUID,
+        start_at: datetime | None = None,
+        end_at: datetime | None = None,
+    ) -> list[StatsAggregationRow]:
+        stmt = (
+            select(
+                SessionModel.id,
+                OutputModel.submitted_at,
+                SessionModel.input_minutes,
+                SessionModel.output_minutes,
+                SessionModel.break_minutes,
+                JudgmentModel.verdict,
+            )
+            .join(OutputModel, OutputModel.session_id == SessionModel.id)
+            .outerjoin(JudgmentModel, JudgmentModel.session_id == SessionModel.id)
+            .where(SessionModel.user_id == user_id)
+            .order_by(OutputModel.submitted_at.asc(), SessionModel.id.asc())
+        )
+        if start_at is not None:
+            stmt = stmt.where(OutputModel.submitted_at >= start_at)
+        if end_at is not None:
+            stmt = stmt.where(OutputModel.submitted_at < end_at)
+
+        result = await self._session.execute(stmt)
+        return [
+            StatsAggregationRow(
+                session_id=row.id,
+                submitted_at=row.submitted_at,
+                input_minutes=row.input_minutes,
+                output_minutes=row.output_minutes,
+                break_minutes=row.break_minutes,
+                verdict=Verdict(row.verdict) if row.verdict is not None else None,
+            )
+            for row in result.all()
+        ]

--- a/backend/src/infrastructure/persistence/unit_of_work.py
+++ b/backend/src/infrastructure/persistence/unit_of_work.py
@@ -20,6 +20,7 @@ from src.infrastructure.persistence.repositories.pg_output_repository import PgO
 from src.infrastructure.persistence.repositories.pg_session_repository import (
     PgSessionRepository,
 )
+from src.infrastructure.persistence.repositories.pg_stats_repository import PgStatsRepository
 from src.infrastructure.persistence.repositories.pg_study_subject_repository import (
     PgStudySubjectRepository,
 )
@@ -40,6 +41,7 @@ class SqlAlchemyUnitOfWork(ApplicationUnitOfWork):
         self.study_subjects: PgStudySubjectRepository
         self.judgments: PgJudgmentRepository
         self.judgment_progresses: PgJudgmentProgressRepository
+        self.stats: PgStatsRepository
 
     async def __aenter__(self) -> Self:
         self._session_context = self._database.session()
@@ -51,6 +53,7 @@ class SqlAlchemyUnitOfWork(ApplicationUnitOfWork):
         self.study_subjects = PgStudySubjectRepository(self._session)
         self.judgments = PgJudgmentRepository(self._session)
         self.judgment_progresses = PgJudgmentProgressRepository(self._session)
+        self.stats = PgStatsRepository(self._session)
         return self
 
     async def __aexit__(

--- a/backend/src/presentation/api/v1/stats.py
+++ b/backend/src/presentation/api/v1/stats.py
@@ -13,14 +13,22 @@ from fastapi import APIRouter, Depends, Query, Request, status
 
 from src.domain.entities.user import User
 from src.domain.value_objects.auth_provider import AuthProvider
+from src.domain.value_objects.stats_period import StatsPeriod
 from src.presentation.container_access import get_presentation_container
 from src.presentation.mappers.response_mapper import (
     to_daily_report_response,
+    to_stats_period_response,
+    to_stats_summary_response,
     to_weekly_report_response,
 )
 from src.presentation.middleware.auth_middleware import get_current_user
 from src.presentation.problem_details import ProblemDetailsError
-from src.presentation.schemas.stats_schema import DailyReportResponse, WeeklyReportResponse
+from src.presentation.schemas.stats_schema import (
+    DailyReportResponse,
+    StatsPeriodResponse,
+    StatsSummaryResponse,
+    WeeklyReportResponse,
+)
 
 stats_router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -36,27 +44,57 @@ def require_registered_user(current_user: User) -> None:
         )
 
 
-@stats_router.get("/weekly", response_model=WeeklyReportResponse)
+@stats_router.get("/summary", response_model=StatsSummaryResponse)
+async def get_stats_summary(
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> StatsSummaryResponse:
+    """全期間の代表指標サマリーを返す。"""
+    container = get_presentation_container(request)
+    view = await container.get_stats_summary.execute(current_user)
+    return to_stats_summary_response(view)
+
+
+@stats_router.get("/weekly", response_model=WeeklyReportResponse | StatsPeriodResponse)
 async def get_weekly_report(
     request: Request,
     week_start: Annotated[date | None, Query()] = None,
     current_user: User = Depends(get_current_user),  # noqa: B008
-) -> WeeklyReportResponse:
-    """週単位レポート画面に必要な集計とアウトプット履歴を返す。"""
+) -> WeeklyReportResponse | StatsPeriodResponse:
+    """週単位の統計、または週単位レポート画面用データを返す。"""
     require_registered_user(current_user)
     container = get_presentation_container(request)
+    if week_start is None:
+        view = await container.get_stats_period.execute(current_user, StatsPeriod.WEEKLY)
+        return to_stats_period_response(view)
+
     view = await container.get_weekly_report.execute(current_user, week_start)
     return to_weekly_report_response(view)
 
 
-@stats_router.get("/daily", response_model=DailyReportResponse)
+@stats_router.get("/daily", response_model=DailyReportResponse | StatsPeriodResponse)
 async def get_daily_report(
     request: Request,
     target_date: Annotated[date | None, Query(alias="date")] = None,
     current_user: User = Depends(get_current_user),  # noqa: B008
-) -> DailyReportResponse:
-    """日単位レポート画面に必要な集計とアウトプット履歴を返す。"""
+) -> DailyReportResponse | StatsPeriodResponse:
+    """日単位の統計、または日単位レポート画面用データを返す。"""
     require_registered_user(current_user)
     container = get_presentation_container(request)
+    if target_date is None:
+        view = await container.get_stats_period.execute(current_user, StatsPeriod.DAILY)
+        return to_stats_period_response(view)
+
     view = await container.get_daily_report.execute(current_user, target_date)
     return to_daily_report_response(view)
+
+
+@stats_router.get("/monthly", response_model=StatsPeriodResponse)
+async def get_monthly_stats(
+    request: Request,
+    current_user: User = Depends(get_current_user),  # noqa: B008
+) -> StatsPeriodResponse:
+    """月単位の統計を返す。"""
+    container = get_presentation_container(request)
+    view = await container.get_stats_period.execute(current_user, StatsPeriod.MONTHLY)
+    return to_stats_period_response(view)

--- a/backend/src/presentation/container_access.py
+++ b/backend/src/presentation/container_access.py
@@ -12,6 +12,7 @@ from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
+from src.application.use_cases.get_stats import GetStatsPeriod, GetStatsSummary
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.get_weekly_report import GetWeeklyReport
@@ -61,6 +62,8 @@ class PresentationContainer(ABC):
     get_judgment_progress: GetJudgmentProgress
     list_judgments: ListJudgments
     list_today_outputs: ListTodayOutputs
+    get_stats_summary: GetStatsSummary
+    get_stats_period: GetStatsPeriod
     get_weekly_report: GetWeeklyReport
     get_daily_report: GetDailyReport
 

--- a/backend/src/presentation/mappers/response_mapper.py
+++ b/backend/src/presentation/mappers/response_mapper.py
@@ -13,7 +13,12 @@ from src.application.dto.session_dto import (
     SubmitOutputView,
     TodayOutputsView,
 )
-from src.application.dto.stats_dto import DailyReportView, WeeklyReportView
+from src.application.dto.stats_dto import (
+    DailyReportView,
+    StatsPeriodView,
+    StatsSummaryView,
+    WeeklyReportView,
+)
 from src.application.dto.user_dto import UserProfileView
 from src.application.dto.user_settings_dto import UserSettingsView
 from src.presentation.schemas.judgment_schema import (
@@ -35,6 +40,9 @@ from src.presentation.schemas.session_schema import (
 from src.presentation.schemas.stats_schema import (
     DailyReportResponse,
     DailyReportSummaryResponse,
+    StatsDataPointResponse,
+    StatsPeriodResponse,
+    StatsSummaryResponse,
     WeeklyReportPointResponse,
     WeeklyReportResponse,
     WeeklyReportSummaryResponse,
@@ -198,6 +206,35 @@ def to_daily_report_response(view: DailyReportView) -> DailyReportResponse:
             )
             for item in view.output_history
         ],
+    )
+
+
+def to_stats_summary_response(view: StatsSummaryView) -> StatsSummaryResponse:
+    return StatsSummaryResponse(
+        total_sessions=view.total_sessions,
+        total_study_minutes=view.total_study_minutes,
+        correct_rate=view.correct_rate,
+        streak_days=view.streak_days,
+        period=view.period,
+        from_date=view.from_date,
+        to_date=view.to_date,
+    )
+
+
+def to_stats_period_response(view: StatsPeriodView) -> StatsPeriodResponse:
+    return StatsPeriodResponse(
+        period=view.period,
+        points=[
+            StatsDataPointResponse(
+                bucket=point.bucket,
+                label=point.label,
+                sessions=point.sessions,
+                study_minutes=point.study_minutes,
+                correct_rate=point.correct_rate,
+            )
+            for point in view.points
+        ],
+        summary=to_stats_summary_response(view.summary),
     )
 
 

--- a/backend/src/presentation/schemas/stats_schema.py
+++ b/backend/src/presentation/schemas/stats_schema.py
@@ -2,8 +2,41 @@
 
 from datetime import date
 
+from pydantic import Field
+
 from src.common.models import FrozenModel
+from src.domain.value_objects.stats_period import StatsPeriod
 from src.presentation.schemas.session_schema import OutputReviewItemResponse
+
+
+class StatsSummaryResponse(FrozenModel):
+    """代表指標のサマリーレスポンス。"""
+
+    total_sessions: int
+    total_study_minutes: int
+    correct_rate: float
+    streak_days: int
+    period: StatsPeriod
+    from_date: date = Field(serialization_alias="from")
+    to_date: date = Field(serialization_alias="to")
+
+
+class StatsDataPointResponse(FrozenModel):
+    """期間別統計の 1 点。"""
+
+    bucket: str
+    label: str
+    sessions: int
+    study_minutes: int
+    correct_rate: float
+
+
+class StatsPeriodResponse(FrozenModel):
+    """日 / 週 / 月単位の統計レスポンス。"""
+
+    period: StatsPeriod
+    points: list[StatsDataPointResponse]
+    summary: StatsSummaryResponse
 
 
 class WeeklyReportSummaryResponse(FrozenModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,6 +21,7 @@ from src.application.use_cases.get_daily_report import GetDailyReport
 from src.application.use_cases.get_judgment import GetJudgment
 from src.application.use_cases.get_judgment_detail import GetJudgmentDetail
 from src.application.use_cases.get_judgment_progress import GetJudgmentProgress
+from src.application.use_cases.get_stats import GetStatsPeriod, GetStatsSummary
 from src.application.use_cases.get_user_profile import GetUserProfile
 from src.application.use_cases.get_user_settings import GetUserSettings
 from src.application.use_cases.get_weekly_report import GetWeeklyReport
@@ -41,6 +42,7 @@ from tests.fakes.fake_judgment_progress_repository import FakeJudgmentProgressRe
 from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
 from tests.fakes.fake_output_repository import FakeOutputRepository
 from tests.fakes.fake_session_repository import FakeSessionRepository
+from tests.fakes.fake_stats_repository import FakeStatsRepository
 from tests.fakes.fake_study_subject_repository import FakeStudySubjectRepository
 from tests.fakes.fake_unit_of_work import FakeUnitOfWork
 from tests.fakes.fake_user_repository import FakeUserRepository
@@ -89,6 +91,11 @@ def fake_judgment_progress_repository() -> FakeJudgmentProgressRepository:
 
 
 @pytest.fixture
+def fake_stats_repository() -> FakeStatsRepository:
+    return FakeStatsRepository()
+
+
+@pytest.fixture
 def fake_auth_verifier() -> FakeAuthVerifier:
     return FakeAuthVerifier()
 
@@ -102,6 +109,7 @@ def container(
     fake_study_subject_repository: FakeStudySubjectRepository,
     fake_judgment_repository: FakeJudgmentRepository,
     fake_judgment_progress_repository: FakeJudgmentProgressRepository,
+    fake_stats_repository: FakeStatsRepository,
     fake_auth_verifier: FakeAuthVerifier,
 ) -> Container:
     """fake 実装を差し込んだ Container。"""
@@ -115,6 +123,7 @@ def container(
             study_subjects=fake_study_subject_repository,
             judgments=fake_judgment_repository,
             judgment_progresses=fake_judgment_progress_repository,
+            stats=fake_stats_repository,
         )
 
     return Container(
@@ -142,6 +151,8 @@ def container(
         get_judgment_progress=GetJudgmentProgress(unit_of_work_factory=unit_of_work_factory),
         list_judgments=ListJudgments(unit_of_work_factory=unit_of_work_factory),
         list_today_outputs=ListTodayOutputs(unit_of_work_factory=unit_of_work_factory),
+        get_stats_summary=GetStatsSummary(unit_of_work_factory=unit_of_work_factory),
+        get_stats_period=GetStatsPeriod(unit_of_work_factory=unit_of_work_factory),
         get_weekly_report=GetWeeklyReport(unit_of_work_factory=unit_of_work_factory),
         get_daily_report=GetDailyReport(unit_of_work_factory=unit_of_work_factory),
     )

--- a/backend/tests/fakes/fake_stats_repository.py
+++ b/backend/tests/fakes/fake_stats_repository.py
@@ -1,0 +1,85 @@
+"""インメモリな StatsRepository 実装。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from src.domain.repositories.stats_repository import StatsAggregationRow, StatsRepository
+from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
+from tests.fakes.fake_output_repository import FakeOutputRepository
+from tests.fakes.fake_session_repository import FakeSessionRepository
+
+
+class FakeStatsRepository(StatsRepository):
+    """fake repository 群から統計集計用の行を組み立てる。"""
+
+    def __init__(self) -> None:
+        self._sessions: FakeSessionRepository | None = None
+        self._outputs: FakeOutputRepository | None = None
+        self._judgments: FakeJudgmentRepository | None = None
+
+    def bind_sources(
+        self,
+        *,
+        sessions: FakeSessionRepository,
+        outputs: FakeOutputRepository,
+        judgments: FakeJudgmentRepository,
+    ) -> None:
+        self._sessions = sessions
+        self._outputs = outputs
+        self._judgments = judgments
+
+    async def list_aggregation_rows(
+        self,
+        *,
+        user_id: UUID,
+        start_at: datetime | None = None,
+        end_at: datetime | None = None,
+    ) -> list[StatsAggregationRow]:
+        sessions = self._require_sessions()
+        outputs = self._require_outputs()
+        judgments = self._require_judgments()
+
+        rows = []
+        for session in sessions.sessions.values():
+            if session.user_id != user_id:
+                continue
+
+            output = outputs.outputs_by_session_id.get(session.id)
+            if output is None:
+                continue
+            if start_at is not None and output.submitted_at < start_at:
+                continue
+            if end_at is not None and output.submitted_at >= end_at:
+                continue
+
+            judgment = judgments.judgments_by_session_id.get(session.id)
+            rows.append(
+                StatsAggregationRow(
+                    session_id=session.id,
+                    submitted_at=output.submitted_at,
+                    input_minutes=session.input_minutes,
+                    output_minutes=session.output_minutes,
+                    break_minutes=session.break_minutes,
+                    verdict=judgment.verdict if judgment is not None else None,
+                )
+            )
+
+        rows.sort(key=lambda row: (row.submitted_at, row.session_id))
+        return rows
+
+    def _require_sessions(self) -> FakeSessionRepository:
+        if self._sessions is None:
+            raise RuntimeError("FakeStatsRepository sources are not bound")
+        return self._sessions
+
+    def _require_outputs(self) -> FakeOutputRepository:
+        if self._outputs is None:
+            raise RuntimeError("FakeStatsRepository sources are not bound")
+        return self._outputs
+
+    def _require_judgments(self) -> FakeJudgmentRepository:
+        if self._judgments is None:
+            raise RuntimeError("FakeStatsRepository sources are not bound")
+        return self._judgments

--- a/backend/tests/fakes/fake_unit_of_work.py
+++ b/backend/tests/fakes/fake_unit_of_work.py
@@ -10,6 +10,7 @@ from tests.fakes.fake_judgment_progress_repository import FakeJudgmentProgressRe
 from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
 from tests.fakes.fake_output_repository import FakeOutputRepository
 from tests.fakes.fake_session_repository import FakeSessionRepository
+from tests.fakes.fake_stats_repository import FakeStatsRepository
 from tests.fakes.fake_study_subject_repository import FakeStudySubjectRepository
 from tests.fakes.fake_user_repository import FakeUserRepository
 
@@ -26,6 +27,7 @@ class FakeUnitOfWork(ApplicationUnitOfWork):
         study_subjects: FakeStudySubjectRepository | None = None,
         judgments: FakeJudgmentRepository | None = None,
         judgment_progresses: FakeJudgmentProgressRepository | None = None,
+        stats: FakeStatsRepository | None = None,
     ) -> None:
         self.users = users or FakeUserRepository()
         self.sessions = sessions or FakeSessionRepository()
@@ -34,6 +36,12 @@ class FakeUnitOfWork(ApplicationUnitOfWork):
         self.judgments = judgments or FakeJudgmentRepository()
         self.judgment_progresses = judgment_progresses or FakeJudgmentProgressRepository()
         self.judgments.bind_sessions(self.sessions)
+        self.stats = stats or FakeStatsRepository()
+        self.stats.bind_sources(
+            sessions=self.sessions,
+            outputs=self.outputs,
+            judgments=self.judgments,
+        )
         self.commit_count = 0
         self.rollback_count = 0
         self.enter_count = 0

--- a/backend/tests/integration/test_api_stats.py
+++ b/backend/tests/integration/test_api_stats.py
@@ -396,3 +396,212 @@ async def test_get_daily_report_requires_registered_user(client: AsyncClient):
     assert response.status_code == 403
     body = response.json()
     assert body["type"].endswith("registration_required")
+
+
+@pytest.mark.asyncio
+async def test_get_stats_summary_returns_current_users_aggregate(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    auth_uid = "stats-summary-user"
+    first = await _create_session_with_output(
+        client,
+        auth_uid,
+        subject="英語",
+        topic="関係代名詞",
+        input_minutes=20,
+        output_minutes=5,
+        break_minutes=5,
+        content="1日目のアウトプットです。",
+        submitted_at="2026-04-29T01:00:00Z",
+    )
+    second = await _create_session_with_output(
+        client,
+        auth_uid,
+        subject="数学",
+        topic="二次関数",
+        input_minutes=30,
+        output_minutes=10,
+        break_minutes=5,
+        content="2日目のアウトプットです。",
+        submitted_at="2026-04-30T01:00:00Z",
+    )
+    await _create_session_with_output(
+        client,
+        auth_uid,
+        subject="国語",
+        topic="随筆",
+        input_minutes=15,
+        output_minutes=5,
+        break_minutes=5,
+        content="3日目のアウトプットです。",
+        submitted_at="2026-05-01T01:00:00Z",
+    )
+    await _create_session_with_output(
+        client,
+        "stats-summary-other-user",
+        subject="理科",
+        topic="化学",
+        input_minutes=100,
+        output_minutes=20,
+        break_minutes=5,
+        content="別ユーザーのアウトプットです。",
+        submitted_at="2026-05-01T01:00:00Z",
+    )
+    await fake_judgment_repository.add(
+        Judgment(
+            id=uuid4(),
+            session_id=UUID(str(first["id"])),
+            verdict=Verdict.CORRECT,
+            score=100,
+            advice="よくできています。",
+            corrections=[],
+            judged_at=datetime.now(UTC),
+        )
+    )
+    await fake_judgment_repository.add(
+        Judgment(
+            id=uuid4(),
+            session_id=UUID(str(second["id"])),
+            verdict=Verdict.PARTIAL,
+            score=70,
+            advice="一部修正しましょう。",
+            corrections=[],
+            judged_at=datetime.now(UTC),
+        )
+    )
+
+    response = await client.get(
+        "/api/v1/stats/summary",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "total_sessions": 3,
+        "total_study_minutes": 85,
+        "correct_rate": 0.5,
+        "streak_days": 3,
+        "period": "daily",
+        "from": "2026-04-29",
+        "to": "2026-05-01",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_stats_periods_return_bucketed_points(
+    client: AsyncClient,
+    fake_judgment_repository: FakeJudgmentRepository,
+):
+    auth_uid = "stats-period-user"
+    first = await _create_session_with_output(
+        client,
+        auth_uid,
+        subject="英語",
+        topic="関係代名詞",
+        input_minutes=20,
+        output_minutes=5,
+        break_minutes=5,
+        content="4月のアウトプットです。",
+        submitted_at="2026-04-26T01:00:00Z",
+    )
+    second = await _create_session_with_output(
+        client,
+        auth_uid,
+        subject="数学",
+        topic="二次関数",
+        input_minutes=30,
+        output_minutes=10,
+        break_minutes=5,
+        content="5月のアウトプットです。",
+        submitted_at="2026-05-03T01:00:00Z",
+    )
+    await fake_judgment_repository.add(
+        Judgment(
+            id=uuid4(),
+            session_id=UUID(str(first["id"])),
+            verdict=Verdict.CORRECT,
+            score=95,
+            advice="よくできています。",
+            corrections=[],
+            judged_at=datetime.now(UTC),
+        )
+    )
+    await fake_judgment_repository.add(
+        Judgment(
+            id=uuid4(),
+            session_id=UUID(str(second["id"])),
+            verdict=Verdict.INCORRECT,
+            score=20,
+            advice="復習しましょう。",
+            corrections=[],
+            judged_at=datetime.now(UTC),
+        )
+    )
+
+    daily_response = await client.get(
+        "/api/v1/stats/daily",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+    weekly_response = await client.get(
+        "/api/v1/stats/weekly",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+    monthly_response = await client.get(
+        "/api/v1/stats/monthly",
+        headers={"Authorization": f"Bearer {auth_uid}"},
+    )
+
+    assert daily_response.status_code == 200
+    daily_body = daily_response.json()
+    assert daily_body["period"] == "daily"
+    assert daily_body["summary"]["total_sessions"] == 2
+    assert daily_body["summary"]["total_study_minutes"] == 65
+    assert daily_body["summary"]["correct_rate"] == 0.5
+    assert [point["bucket"] for point in daily_body["points"]] == [
+        "2026-04-26",
+        "2026-04-27",
+        "2026-04-28",
+        "2026-04-29",
+        "2026-04-30",
+        "2026-05-01",
+        "2026-05-02",
+        "2026-05-03",
+    ]
+    assert [point["sessions"] for point in daily_body["points"]] == [1, 0, 0, 0, 0, 0, 0, 1]
+    assert "output_history" not in daily_body
+
+    assert weekly_response.status_code == 200
+    weekly_body = weekly_response.json()
+    assert weekly_body["period"] == "weekly"
+    assert [point["bucket"] for point in weekly_body["points"]] == [
+        "2026-04-26",
+        "2026-05-03",
+    ]
+    assert [point["study_minutes"] for point in weekly_body["points"]] == [25, 40]
+
+    assert monthly_response.status_code == 200
+    monthly_body = monthly_response.json()
+    assert monthly_body["period"] == "monthly"
+    assert [point["bucket"] for point in monthly_body["points"]] == ["2026-04", "2026-05"]
+    assert [point["correct_rate"] for point in monthly_body["points"]] == [1.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_stats_returns_zero_filled_empty_response(client: AsyncClient):
+    response = await client.get(
+        "/api/v1/stats/monthly",
+        headers={"Authorization": "Bearer stats-empty-monthly-user"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["period"] == "monthly"
+    assert body["summary"]["total_sessions"] == 0
+    assert body["summary"]["total_study_minutes"] == 0
+    assert body["summary"]["correct_rate"] == 0.0
+    assert body["summary"]["streak_days"] == 0
+    assert len(body["points"]) == 1
+    assert body["points"][0]["sessions"] == 0
+    assert body["points"][0]["study_minutes"] == 0

--- a/mobile/src/features/stats/screens/StatsScreen.tsx
+++ b/mobile/src/features/stats/screens/StatsScreen.tsx
@@ -722,10 +722,12 @@ function MonthlyCalendar({
   monthStart,
   reports,
   onMonthChange,
+  onDatePress,
 }: {
   monthStart: string;
   reports: WeeklyReportResponse[];
   onMonthChange: (monthStart: string) => void;
+  onDatePress: (dateKey: string) => void;
 }) {
   const todayKey = getTokyoDateKey();
   const monthPrefix = monthStart.slice(0, 7);
@@ -791,8 +793,11 @@ function MonthlyCalendar({
                     : 'empty';
 
                 return (
-                  <View
+                  <Pressable
+                    accessibilityLabel={`${getMonthDayLabel(dateKey)}のサマリーを表示`}
+                    accessibilityRole="button"
                     key={dateKey}
+                    onPress={() => onDatePress(dateKey)}
                     style={styles.monthDaySlot}
                     testID={`month-day-${dateKey}-${studiedTestSuffix}`}
                   >
@@ -820,7 +825,7 @@ function MonthlyCalendar({
                         {getDateNumberLabel(dateKey)}
                       </SizableText>
                     </View>
-                  </View>
+                  </Pressable>
                 );
               })}
             </View>
@@ -1799,6 +1804,10 @@ export function StatsScreen() {
   const handleCloseMonthlyCalendar = useCallback(() => {
     setReportViewMode('daily');
   }, []);
+  const handleSelectMonthlyDate = useCallback((dateKey: string) => {
+    setSelectedDateKey(dateKey);
+    setReportViewMode('daily');
+  }, []);
   const handleWeekChange = useCallback(
     (newWeekStart: string) => {
       const offsetDays = daysBetweenDateKeys(newWeekStart, weekStart);
@@ -1874,6 +1883,7 @@ export function StatsScreen() {
           monthStart={calendarMonthStart}
           reports={monthlyReports.reports}
           onMonthChange={setCalendarMonthStart}
+          onDatePress={handleSelectMonthlyDate}
         />
         <View style={styles.monthlyHighlightTitleRow}>
           <SizableText style={styles.highlightTitle}>今月のハイライト</SizableText>

--- a/mobile/src/features/stats/screens/__tests__/StatsScreen.test.tsx
+++ b/mobile/src/features/stats/screens/__tests__/StatsScreen.test.tsx
@@ -806,6 +806,42 @@ describe('StatsScreen', () => {
     expect(getByText('最高連続日数')).toBeTruthy();
   });
 
+  it('月間カレンダーの日付セルをタップするとその日の日別サマリーに戻る', async () => {
+    (statsApi.fetchDailyReport as jest.Mock).mockImplementation((date: string) =>
+      Promise.resolve(makeDailyResponse({ date })),
+    );
+    (statsApi.fetchWeeklyReport as jest.Mock).mockImplementation((weekStart: string) =>
+      Promise.resolve(
+        makeWeeklyResponseForDates(weekStart, {
+          '2026-04-12': 50,
+        }),
+      ),
+    );
+
+    const { getByTestId, getByText, queryByTestId } = renderWithProviders(<StatsScreen />);
+    await flushAsyncUpdates();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('stats-calendar-toggle'));
+    });
+    await flushAsyncUpdates();
+
+    await waitFor(() => {
+      expect(getByTestId('month-day-2026-04-12-single')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('month-day-2026-04-12-single'));
+    });
+    await flushAsyncUpdates();
+
+    await waitFor(() => {
+      expect(statsApi.fetchDailyReport).toHaveBeenCalledWith('2026-04-12');
+    });
+    expect(queryByTestId('stats-monthly-content')).toBeNull();
+    expect(getByText('4月12日のハイライト')).toBeTruthy();
+  });
+
   it('取得失敗時は error メッセージと retry ボタンが表示される', async () => {
     (statsApi.fetchDailyReport as jest.Mock).mockRejectedValue(
       new ApiError(500, {


### PR DESCRIPTION
<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->
統計画面で利用する summary / daily / weekly / monthly の集計 API を backend に実装した。
あわせて、mobile の月表示カレンダーで日付を押したときに、その日のサマリーへ戻るようにした。
## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->
- Closes #54 
- Refs #21 #25 #5 

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

- 認証済みユーザー単位の統計集計 repository / use case を追加
- summary / daily / weekly / monthly の stats API response schema を整備
- 日 / 週 / 月ごとの件数、学習分数、正答率、継続日数を返すように変更
- 空データ時も 0 件のレスポンスを返すように対応
- 月表示カレンダーの日付セル押下で日別サマリーへ戻る導線を追加
- backend / mobile の API・画面テストを追加


## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

- スコアの追加集計は今回の対象外
- グラフ UI の追加改善は後続 Issue で扱う
## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

``bash
cd backend
uv run python -m pytest tests/integration/test_api_stats.py
uv run python -m pytest
uv run ruff check
uv run ty check

cd ../mobile
npm test -- StatsScreen.test.tsx --runInBand
npm run typecheck

### スクリーンショット / 動画
before

<img width="1170" height="2532" alt="IMG_0045" src="https://github.com/user-attachments/assets/c722b8a8-de08-45a7-b69b-e92f02f3f957" />

after
<img width="1170" height="2532" alt="IMG_0050" src="https://github.com/user-attachments/assets/1c34d674-02de-4fdd-a36b-4c770dd485af" />
https://github.com/user-attachments/assets/610162ff-704b-4c7b-af5e-0576a10c671f
<img width="1170" height="2532" alt="IMG_0049" src="https://github.com/user-attachments/assets/404267a4-dbad-4e73-a22b-2a177da26f87" />
<img width="1170" height="2532" alt="IMG_0048" src="https://github.com/user-attachments/assets/85d2fa76-5cf4-4d0e-b65d-50f9860854cd" />


<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [x] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [x] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
