### PR TITLE
feat: アカウント削除を即時物理削除に変更し Firebase Auth ユーザも削除する

### DIFF
--- a/backend/src/application/use_cases/delete_account.py
+++ b/backend/src/application/use_cases/delete_account.py
@@ -1,30 +1,51 @@
-"""DELETE /users/me の UseCase（論理削除）。
+"""DELETE /users/me の UseCase（即時物理削除）。
 
-`users.deleted_at` をセットし、`fcm_token` をクリアする。user_settings / sessions /
-outputs / judgments は FK ondelete=CASCADE を張っているが、本 UseCase では DB 行
-を物理削除しないため連鎖削除は発生しない。30 日後のバッチジョブ（Issue #61）で
-物理削除される時点で FK CASCADE が効く。Firebase Authentication 上のアカウント
-自体の削除は本 UseCase の責務外で、mobile 側で signOut させる方針。
+退会方針:
+1. Firebase Auth ユーザを削除する
+   - UserNotFound（既に Firebase 側に存在しない）は握り潰して退会を続行する
+   - その他のエラーは例外をそのまま伝播し、DB 削除はスキップする
+2. DB の users 行を物理削除する
+   - delete_by_id は rowcount=0 を許容する（冪等）
+   - commit 後、FK ondelete=CASCADE により user_settings / sessions / outputs / judgments
+     などの関連データも削除される
+
+注意:
+- Firebase 削除と DB 削除は原子的ではない。Firebase 削除成功後に DB 削除が失敗した
+  場合は Firebase 側だけが削除済みで DB 行が残る可能性がある。本実装では補償ジョブや
+  リトライキューは設けず、運用上のレアケースとして許容する。
+- `users.deleted_at` カラムや `User.with_deleted_at()` は本 UseCase では使用しないが、
+  将来の運用変更（30 日猶予への回帰など）に備えて削除せず残している。
+- 退会後に同じ外部認証アカウントで再ログインした場合は、新規ユーザーとして再登録される
+  想定とする（Firebase UID 再利用に関する仕様の断言はしない）。
 """
 
-from datetime import UTC, datetime
+import contextlib
 
 from src.application.unit_of_work import UnitOfWorkFactory
 from src.domain.entities.user import User
+from src.domain.services.auth_account_admin import (
+    AuthAccountAdmin,
+    AuthAccountNotFoundError,
+)
 
 
 class DeleteAccount:
-    """認証済みユーザ自身のアカウントを論理削除する。"""
+    """認証済みユーザ自身のアカウントを Firebase Auth ごと物理削除する。"""
 
-    def __init__(self, unit_of_work_factory: UnitOfWorkFactory) -> None:
-        self.unit_of_work_factory = unit_of_work_factory
+    def __init__(
+        self,
+        unit_of_work_factory: UnitOfWorkFactory,
+        auth_account_admin: AuthAccountAdmin,
+    ) -> None:
+        self._unit_of_work_factory = unit_of_work_factory
+        self._auth_account_admin = auth_account_admin
 
     async def execute(self, current_user: User) -> None:
-        if current_user.deleted_at is not None:
-            # 認証 use case が生きているユーザのみ渡す前提だが、冪等性のため
-            # 既に削除済みなら no-op として扱う。
-            return
-        soft_deleted = current_user.with_deleted_at(deleted_at=datetime.now(UTC))
-        async with self.unit_of_work_factory() as uow:
-            await uow.users.update(soft_deleted)
+        # 1) Firebase Auth ユーザの削除。NotFound は冪等に成功扱い、それ以外は例外伝播。
+        with contextlib.suppress(AuthAccountNotFoundError):
+            await self._auth_account_admin.delete_user(current_user.firebase_uid)
+
+        # 2) DB users 行の物理削除（FK CASCADE で関連データも削除される）。
+        async with self._unit_of_work_factory() as uow:
+            await uow.users.delete_by_id(current_user.id)
             await uow.commit()

--- a/backend/src/container.py
+++ b/backend/src/container.py
@@ -29,6 +29,7 @@ from src.application.use_cases.update_user_settings import UpdateUserSettings
 from src.config import Settings
 from src.domain.services.output_image_storage import OutputImageStorage
 from src.infrastructure.auth.firebase_auth import FirebaseAuthVerifier
+from src.infrastructure.auth.firebase_auth_account_admin import FirebaseAuthAccountAdmin
 from src.infrastructure.llm.factory import build_llm_judge_service
 from src.infrastructure.persistence.database import Database
 from src.infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
@@ -123,7 +124,10 @@ def build_container(settings: Settings) -> Container:
         update_user_profile=UpdateUserProfile(unit_of_work_factory=unit_of_work_factory),
         get_user_settings=GetUserSettings(unit_of_work_factory=unit_of_work_factory),
         update_user_settings=UpdateUserSettings(unit_of_work_factory=unit_of_work_factory),
-        delete_account=DeleteAccount(unit_of_work_factory=unit_of_work_factory),
+        delete_account=DeleteAccount(
+            unit_of_work_factory=unit_of_work_factory,
+            auth_account_admin=FirebaseAuthAccountAdmin(settings=settings),
+        ),
         create_session=CreateSession(unit_of_work_factory=unit_of_work_factory),
         update_session_status=UpdateSessionStatus(unit_of_work_factory=unit_of_work_factory),
         submit_text_output=SubmitTextOutput(unit_of_work_factory=unit_of_work_factory),

--- a/backend/src/domain/services/auth_account_admin.py
+++ b/backend/src/domain/services/auth_account_admin.py
@@ -1,0 +1,30 @@
+"""外部認証プロバイダー上のユーザ管理サービス IF。
+
+退会フローでは backend DB と外部認証側のユーザを両方削除する必要があるため、
+DB 永続化とは独立した IF として切り出す。具体実装は
+`infrastructure/auth/firebase_auth_account_admin.py` にあり、Composition Root で
+組み立てる。Application 層は本インタフェース経由でのみ削除処理を呼ぶ。
+"""
+
+from abc import ABC, abstractmethod
+
+
+class AuthAccountNotFoundError(Exception):
+    """対象 uid が外部認証プロバイダー側に存在しなかった。
+
+    既に削除済みのアカウントを再削除するケースなどで発生する。退会 UseCase は
+    本例外を idempotent に握り潰し、DB 削除を続行する。
+    """
+
+
+class AuthAccountAdmin(ABC):
+    """外部認証プロバイダー上のユーザを管理するサービス。"""
+
+    @abstractmethod
+    async def delete_user(self, uid: str) -> None:
+        """指定 uid のユーザを削除する。
+
+        対象が既に存在しない場合は AuthAccountNotFoundError を送出する。
+        それ以外のエラー（ネットワーク / 認証情報不備 等）は原例外をそのまま伝播し、
+        呼び出し元（退会 UseCase）で DB 削除をスキップして処理を中断させる。
+        """

--- a/backend/src/infrastructure/auth/firebase_auth_account_admin.py
+++ b/backend/src/infrastructure/auth/firebase_auth_account_admin.py
@@ -1,0 +1,78 @@
+"""Firebase Admin SDK を使った外部認証ユーザの削除。
+
+Firebase Admin SDK の `auth.delete_user` は同期 API のため、FastAPI の event loop を
+ブロックしないよう anyio の to_thread で別スレッドへ逃がす。
+
+既存の `FirebaseAuthVerifier` と同じく、Settings から credential を解決し、`id(self)`
+ベースのユニーク name で `initialize_app` する。同一プロセス内に複数の Firebase App が
+共存することを許容するパターンで、Verifier の app と二重初期化エラーになるのを避ける。
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import TYPE_CHECKING
+
+import anyio.to_thread
+import firebase_admin
+from firebase_admin import auth as firebase_auth
+from firebase_admin import credentials
+
+from src.domain.services.auth_account_admin import (
+    AuthAccountAdmin,
+    AuthAccountNotFoundError,
+)
+
+if TYPE_CHECKING:
+    from src.config import Settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class FirebaseAuthAccountAdmin(AuthAccountAdmin):
+    """Firebase Auth 上のユーザを削除するアダプタ。"""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._app: firebase_admin.App | None = None
+
+    async def delete_user(self, uid: str) -> None:
+        app = self._get_app()
+        logger.info(
+            "firebase delete_user start uid=%s project=%s app=%s",
+            uid,
+            self._settings.firebase_project_id,
+            app.name,
+        )
+        try:
+            await anyio.to_thread.run_sync(partial(firebase_auth.delete_user, uid, app=app))
+        except firebase_auth.UserNotFoundError as exc:
+            logger.warning("firebase delete_user not_found uid=%s", uid)
+            raise AuthAccountNotFoundError(uid) from exc
+        except Exception:
+            logger.exception("firebase delete_user failed uid=%s", uid)
+            raise
+        else:
+            logger.info("firebase delete_user success uid=%s", uid)
+
+    def _get_app(self) -> firebase_admin.App:
+        """Firebase Admin SDK の App を遅延初期化する。"""
+        if self._app is not None:
+            return self._app
+        cred_path = self._settings.firebase_credentials_path
+        cred = credentials.Certificate(cred_path) if cred_path else credentials.ApplicationDefault()
+        # 同一プロセス内で複数回初期化されないよう、Verifier 側と被らない一意な name を付ける。
+        self._app = firebase_admin.initialize_app(
+            cred,
+            {"projectId": self._settings.firebase_project_id},
+            name=f"hourglass-account-admin-{id(self)}",
+        )
+        logger.info(
+            "firebase admin app initialized name=%s project=%s cred_path=%s",
+            self._app.name,
+            self._settings.firebase_project_id,
+            cred_path,
+        )
+        return self._app

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,6 +3,7 @@
 Composition Root でコンテナを組み立て、ルーターを束ねる。
 """
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -28,6 +29,11 @@ def create_app(
 ) -> FastAPI:
     """FastAPI アプリを生成する。テストでは `container` を差し替えて fake 実装を注入する。"""
     resolved_settings = settings or get_settings()
+    # アプリ独自 logger（src.* 配下）の INFO ログが uvicorn 経由で表示されるように、
+    # root logger のレベルを Settings に合わせて引き下げる。force=False で uvicorn の
+    # 既存 handler 設定は維持する。
+    logging.basicConfig(level=resolved_settings.log_level)
+    logging.getLogger("src").setLevel(resolved_settings.log_level)
     resolved_container: Container = container or build_container(resolved_settings)
 
     @asynccontextmanager

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,6 +37,7 @@ from src.config import Settings
 from src.container import Container
 from src.infrastructure.persistence.database import Database
 from src.main import create_app
+from tests.fakes.fake_auth_account_admin import FakeAuthAccountAdmin
 from tests.fakes.fake_auth_verifier import FakeAuthVerifier
 from tests.fakes.fake_judgment_progress_repository import FakeJudgmentProgressRepository
 from tests.fakes.fake_judgment_repository import FakeJudgmentRepository
@@ -101,6 +102,11 @@ def fake_auth_verifier() -> FakeAuthVerifier:
 
 
 @pytest.fixture
+def fake_auth_account_admin() -> FakeAuthAccountAdmin:
+    return FakeAuthAccountAdmin()
+
+
+@pytest.fixture
 def container(
     settings: Settings,
     fake_user_repository: FakeUserRepository,
@@ -111,6 +117,7 @@ def container(
     fake_judgment_progress_repository: FakeJudgmentProgressRepository,
     fake_stats_repository: FakeStatsRepository,
     fake_auth_verifier: FakeAuthVerifier,
+    fake_auth_account_admin: FakeAuthAccountAdmin,
 ) -> Container:
     """fake 実装を差し込んだ Container。"""
     database = Database(database_url=settings.database_url)
@@ -137,7 +144,10 @@ def container(
         update_user_profile=UpdateUserProfile(unit_of_work_factory=unit_of_work_factory),
         get_user_settings=GetUserSettings(unit_of_work_factory=unit_of_work_factory),
         update_user_settings=UpdateUserSettings(unit_of_work_factory=unit_of_work_factory),
-        delete_account=DeleteAccount(unit_of_work_factory=unit_of_work_factory),
+        delete_account=DeleteAccount(
+            unit_of_work_factory=unit_of_work_factory,
+            auth_account_admin=fake_auth_account_admin,
+        ),
         create_session=CreateSession(unit_of_work_factory=unit_of_work_factory),
         update_session_status=UpdateSessionStatus(unit_of_work_factory=unit_of_work_factory),
         submit_text_output=SubmitTextOutput(unit_of_work_factory=unit_of_work_factory),
@@ -160,9 +170,14 @@ def container(
 
 @pytest_asyncio.fixture
 async def client(settings: Settings, container: Container) -> AsyncIterator[AsyncClient]:
-    """ASGITransport で lifespan を実行しながら HTTP 呼び出しできる AsyncClient。"""
+    """ASGITransport で lifespan を実行しながら HTTP 呼び出しできる AsyncClient。
+
+    `raise_app_exceptions=False` にして、未捕捉例外も `unexpected_exception_handler`
+    が 500 にラップして応答するようにする。これによりテストから HTTP ステータスコード
+    として 500 を検証できる（DELETE /users/me で Firebase エラー時の挙動など）。
+    """
     app = create_app(settings=settings, container=container)
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with (
         AsyncClient(transport=transport, base_url="http://testserver") as ac,
         app.router.lifespan_context(app),

--- a/backend/tests/fakes/fake_auth_account_admin.py
+++ b/backend/tests/fakes/fake_auth_account_admin.py
@@ -1,0 +1,25 @@
+"""テスト用の AuthAccountAdmin fake。
+
+呼び出された uid を `deleted_uids` に記録する。`not_found_uids` に含まれる uid は
+`AuthAccountNotFoundError` を送出し、`error_uid_to_raise` に登録された uid は任意の
+例外を再現する。
+"""
+
+from src.domain.services.auth_account_admin import (
+    AuthAccountAdmin,
+    AuthAccountNotFoundError,
+)
+
+
+class FakeAuthAccountAdmin(AuthAccountAdmin):
+    def __init__(self) -> None:
+        self.deleted_uids: list[str] = []
+        self.not_found_uids: set[str] = set()
+        self.error_uid_to_raise: dict[str, Exception] = {}
+
+    async def delete_user(self, uid: str) -> None:
+        self.deleted_uids.append(uid)
+        if uid in self.error_uid_to_raise:
+            raise self.error_uid_to_raise[uid]
+        if uid in self.not_found_uids:
+            raise AuthAccountNotFoundError(uid)

--- a/backend/tests/integration/test_api_users_settings.py
+++ b/backend/tests/integration/test_api_users_settings.py
@@ -6,6 +6,7 @@ FakeAuthVerifier + FakeUserRepository 経由で、実 DB / Firebase 無しで経
 import pytest
 from httpx import AsyncClient
 
+from tests.fakes.fake_auth_account_admin import FakeAuthAccountAdmin
 from tests.fakes.fake_user_repository import FakeUserRepository
 
 
@@ -128,51 +129,108 @@ async def test_delete_account_requires_authorization_header(client: AsyncClient)
 
 
 @pytest.mark.asyncio
-async def test_delete_account_soft_deletes_user_and_returns_204(
-    client: AsyncClient, fake_user_repository: FakeUserRepository
+async def test_delete_account_returns_204_and_invokes_firebase_delete(
+    client: AsyncClient, fake_auth_account_admin: FakeAuthAccountAdmin
 ):
+    """DELETE /users/me が 204 を返し、Firebase 削除が呼ばれることを確認する。
+
+    DB 上の cascade 削除は fake repository では再現せず、別途 DB integration test に委ねる。
+    本ケースでは API レベルの応答と Firebase 連携の発火だけを検証する。
+    """
     headers = {"Authorization": "Bearer settings-user-delete"}
     # 初回 GET で users + user_settings を AuthenticateUser に作らせる
     get_response = await client.get("/api/v1/users/me/settings", headers=headers)
     assert get_response.status_code == 200
-    assert "settings-user-delete" in fake_user_repository.users
 
     delete_response = await client.delete("/api/v1/users/me", headers=headers)
     assert delete_response.status_code == 204
     assert delete_response.text == ""
 
-    # 論理削除: 行は残り、deleted_at がセットされ、fcm_token がクリアされる
-    soft_deleted = fake_user_repository.users["settings-user-delete"]
-    assert soft_deleted.deleted_at is not None
-    assert soft_deleted.fcm_token is None
-    # user_settings は保持される（30 日後バッチで物理削除される時点で CASCADE）
-    assert soft_deleted.id in fake_user_repository.settings
+    # Firebase 側の削除が対象 uid 1 件で呼ばれたことを確認する
+    assert fake_auth_account_admin.deleted_uids == ["settings-user-delete"]
 
 
 @pytest.mark.asyncio
-async def test_protected_api_returns_401_after_account_deleted(
-    client: AsyncClient,
+async def test_post_delete_request_with_same_token_creates_new_user(
+    client: AsyncClient, fake_user_repository: FakeUserRepository
 ):
-    """論理削除後に同じトークンで保護 API を叩くと 401 になる（再利用防止）。"""
+    """退会後に同じ Bearer トークンで再アクセスすると、新規ユーザーとして再登録される。
+
+    実プロダクションでは Firebase Auth 側で対象 UID が削除されるため、その UID で発行
+    された ID Token は失効して認証段階で 401 になる。本テストは fake AuthVerifier を
+    使うため、認証段階を通過した後の backend 側挙動 (= 新規ユーザ作成) を検証する。
+    """
     headers = {"Authorization": "Bearer settings-user-afterdel"}
-    assert (await client.get("/api/v1/users/me/settings", headers=headers)).status_code == 200
+    first = await client.get("/api/v1/users/me/settings", headers=headers)
+    assert first.status_code == 200
+    first_user_id = fake_user_repository.users["settings-user-afterdel"].id
+
     assert (await client.delete("/api/v1/users/me", headers=headers)).status_code == 204
+    # DB 上の user 行は物理削除されている
+    assert "settings-user-afterdel" not in fake_user_repository.users
 
     retry = await client.get("/api/v1/users/me/settings", headers=headers)
-    assert retry.status_code == 401
-    body = retry.json()
-    assert body["type"] == "authentication_required"
+    assert retry.status_code == 200
+    # 同じ firebase_uid で別 user_id の行が新規作成されている
+    new_user_id = fake_user_repository.users["settings-user-afterdel"].id
+    assert new_user_id != first_user_id
 
 
 @pytest.mark.asyncio
-async def test_delete_account_second_call_returns_401_for_already_deleted_user(
-    client: AsyncClient,
+async def test_delete_account_second_call_after_reregistration_succeeds(
+    client: AsyncClient, fake_auth_account_admin: FakeAuthAccountAdmin
 ):
-    """2 度目の DELETE は認証 use case 段階で 401 になる。"""
+    """退会 → 同じ Bearer で再アクセス（新規再登録）→ 再退会 が冪等に成功する。"""
     headers = {"Authorization": "Bearer settings-user-twicedel"}
     await client.get("/api/v1/users/me/settings", headers=headers)
     first = await client.delete("/api/v1/users/me", headers=headers)
     assert first.status_code == 204
 
+    # 再アクセスで新規ユーザーとして作り直され、再退会も 204 を返す。
+    await client.get("/api/v1/users/me/settings", headers=headers)
     second = await client.delete("/api/v1/users/me", headers=headers)
-    assert second.status_code == 401
+    assert second.status_code == 204
+    # Firebase 削除は 2 回呼ばれている
+    assert fake_auth_account_admin.deleted_uids == [
+        "settings-user-twicedel",
+        "settings-user-twicedel",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_account_treats_firebase_user_not_found_as_success(
+    client: AsyncClient,
+    fake_auth_account_admin: FakeAuthAccountAdmin,
+    fake_user_repository: FakeUserRepository,
+):
+    """Firebase 側で対象 uid が既に存在しないケースでも 204 を返し DB 削除は実行される。"""
+    headers = {"Authorization": "Bearer settings-user-fbmissing"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+    fake_auth_account_admin.not_found_uids.add("settings-user-fbmissing")
+
+    response = await client.delete("/api/v1/users/me", headers=headers)
+    assert response.status_code == 204
+
+    # Firebase 削除は試行された
+    assert "settings-user-fbmissing" in fake_auth_account_admin.deleted_uids
+    # DB users 行は物理削除されている
+    assert "settings-user-fbmissing" not in fake_user_repository.users
+
+
+@pytest.mark.asyncio
+async def test_delete_account_returns_500_when_firebase_fails_and_keeps_db_row(
+    client: AsyncClient, fake_auth_account_admin: FakeAuthAccountAdmin
+):
+    """Firebase その他エラー時は 500 を返し、DB 行は残る (退会処理が中断される)。"""
+    headers = {"Authorization": "Bearer settings-user-fberror"}
+    await client.get("/api/v1/users/me/settings", headers=headers)
+    fake_auth_account_admin.error_uid_to_raise["settings-user-fberror"] = RuntimeError(
+        "firebase down"
+    )
+
+    response = await client.delete("/api/v1/users/me", headers=headers)
+    assert response.status_code == 500
+
+    # 退会前の保護 API はまだ通る (= DB 行が残っている)
+    retry = await client.get("/api/v1/users/me/settings", headers=headers)
+    assert retry.status_code == 200

--- a/backend/tests/unit/test_use_cases/test_delete_account.py
+++ b/backend/tests/unit/test_use_cases/test_delete_account.py
@@ -1,4 +1,11 @@
-"""DeleteAccount UseCase の振る舞い（論理削除）。"""
+"""DeleteAccount UseCase の振る舞い（即時物理削除）。
+
+退会フローの方針:
+- Firebase Auth ユーザを削除 → DB users 行を物理削除（FK CASCADE で関連連鎖）
+- Firebase の UserNotFound は握り潰す
+- それ以外の Firebase エラーは伝播し、DB 削除はスキップする
+- Firebase 成功 + DB 失敗の非原子性は許容（補償処理は本実装にない）
+"""
 
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -9,6 +16,7 @@ from src.application.use_cases.delete_account import DeleteAccount
 from src.domain.entities.user import User
 from src.domain.entities.user_settings import UserSettings
 from src.domain.value_objects.auth_provider import AuthProvider
+from tests.fakes.fake_auth_account_admin import FakeAuthAccountAdmin
 from tests.fakes.fake_unit_of_work import FakeUnitOfWork
 from tests.fakes.fake_user_repository import FakeUserRepository
 
@@ -31,38 +39,101 @@ def _make_user_with_settings() -> tuple[User, UserSettings]:
     return user, settings
 
 
+def _build_use_case(
+    repo: FakeUserRepository,
+    auth_admin: FakeAuthAccountAdmin,
+) -> DeleteAccount:
+    return DeleteAccount(
+        unit_of_work_factory=lambda: FakeUnitOfWork(users=repo),
+        auth_account_admin=auth_admin,
+    )
+
+
 @pytest.mark.asyncio
-async def test_delete_account_soft_deletes_user_and_preserves_settings():
+async def test_execute_deletes_firebase_user_and_db_row():
     repo = FakeUserRepository()
     user, settings = _make_user_with_settings()
     await repo.add(user, settings)
+    auth_admin = FakeAuthAccountAdmin()
 
-    use_case = DeleteAccount(unit_of_work_factory=lambda: FakeUnitOfWork(users=repo))
-    await use_case.execute(user)
+    await _build_use_case(repo, auth_admin).execute(user)
 
-    # 行は残り、deleted_at がセットされ、fcm_token がクリアされる
-    stored = repo.users[user.firebase_uid]
-    assert stored.deleted_at is not None
-    assert stored.fcm_token is None
-    # user_settings は保持される（30 日後バッチで物理削除されるまで残す）
+    # Firebase 削除が呼ばれた
+    assert auth_admin.deleted_uids == [user.firebase_uid]
+    # DB 上の users 行と user_settings が消えている
+    assert user.firebase_uid not in repo.users
+    assert user.id not in repo.settings
+
+
+@pytest.mark.asyncio
+async def test_execute_swallows_firebase_user_not_found_and_continues_db_delete():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+    auth_admin = FakeAuthAccountAdmin()
+    auth_admin.not_found_uids.add(user.firebase_uid)
+
+    await _build_use_case(repo, auth_admin).execute(user)
+
+    # NotFound は握り潰される (例外は出ない)
+    assert auth_admin.deleted_uids == [user.firebase_uid]
+    # DB 削除はそのまま実行される
+    assert user.firebase_uid not in repo.users
+
+
+@pytest.mark.asyncio
+async def test_execute_propagates_firebase_error_without_db_delete():
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+    auth_admin = FakeAuthAccountAdmin()
+    auth_admin.error_uid_to_raise[user.firebase_uid] = RuntimeError("firebase down")
+
+    with pytest.raises(RuntimeError, match="firebase down"):
+        await _build_use_case(repo, auth_admin).execute(user)
+
+    # DB は無変更
+    assert user.firebase_uid in repo.users
     assert user.id in repo.settings
-    # find_by_firebase_uid 経由では生きているユーザとして見えない
-    assert await repo.find_by_firebase_uid(user.firebase_uid) is None
 
 
 @pytest.mark.asyncio
-async def test_delete_account_is_idempotent():
-    """既に削除済みのユーザーに対して例外を投げず、deleted_at も上書きしない。"""
+async def test_execute_propagates_db_error_after_firebase_delete_succeeded():
+    """非原子性を許容する設計の確認。
+
+    Firebase 削除は成功したが DB 削除で例外が発生した場合、例外は呼び出し元へ伝播する。
+    Firebase 側は既に削除済みのままになるが、本実装では補償処理は行わない。
+    """
     repo = FakeUserRepository()
     user, settings = _make_user_with_settings()
     await repo.add(user, settings)
+    auth_admin = FakeAuthAccountAdmin()
 
-    use_case = DeleteAccount(unit_of_work_factory=lambda: FakeUnitOfWork(users=repo))
+    async def _raise_db_error(_user_id):  # noqa: ANN001 -- monkeypatched stub
+        raise RuntimeError("db down")
+
+    repo.delete_by_id = _raise_db_error  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await _build_use_case(repo, auth_admin).execute(user)
+
+    # Firebase 削除は呼ばれた
+    assert auth_admin.deleted_uids == [user.firebase_uid]
+
+
+@pytest.mark.asyncio
+async def test_execute_is_idempotent_when_db_row_already_missing():
+    """既に DB 行が無いユーザーへの再実行も例外にならない。"""
+    repo = FakeUserRepository()
+    user, settings = _make_user_with_settings()
+    await repo.add(user, settings)
+    auth_admin = FakeAuthAccountAdmin()
+
+    use_case = _build_use_case(repo, auth_admin)
     await use_case.execute(user)
-    first_deleted_at = repo.users[user.firebase_uid].deleted_at
-    assert first_deleted_at is not None
+    # 2 回目: DB 行は既に消えているが例外にはならない
+    auth_admin.not_found_uids.add(user.firebase_uid)
+    await use_case.execute(user)
 
-    # 既に削除済みの User を渡しても例外にならず、deleted_at も上書きされない
-    already_deleted = repo.users[user.firebase_uid]
-    await use_case.execute(already_deleted)
-    assert repo.users[user.firebase_uid].deleted_at == first_deleted_at
+    assert user.firebase_uid not in repo.users
+    assert auth_admin.deleted_uids == [user.firebase_uid, user.firebase_uid]

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -6,7 +6,11 @@
  * - `setTokenProvider`: API リクエスト毎に最新の ID Token を Authorization に差し込む
  * - `setTokenRefresher`: 401 を受けた際に Firebase から ID Token を再取得させる
  * - `subscribeIdTokenChanged`: Firebase の onIdTokenChanged を購読して authStore に反映する
- * - `ensureAnonymousSession`: 未サインイン時に匿名 UID を作成し、登録なし利用を可能にする
+ *
+ * 匿名 sign-in (`ensureAnonymousSession`) は本ファイルでは呼ばない。退会後に
+ * onIdTokenChanged が session=null で発火した瞬間に匿名ユーザーが自動作成され、
+ * 「削除したのに Firebase Auth に新しい匿名ユーザーが残る」現象が起きるため、
+ * 匿名作成は OverviewScreen の「はじめる」ボタン押下時のユーザーアクションに紐付ける。
  */
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
@@ -16,11 +20,7 @@ import { TamaguiProvider } from 'tamagui';
 import config from '../tamagui.config';
 import { configureGoogleSignIn } from '@/features/auth/lib/signInWithGoogle';
 import { AuthGate } from '@/shared/components/AuthGate';
-import {
-  ensureAnonymousSession,
-  refreshIdToken,
-  subscribeIdTokenChanged,
-} from '@/shared/lib/firebase';
+import { refreshIdToken, subscribeIdTokenChanged } from '@/shared/lib/firebase';
 import { installDevMockAuth } from '@/shared/lib/devMockAuth';
 import { initializeFirebaseAuth } from '@/shared/lib/firebaseAuth';
 import { setTokenProvider, setTokenRefresher } from '@/shared/lib/api';
@@ -43,10 +43,10 @@ export default function RootLayout() {
     const unsubscribe = subscribeIdTokenChanged((session) => {
       const { setSession, clear } = useAuthStore.getState();
       if (session === null) {
+        // 退会後やログアウト後の自動匿名再 sign-in は意図的に行わない。
+        // ユーザーが OverviewScreen の「はじめる」を押すか、(auth)/sign-in で
+        // 正式登録するまでは未認証状態のまま AuthGate が画面遷移を制御する。
         clear();
-        // 初回起動 / signOut / token 期限切れのいずれでも未サインイン状態に陥った場合は
-        // 匿名で接続し直し、未登録ユーザーでもタイマー / LLM 判定を継続できるようにする。
-        void ensureAnonymousSession();
       } else {
         setSession(session.uid, session.idToken, session.isAnonymous);
       }

--- a/mobile/src/features/auth/screens/OverviewScreen.tsx
+++ b/mobile/src/features/auth/screens/OverviewScreen.tsx
@@ -1,7 +1,9 @@
 /**
  * スプラッシュ後に表示する概要説明画面。
  *
- * ボタン操作でチュートリアル Step1 へ遷移する。
+ * 「はじめる」ボタン押下時に Firebase Anonymous Auth で匿名ユーザーを作成してから
+ * チュートリアル Step1 へ遷移する。匿名 sign-in をユーザーアクション起点にすることで、
+ * 退会後やログアウト後に裏で匿名ユーザーが自動再作成される現象を防いでいる。
  */
 import { useRouter, type Href } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -13,6 +15,7 @@ import {
   OVERVIEW_ACTION_BUTTON_HEIGHT,
   TUTORIAL_ROUTE_TRANSITION_DELAY_MS,
 } from '@/features/auth/screens/tutorialConfig';
+import { ensureAnonymousSession } from '@/shared/lib/firebase';
 
 const OVERVIEW_BACKGROUND = require('../../../../assets/images/backgrounds/overview.jpg');
 const TYPOGRAPHY_WHITE = require('../../../../assets/images/logos/typography_white.png');
@@ -32,7 +35,19 @@ export function OverviewScreen() {
 
     setIsNavigating(true);
     navigationTimeoutRef.current = setTimeout(() => {
-      router.replace(TUTORIAL_STEP_ONE_ROUTE);
+      void (async () => {
+        try {
+          // 匿名 sign-in は本ボタン押下を起点に Firebase Auth 上のユーザーを作成する。
+          // 既に currentUser が存在する場合 (Apple/Google 復帰直後など) は内部で
+          // early return するため二重作成は起きない。
+          await ensureAnonymousSession();
+          router.replace(TUTORIAL_STEP_ONE_ROUTE);
+        } catch {
+          // ネットワーク障害などで sign-in に失敗した場合はボタン押下をやり直せるよう
+          // isNavigating を戻す。エラーメッセージ表示の追加は別 Issue で扱う。
+          setIsNavigating(false);
+        }
+      })();
     }, TUTORIAL_ROUTE_TRANSITION_DELAY_MS);
   }, [isNavigating, router]);
 

--- a/mobile/src/features/auth/screens/__tests__/OverviewScreen.test.tsx
+++ b/mobile/src/features/auth/screens/__tests__/OverviewScreen.test.tsx
@@ -1,19 +1,26 @@
 /**
  * OverviewScreen の初期表示とボタン遷移を検証する。
  */
-import { act, cleanup, fireEvent, render } from '@testing-library/react-native';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { TamaguiProvider } from 'tamagui';
 
 import config from '../../../../../tamagui.config';
 import { OverviewScreen } from '@/features/auth/screens/OverviewScreen';
 import { TUTORIAL_ROUTE_TRANSITION_DELAY_MS } from '@/features/auth/screens/tutorialConfig';
+import { ensureAnonymousSession } from '@/shared/lib/firebase';
 
 const mockReplace = jest.fn();
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ replace: mockReplace }),
 }));
+
+jest.mock('@/shared/lib/firebase', () => ({
+  ensureAnonymousSession: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockedEnsureAnonymousSession = ensureAnonymousSession as jest.Mock;
 
 function renderWithProviders(ui: ReactNode) {
   return render(
@@ -51,20 +58,54 @@ describe('OverviewScreen', () => {
     expect(screen.getByText('はじめる')).toBeTruthy();
   });
 
-  it('次へは少し待ってからチュートリアル Step1 へ進む', () => {
+  it('次へは少し待ってから匿名 sign-in を実行し、チュートリアル Step1 へ進む', async () => {
     const screen = renderWithProviders(<OverviewScreen />);
 
     fireEvent.press(screen.getByTestId('overview-next'));
 
+    expect(mockedEnsureAnonymousSession).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
     act(() => {
       jest.advanceTimersByTime(TUTORIAL_ROUTE_TRANSITION_DELAY_MS - 1);
     });
-    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockedEnsureAnonymousSession).not.toHaveBeenCalled();
 
     act(() => {
       jest.advanceTimersByTime(1);
     });
-    expect(mockReplace).toHaveBeenCalledWith('/(auth)/tutorial-step-one');
+    await waitFor(() => {
+      expect(mockedEnsureAnonymousSession).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(auth)/tutorial-step-one');
+    });
+  });
+
+  it('匿名 sign-in に失敗した場合は遷移せずボタンが再度押せるようになる', async () => {
+    mockedEnsureAnonymousSession.mockRejectedValueOnce(new Error('network down'));
+    const screen = renderWithProviders(<OverviewScreen />);
+
+    fireEvent.press(screen.getByTestId('overview-next'));
+    act(() => {
+      jest.advanceTimersByTime(TUTORIAL_ROUTE_TRANSITION_DELAY_MS);
+    });
+
+    await waitFor(() => {
+      expect(mockedEnsureAnonymousSession).toHaveBeenCalledTimes(1);
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    // 再度ボタンが効くこと (isNavigating が false に戻った検証)
+    mockedEnsureAnonymousSession.mockResolvedValueOnce(undefined);
+    fireEvent.press(screen.getByTestId('overview-next'));
+    act(() => {
+      jest.advanceTimersByTime(TUTORIAL_ROUTE_TRANSITION_DELAY_MS);
+    });
+    await waitFor(() => {
+      expect(mockedEnsureAnonymousSession).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(auth)/tutorial-step-one');
+    });
   });
 });

--- a/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
+++ b/mobile/src/features/settings/hooks/__tests__/useDeleteAccount.test.ts
@@ -1,17 +1,25 @@
 /**
  * useDeleteAccount の振る舞いを検証する。
- * 成功時に QueryClient のキャッシュ全消去と authStore のクリアが行われることを担保する。
+ * 成功時に Firebase signOut → QueryClient のキャッシュ全消去 → authStore のクリアが
+ * 行われることを担保する。signOut は failure を握り潰すが、finally で authStore は
+ * clear される (signOut.ts の実装に依存)。
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react-native';
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
 
+import * as signOutLib from '@/features/auth/lib/signOut';
 import * as settingsApi from '@/features/settings/api/settingsApi';
 import { useDeleteAccount } from '@/features/settings/hooks/useDeleteAccount';
 import { useAuthStore } from '@/shared/stores/authStore';
 
 jest.mock('@/features/settings/api/settingsApi');
+// jest.mock の auto-mock では中で @react-native-firebase/auth が初期化されてしまうため、
+// factory を渡して空 signOut だけを export する明示モックにする。
+jest.mock('@/features/auth/lib/signOut', () => ({
+  signOut: jest.fn().mockResolvedValue(undefined),
+}));
 
 function buildWrapper() {
   const queryClient = new QueryClient({
@@ -40,8 +48,12 @@ describe('useDeleteAccount', () => {
     });
   });
 
-  it('mutate で deleteMyAccount を呼び、成功時に queryClient.clear() と authStore.clear() を実行する', async () => {
+  it('mutate で deleteMyAccount を呼び、成功時に signOut → queryClient.clear() → authStore.clear() を実行する', async () => {
     (settingsApi.deleteMyAccount as jest.Mock).mockResolvedValue(undefined);
+    // 本物の signOut を模倣して finally で authStore を clear する。
+    (signOutLib.signOut as jest.Mock).mockImplementation(async () => {
+      useAuthStore.getState().clear();
+    });
     const { queryClient, wrapper } = buildWrapper();
     queryClient.setQueryData(['profile', 'me'], { id: 'u-1' });
 
@@ -56,8 +68,26 @@ describe('useDeleteAccount', () => {
     });
 
     expect(settingsApi.deleteMyAccount).toHaveBeenCalledTimes(1);
+    expect(signOutLib.signOut).toHaveBeenCalledTimes(1);
     expect(queryClient.getQueryData(['profile', 'me'])).toBeUndefined();
     expect(useAuthStore.getState().uid).toBeNull();
     expect(useAuthStore.getState().idToken).toBeNull();
+  });
+
+  it('signOut が失敗してもエラーを握り潰し、queryClient.clear() は実行する', async () => {
+    (settingsApi.deleteMyAccount as jest.Mock).mockResolvedValue(undefined);
+    (signOutLib.signOut as jest.Mock).mockRejectedValue(new Error('firebase down'));
+    const { queryClient, wrapper } = buildWrapper();
+    queryClient.setQueryData(['profile', 'me'], { id: 'u-1' });
+
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+    act(() => {
+      result.current.mutate();
+    });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(queryClient.getQueryData(['profile', 'me'])).toBeUndefined();
   });
 });

--- a/mobile/src/features/settings/hooks/useDeleteAccount.ts
+++ b/mobile/src/features/settings/hooks/useDeleteAccount.ts
@@ -1,23 +1,30 @@
 /**
  * DELETE /users/me のための useMutation hook。
  *
- * 成功時は QueryClient のキャッシュを全て破棄し、authStore からセッションを消すことで
- * AuthGate が自動的にサインイン画面へ戻す。Firebase Auth 上のサインアウトは呼び出し側
- * （SettingsScreen）の責務にして、副作用の責務を分離する。
+ * 成功時は次の順序で副作用を実行する。
+ * 1. Firebase Auth から signOut() する。Backend 側で Firebase Auth ユーザは既に削除
+ *    されているが、mobile プロセス内の `auth().currentUser` はメモリに残ったままなので
+ *    明示サインアウトしないと、後続の ID Token 取得が「ユーザー未存在」で失敗ループに
+ *    入り画面がローディングで固まる。
+ * 2. QueryClient のキャッシュを全破棄する。退会後に同じ Firebase UID で
+ *    新規ユーザーとして再登録された場合に古いデータが残らないようにする。
+ *
+ * `signOut()` の finally で `useAuthStore.clear()` が呼ばれるため、authStore の
+ * クリアはここでは行わない。AuthGate が `uid===null` を検知して画面側で遷移する想定。
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { signOut } from '@/features/auth/lib/signOut';
 import { deleteMyAccount } from '@/features/settings/api/settingsApi';
-import { useAuthStore } from '@/shared/stores/authStore';
 
 export function useDeleteAccount() {
   const queryClient = useQueryClient();
-  const clearAuth = useAuthStore((s) => s.clear);
   return useMutation<void, Error, void>({
     mutationFn: () => deleteMyAccount(),
-    onSuccess: () => {
+    onSuccess: async () => {
+      // best-effort: signOut が失敗しても authStore は clear される (signOut.ts の finally)。
+      await signOut().catch(() => undefined);
       queryClient.clear();
-      clearAuth();
     },
   });
 }

--- a/mobile/src/features/settings/screens/SettingsScreen.tsx
+++ b/mobile/src/features/settings/screens/SettingsScreen.tsx
@@ -105,8 +105,17 @@ export function SettingsScreen() {
           text: '削除する',
           style: 'destructive',
           onPress: () => {
-            // mutateAsync の例外は onError 経由でエラー表示に流すため、ここでは握り潰す。
-            void deleteAccount.mutateAsync();
+            void (async () => {
+              try {
+                await deleteAccount.mutateAsync();
+                // Backend の物理削除 + Firebase signOut が完了したので、(tabs) 配下から
+                // 確実に (auth) 配下へ抜ける。AuthGate の遷移ロジックは tabs/auth 配下を
+                // 許容するため明示遷移しないと画面が settings のまま残る。
+                router.replace('/(auth)/overview');
+              } catch {
+                // 失敗時のエラー表示は deleteAccount.error 経由で settings の errorText に出す。
+              }
+            })();
           },
         },
       ],

--- a/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
+++ b/mobile/src/features/settings/screens/__tests__/SettingsScreen.test.tsx
@@ -29,6 +29,16 @@ jest.mock('expo-router', () => ({
 }));
 
 jest.mock('@/features/settings/api/settingsApi');
+// 本テストでは Firebase Auth を実初期化しない。signOut は実装側の finally で authStore を
+// clear するため、mock も同じ副作用 (authStore.clear) を再現する。
+jest.mock('@/features/auth/lib/signOut', () => {
+  const { useAuthStore } = jest.requireActual('@/shared/stores/authStore');
+  return {
+    signOut: jest.fn().mockImplementation(async () => {
+      useAuthStore.getState().clear();
+    }),
+  };
+});
 
 const SETTINGS_FIXTURE = {
   input_minutes: 25,
@@ -192,6 +202,10 @@ describe('SettingsScreen', () => {
     });
     await waitFor(() => {
       expect(useAuthStore.getState().uid).toBeNull();
+    });
+    // 削除成功後は AuthGate に頼らず明示的に (auth)/overview へ遷移する。
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/(auth)/overview');
     });
 
     alertSpy.mockRestore();


### PR DESCRIPTION
## 概要

`DELETE /api/v1/users/me` を 30 日猶予の論理削除から即時物理削除に切り替え、Firebase Auth ユーザも併せて削除する。退会後に裏で匿名ユーザーが自動再作成される問題も併せて修正し、退会 → 新規ユーザー再登録の動線を整える。

## 関連 Issue

- Closes #61
- Refs #24

## 変更内容

### backend: 即時物理削除 + Firebase Auth 削除

- `domain/services/auth_account_admin.py` を新規追加し `AuthAccountAdmin` IF と `AuthAccountNotFoundError` を定義
- `infrastructure/auth/firebase_auth_account_admin.py` で `firebase_admin.auth.delete_user` を `anyio.to_thread.run_sync` 経由で呼ぶ実装を追加。`UserNotFoundError` は idempotent に握り潰す
- `application/use_cases/delete_account.py` を全面改訂。Firebase Auth 削除 → DB users 物理削除の順に実行する。FK `ondelete=CASCADE` により関連データは連鎖削除
- `container.py` / `tests/conftest.py` に DI 注入を追加。`FakeAuthAccountAdmin` も追加
- 観測性向上のため `main.py` で `src.*` 配下 logger の INFO ログが uvicorn 経由で表示されるよう `logging.basicConfig` を導入
- unit / integration テストを物理削除前提に更新。Firebase NotFound / Firebase その他エラー / Firebase 成功 + DB 失敗の非原子性ケースを明示テスト

### mobile: 退会後の signOut + 匿名再作成停止 + 画面遷移

- `useDeleteAccount.onSuccess` で Firebase `signOut()` を呼んで `auth().currentUser` を明示的にクリアする
- `SettingsScreen` で削除成功後に `router.replace('/(auth)/overview')` で確実に auth 配下へ遷移する
- `app/_layout.tsx` の `subscribeIdTokenChanged` listener から自動 `ensureAnonymousSession()` 呼び出しを削除。退会・ログアウト・token 期限切れで session=null になっても匿名ユーザーが裏で再作成されない
- `OverviewScreen` の「はじめる」ボタン押下時のみ `ensureAnonymousSession()` を実行する。失敗時はボタン押下を再試行可能にする

## 削除フローの方針 (PR 内サマリ)

```
削除順序:
1. Firebase Auth ユーザを削除する
   - UserNotFound は握り潰す
   - その他エラーは例外伝播し、DB 削除は行わない (HTTP 500)
2. DB users 行を物理削除する
   - delete_by_id は rowcount=0 を許容 (冪等)
   - commit 後、FK CASCADE により関連データも削除される

注意:
- Firebase Auth 削除と DB 削除は原子的ではない
- Firebase 削除成功後に DB 削除が失敗した場合、Firebase は削除済みだが DB 行が残る可能性がある
- このケースへの補償ジョブ・リトライキュー・tombstone 管理は今回の対象外
- users.deleted_at カラム / with_deleted_at() は将来 30 日猶予方針へ戻す可能性に備えて残置するが本実装では使用しない
- 退会後に同じ外部認証アカウントで再ログインした場合は新規ユーザーとして再登録される想定
```

## スコープ外 / 残課題

- 30 日猶予方針 (Issue #61 原文) は採用せず、即時物理削除に変更している
- Cloud Scheduler / Cloud Run Job / `infra/` Terraform は本 PR では作らない
- 実 DB 上の FK CASCADE 動作確認はモデル定義の `ondelete="CASCADE"` 確認に留め、フル DB integration テスト基盤の整備は別 PR
- ログアウト経路では自動匿名再復帰しなくなるため、必要に応じて (auth)/sign-in 画面に「ゲストとして続ける」動線を別途検討する余地あり

## 動作確認

```bash
task ci   # backend 163 passed / mobile 全テスト pass
```

実機:

- [x] 匿名ユーザーで退会 → Firebase Console から該当 uid が消える、新匿名ユーザーが残らない
- [x] 退会後に OverviewScreen に遷移 → 「はじめる」を押すと新規匿名ユーザーが作られて (tabs) に進む
- [x] Apple/Google 登録ユーザーで退会 → Firebase Auth ユーザも DB 行も消える
- [x] 退会後に同じ Apple/Google アカウントで再ログイン → 新規ユーザーとして再登録され、過去のセッション / アウトプット履歴は復元されない

## チェックリスト

- [x] `task ci` がローカルで通る
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書 (`docs/requirements/requirements.md`) と矛盾していない (即時物理削除の方針判断は本 PR で記録)
- [x] 破壊的変更なし (DELETE /users/me の API スキーマは変わらず)