### PR TITLE
Feature/56 users me settings validation

### DIFF
--- a/backend/src/application/dto/user_settings_dto.py
+++ b/backend/src/application/dto/user_settings_dto.py
@@ -7,7 +7,10 @@ CQRS 的な命名で役割を明示する:
 
 from datetime import datetime
 
+from pydantic import Field, StrictBool, StrictInt
+
 from src.common.models import FrozenModel
+from src.domain.entities.user_settings import MAX_TIMER_MINUTES, MIN_TIMER_MINUTES
 
 
 class UserSettingsView(FrozenModel):
@@ -26,7 +29,19 @@ class UpdateUserSettingsCommand(FrozenModel):
     送られなかったフィールドは現在値を保持するため、ここでは省略可能（None）として表現する。
     """
 
-    input_minutes: int | None = None
-    output_minutes: int | None = None
-    break_minutes: int | None = None
-    notification_enabled: bool | None = None
+    input_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+    )
+    output_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+    )
+    break_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+    )
+    notification_enabled: StrictBool | None = None

--- a/backend/src/domain/entities/user_settings.py
+++ b/backend/src/domain/entities/user_settings.py
@@ -8,16 +8,24 @@ from uuid import UUID
 
 from src.common.models import FrozenModel
 
+MIN_TIMER_MINUTES = 1
+MAX_TIMER_MINUTES = 120
+
+DEFAULT_INPUT_MINUTES = 20
+DEFAULT_OUTPUT_MINUTES = 5
+DEFAULT_BREAK_MINUTES = 5
+DEFAULT_NOTIFICATION_ENABLED = True
+
 
 class UserSettings(FrozenModel):
     """ユーザごとのタイマー / 通知設定。"""
 
     id: UUID
     user_id: UUID
-    input_minutes: int = 20
-    output_minutes: int = 5
-    break_minutes: int = 5
-    notification_enabled: bool = True
+    input_minutes: int = DEFAULT_INPUT_MINUTES
+    output_minutes: int = DEFAULT_OUTPUT_MINUTES
+    break_minutes: int = DEFAULT_BREAK_MINUTES
+    notification_enabled: bool = DEFAULT_NOTIFICATION_ENABLED
     created_at: datetime
     updated_at: datetime
 

--- a/backend/src/presentation/schemas/user_settings_schema.py
+++ b/backend/src/presentation/schemas/user_settings_schema.py
@@ -2,15 +2,10 @@
 
 from datetime import datetime
 
-from pydantic import Field
+from pydantic import Field, StrictBool, StrictInt
 
 from src.common.models import FrozenModel, StrictRequestModel
-
-# タイマー値の許容範囲。セッション作成 (CreateSessionRequest) が 1〜120 分を要求するため、
-# 設定値が 120 分を超えるとセッション作成が 422 で失敗してしまう。ここを session 側に
-# 揃えて 1〜120 分にすることで、設定で保存した値がそのままセッション開始に使える。
-_MINUTES_MIN = 1
-_MINUTES_MAX = 120
+from src.domain.entities.user_settings import MAX_TIMER_MINUTES, MIN_TIMER_MINUTES
 
 
 class UserSettingsResponse(FrozenModel):
@@ -26,16 +21,39 @@ class UserSettingsResponse(FrozenModel):
 class UpdateUserSettingsRequest(StrictRequestModel):
     """PATCH /users/me/settings の body。
 
