### PR TITLE
fix(backend): GCS signed URL を IAM SignBlob で発行

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -107,8 +107,9 @@ class Settings(BaseSettings):
         default=None,
         description=(
             "GCS 認証用サービスアカウント鍵 JSON のパス。"
-            "未指定時は ADC を使う（その場合 signed URL 発行に private key が必要なので"
-            "Cloud Run 等の workload identity 環境では別途対応が必要）。"
+            "未指定時は ADC を使う。Cloud Run 等の workload identity 環境では"
+            "ランタイム SA の自分自身に対する `roles/iam.serviceAccountTokenCreator` を"
+            "付与しておけば、signed URL は IAM SignBlob 経由で発行される。"
         ),
     )
     gcs_signed_upload_url_ttl_seconds: int = Field(

--- a/backend/src/infrastructure/storage/gcs_output_image_storage.py
+++ b/backend/src/infrastructure/storage/gcs_output_image_storage.py
@@ -3,21 +3,28 @@
 import asyncio
 from datetime import timedelta
 
+import google.auth
+from google.auth import credentials as google_credentials
+from google.auth.transport import requests as google_auth_requests
 from google.cloud import storage
 from google.oauth2 import service_account
 
 from src.domain.services.output_image_storage import OutputImageStorage
 
+# IAM SignBlob を含む GCP 各種 API へアクセスするための広域スコープ。
+_DEFAULT_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
 
 class GcsOutputImageStorage(OutputImageStorage):
     """GCS bucket にアウトプット画像を保管する。
 
-    `credentials_path` が指定されていればサービスアカウント鍵 JSON から
-    認証情報を読み込む。未指定なら ADC（環境変数 / metadata server）に頼る。
-    Signed URL の発行には private key を持つ credentials が必要なので、
-    ローカル開発では `credentials_path` を指定する想定。Cloud Run 等の
-    workload identity 環境では IAM signBlob 経由の signed URL 発行に
-    拡張する余地あり。
+    Signed URL の発行戦略:
+    - `credentials_path` が指定されている場合: サービスアカウント鍵 JSON を読み込み、
+      鍵に含まれる private key で直接 v4 署名する。ローカル開発向け。
+    - 未指定の場合: ADC（環境変数 / metadata server）から credentials を取り、
+      Blob.generate_signed_url の `service_account_email` / `access_token` 引数経由で
+      IAM SignBlob API に署名を委譲する。Cloud Run 等の workload identity 環境向け。
+      ランタイム SA に対し、自分自身への `roles/iam.serviceAccountTokenCreator` が必要。
     """
 
     def __init__(
@@ -30,12 +37,22 @@ class GcsOutputImageStorage(OutputImageStorage):
         client_kwargs: dict[str, object] = {}
         if project_id is not None:
             client_kwargs["project"] = project_id
+
+        signing_credentials: google_credentials.Credentials | None = None
         if credentials_path is not None:
             client_kwargs["credentials"] = service_account.Credentials.from_service_account_file(
                 credentials_path
             )
+            # SA キーは private key を保持しており、generate_signed_url 単独で署名できる。
+        else:
+            adc_credentials, _ = google.auth.default(scopes=list(_DEFAULT_SCOPES))
+            client_kwargs["credentials"] = adc_credentials
+            # private key を持たないため、署名時に IAM SignBlob 経由へフォールバックする。
+            signing_credentials = adc_credentials
+
         self._client = storage.Client(**client_kwargs)
         self._bucket = self._client.bucket(bucket_name)
+        self._signing_credentials = signing_credentials
 
     def issue_upload_url(
         self,
@@ -50,6 +67,7 @@ class GcsOutputImageStorage(OutputImageStorage):
             expiration=timedelta(seconds=ttl_seconds),
             method="PUT",
             content_type=content_type,
+            **self._build_signing_kwargs(),
         )
 
     def issue_download_url(
@@ -63,6 +81,7 @@ class GcsOutputImageStorage(OutputImageStorage):
             version="v4",
             expiration=timedelta(seconds=ttl_seconds),
             method="GET",
+            **self._build_signing_kwargs(),
         )
 
     async def download(self, *, storage_path: str) -> tuple[bytes, str]:
@@ -84,3 +103,25 @@ class GcsOutputImageStorage(OutputImageStorage):
         # best-effort なので呼び出し側で握りつぶす想定。ここでは raise させたまま返す。
         blob = self._bucket.blob(storage_path)
         blob.delete()
+
+    def _build_signing_kwargs(self) -> dict[str, object]:
+        """ADC 経由の場合に generate_signed_url が IAM SignBlob を使うための引数を返す。"""
+        if self._signing_credentials is None:
+            return {}
+        if not self._signing_credentials.valid:
+            self._signing_credentials.refresh(google_auth_requests.Request())
+
+        service_account_email = getattr(self._signing_credentials, "service_account_email", None)
+        if service_account_email is None:
+            # `gcloud auth application-default login` 由来の user credentials は
+            # service_account_email を持たないため IAM SignBlob を呼べない。
+            # ローカルでこのコードに到達した場合は GCS_CREDENTIALS_PATH を設定する。
+            raise RuntimeError(
+                "ADC credentials do not expose 'service_account_email'. "
+                "Provide a service account key via GCS_CREDENTIALS_PATH for local development, "
+                "or run on a workload identity environment (Cloud Run, GCE, GKE)."
+            )
+        return {
+            "service_account_email": service_account_email,
+            "access_token": self._signing_credentials.token,
+        }

--- a/backend/tests/unit/test_infrastructure/test_gcs_output_image_storage.py
+++ b/backend/tests/unit/test_infrastructure/test_gcs_output_image_storage.py
@@ -1,0 +1,65 @@
+import pytest
+
+from src.infrastructure.storage.gcs_output_image_storage import GcsOutputImageStorage
+
+
+class _FakeAdcCredentials:
+    def __init__(
+        self,
+        *,
+        service_account_email_after_refresh: str | None,
+        access_value_after_refresh: str,
+    ) -> None:
+        self.valid = False
+        self.token: str | None = None
+        self.service_account_email: str | None = None
+        self.refresh_calls = 0
+        self._service_account_email_after_refresh = service_account_email_after_refresh
+        self._access_value_after_refresh = access_value_after_refresh
+
+    def refresh(self, _request: object) -> None:
+        self.refresh_calls += 1
+        self.valid = True
+        self.token = self._access_value_after_refresh
+        self.service_account_email = self._service_account_email_after_refresh
+
+
+def _build_storage_with_signing_credentials(
+    credentials: _FakeAdcCredentials | None,
+) -> GcsOutputImageStorage:
+    storage = GcsOutputImageStorage.__new__(GcsOutputImageStorage)
+    storage._signing_credentials = credentials
+    return storage
+
+
+def test_build_signing_kwargs_returns_empty_when_using_service_account_key():
+    storage = _build_storage_with_signing_credentials(None)
+
+    assert storage._build_signing_kwargs() == {}
+
+
+def test_build_signing_kwargs_refreshes_adc_before_reading_service_account_email():
+    credentials = _FakeAdcCredentials(
+        service_account_email_after_refresh="runtime-sa@example.iam.gserviceaccount.com",
+        access_value_after_refresh="access-value",
+    )
+    storage = _build_storage_with_signing_credentials(credentials)
+
+    signing_kwargs = storage._build_signing_kwargs()
+
+    assert credentials.refresh_calls == 1
+    assert signing_kwargs == {
+        "service_account_email": "runtime-sa@example.iam.gserviceaccount.com",
+        "access_token": "access-value",
+    }
+
+
+def test_build_signing_kwargs_rejects_adc_without_service_account_email():
+    credentials = _FakeAdcCredentials(
+        service_account_email_after_refresh=None,
+        access_value_after_refresh="access-value",
+    )
+    storage = _build_storage_with_signing_credentials(credentials)
+
+    with pytest.raises(RuntimeError, match="service_account_email"):
+        storage._build_signing_kwargs()


### PR DESCRIPTION
## 概要

Cloud Run の ADC では private key を持たないため、GCS signed URL の発行を IAM SignBlob 経由に切り替えます。画像アップロード URL 発行時に Cloud Run 実行 SA の credentials を refresh してから service account email を参照するようにし、実行環境での署名失敗を防ぎます。

## 関連 Issue

- Closes #
- Refs #

## 変更内容

- GCS credentials path 未指定時は ADC を取得し、signed URL 発行時に IAM SignBlob 用の `service_account_email` / `access_token` を渡すように変更
- ADC credentials は refresh 後に `service_account_email` を読むようにして、Cloud Run の compute credentials に対応
- GCS 設定説明を IAM SignBlob 前提に更新
- IAM SignBlob 用の signing kwargs の単体テストを追加

## スコープ外 / 残課題

- Cloud Run 実行 SA への `roles/iam.serviceAccountTokenCreator` 付与など、GCP IAM 設定自体はこの PR では変更しない
- 実 Cloud Run revision 上での疎通確認はデプロイ後に実施する

## 動作確認

```bash
cd backend
uv run ruff check src/infrastructure/storage/gcs_output_image_storage.py tests/unit/test_infrastructure/test_gcs_output_image_storage.py
uv run pytest tests/unit/test_infrastructure/test_gcs_output_image_storage.py
uv run ty check tests/unit/test_infrastructure/test_gcs_output_image_storage.py src/infrastructure/storage/gcs_output_image_storage.py
task backend:ci
```

### スクリーンショット / 動画

UI 変更なし。

## チェックリスト

- [x] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [x] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [x] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [x] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