-    すべてのフィールドが省略可能。minutes 系は 1 ～ 120 の範囲を要求し、未知フィールドは
-    StrictRequestModel により拒否する。「全フィールド未指定（空 body）」のチェックは、
+    すべてのフィールドが省略可能。minutes 系は 1 ～ 120 の厳密な整数を要求し、
+    未知フィールドは StrictRequestModel により拒否する。「全フィールド未指定
+    （空 body）」のチェックは、
     Pydantic の model_validator で投げると ValidationError の ctx に ValueError が入って
     Problem Details のシリアライズが失敗するため、ルーター層で明示的にハンドリングする。
     """
 
-    input_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
-    output_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
-    break_minutes: int | None = Field(default=None, ge=_MINUTES_MIN, le=_MINUTES_MAX)
-    notification_enabled: bool | None = None
+    input_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+        description="インプット時間（分）。1〜120 の整数。",
+        examples=[20],
+    )
+    output_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+        description="アウトプット時間（分）。1〜120 の整数。",
+        examples=[5],
+    )
+    break_minutes: StrictInt | None = Field(
+        default=None,
+        ge=MIN_TIMER_MINUTES,
+        le=MAX_TIMER_MINUTES,
+        description="休憩時間（分）。1〜120 の整数。",
+        examples=[5],
+    )
+    notification_enabled: StrictBool | None = Field(
+        default=None,
+        description="プッシュ通知の有効 / 無効。",
+        examples=[True],
+    )
 
     def is_empty(self) -> bool:
         """すべてのフィールドが None かどうか。ルーター層で空 body を弾くために使う。"""

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -78,17 +78,24 @@ async def test_patch_settings_rejects_out_of_range_minutes(
 
 
 @pytest.mark.asyncio
-async def test_patch_settings_rejects_non_numeric_string(client: AsyncClient):
-    """Pydantic は数値文字列 "20" を int に強制変換する（既存 session API と同じ挙動）が、
-    数値として解釈できない文字列は 422 で蹴ることを担保する。
-    """
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"input_minutes": "20"},
+        {"output_minutes": 5.5},
+        {"break_minutes": True},
+        {"notification_enabled": "false"},
+        {"notification_enabled": 0},
+    ],
+)
+async def test_patch_settings_rejects_invalid_types(client: AsyncClient, payload: dict):
     headers = {"Authorization": "Bearer settings-user-string"}
     await client.get("/api/v1/users/me/settings", headers=headers)
 
     response = await client.patch(
         "/api/v1/users/me/settings",
         headers=headers,
-        json={"input_minutes": "abc"},
+        json=payload,
     )
     assert response.status_code == 422
 

--- a/backend/tests/unit/test_use_cases/test_update_user_settings.py
+++ b/backend/tests/unit/test_use_cases/test_update_user_settings.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from src.application.dto.user_settings_dto import UpdateUserSettingsCommand
 from src.application.use_cases.get_user_settings import UserSettingsNotFoundError
@@ -94,6 +95,25 @@ async def test_update_user_settings_can_disable_notification_only():
 
     assert view.notification_enabled is False
     assert view.input_minutes == 20  # 他はデフォルトのまま
+
+
+@pytest.mark.parametrize(
+    ("payload", "field"),
+    [
+        ({"input_minutes": 0}, "input_minutes"),
+        ({"input_minutes": 121}, "input_minutes"),
+        ({"input_minutes": "20"}, "input_minutes"),
+        ({"output_minutes": 5.5}, "output_minutes"),
+        ({"break_minutes": True}, "break_minutes"),
+        ({"notification_enabled": "false"}, "notification_enabled"),
+        ({"notification_enabled": 0}, "notification_enabled"),
+    ],
+)
+def test_update_user_settings_command_rejects_invalid_values(payload: dict, field: str):
+    with pytest.raises(ValidationError) as exc_info:
+        UpdateUserSettingsCommand(**payload)
+
+    assert exc_info.value.errors()[0]["loc"] == (field,)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

<!-- 何を、なぜ変更したかを 1〜3 文で記載してください -->
- `PATCH /api/v1/users/me/settings` の更新入力を厳格化
- timer minutes の許容範囲 `1〜120` を domain 定数として共有
- `notification_enabled` の文字列・数値代用や、minutes の文字列・小数・bool 混入を 422 で拒否
- 正常更新、範囲外、型不正、空 body、未知フィールド、再取得反映のテストを確認
 ##確認してほしいこと
- `PATCH /api/v1/users/me/settings` で、以下の入力を 422 として拒否する方針が妥当か
  - minutes 系: `"20"` などの文字列、`5.5` などの小数、`true` などの bool
  - `notification_enabled`: `"false"` などの文字列、`0` / `1` などの数値
- `UpdateUserSettingsRequest` と `UpdateUserSettingsCommand` の両方で `StrictInt` / `StrictBool` を使っている設計が妥当か
- timer minutes の許容範囲 `1〜120` を `UserSettings` の domain 定数として共有している点に問題がない
## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #56 
- Refs #22 #5 

## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

- `UserSettings` に timer minutes の許容範囲とデフォルト値を定数として定義
- `UpdateUserSettingsRequest` で `StrictInt` / `StrictBool` を使い、API 入力の暗黙変換を拒否
- `UpdateUserSettingsCommand` でも同じ制約を持たせ、use case 境界でも不正な command を作れないように変更
- `PATCH /api/v1/users/me/settings` の integration test に型不正ケースを追加
- `UpdateUserSettingsCommand` の unit test に範囲外・型不正ケースを追加

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

- mobile UI の変更はなし
- DB schema / migration の変更はなし
- Firebase 実トークンを使った手動 E2E 確認は対象外


## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```

```bash
cd backend
uv run python -m pytest
uv run ruff check
uv run ruff format --check
uv run ty check
uv run python -c 'from importlinter.cli import lint_imports_command; lint_imports_command()'
```
### スクリーンショット / 動画
| 種類 | 内容 | 見てほしい点 |
| --- | --- | --- |
| Before | 実装前の Swagger UI | request body の説明・example が少なく、入力仕様が分かりづらいこと |
| After | 実装後の Swagger UI | minutes 系が `1〜120` の整数、`notification_enabled` が boolean として説明されていること |

API関連before（作業ログと同様のもの）
- Before
  - `PATCH /api/v1/users/me/settings` の更新前の Swagger UI
  - request body の説明や example が不足しており、何を送れる API なのかが読み取りづらい状態
<img width="1440" height="4982" alt="users-me-settings-patch-before" src="https://github.com/user-attachments/assets/39fd550c-8f32-44be-8c19-c593fb79ee2e" />
<img width="1440" height="4813" alt="swagger-before" src="https://github.com/user-attachments/assets/8bb44ab8-11cf-44b7-91ab-9078883985dc" />

API関連after
- After
  - `PATCH /api/v1/users/me/settings` の更新後の Swagger UI
  - `input_minutes` / `output_minutes` / `break_minutes` が `1〜120` の整数であること
  - `notification_enabled` が boolean であること
  - 各フィールドの example が OpenAPI schema に反映されていること
<img width="1440" height="4982" alt="users-me-settings-patch-after" src="https://github.com/user-attachments/assets/ece08538-ae7f-4e20-b65b-1dd75cf053df" />
<img width="1440" height="4813" alt="swagger-after" src="https://github.com/user-attachments/assets/9037fc1d-0e85-483f-a2df-a91868adf055" />


<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->

## チェックリスト

- [x] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [x] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
