### PR TITLE
refact(mobile):警告ポップアップ画面の表示修正

### DIFF
--- a/mobile/app/(tabs)/__tests__/_layout.test.tsx
+++ b/mobile/app/(tabs)/__tests__/_layout.test.tsx
@@ -114,8 +114,11 @@ describe('TabsLayout', () => {
 
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(getByTestId('report-blocked-dialog').props.visible).toBe(true);
-      expect(getByText('タイマー起動中はレポート機能を見ることができ')).toBeTruthy();
-      expect(getByText('ません。休憩終了後に見ることができます。')).toBeTruthy();
+      expect(
+        getByText(
+          'タイマー起動中はレポート機能を見ることができません。休憩終了後に見ることができます。',
+        ),
+      ).toBeTruthy();
     },
   );
 

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -12,10 +12,8 @@ const REPORT_ICON_BLUE = require('../../assets/images/icons/icon_report_blue.png
 const REPORT_ICON_GRAY = require('../../assets/images/icons/icon_report_gray.png');
 const TABS_SEGMENT = '(tabs)';
 const TIMER_TAB_ACTIVE_SESSION_PHASES = new Set(['input', 'output', 'break']);
-const REPORT_BLOCKED_MESSAGE_LINES = [
-  'タイマー起動中はレポート機能を見ることができ',
-  'ません。休憩終了後に見ることができます。',
-] as const;
+const REPORT_BLOCKED_MESSAGE =
+  'タイマー起動中はレポート機能を見ることができません。休憩終了後に見ることができます。';
 
 export function isReportTabNavigationBlocked(phase: TimerPhase) {
   return phase === 'input' || phase === 'output' || phase === 'break';
@@ -95,18 +93,9 @@ function ReportBlockedDialog({ visible, onDismiss }: { visible: boolean; onDismi
       <View style={styles.dialogBackdrop}>
         <View style={styles.dialogCard}>
           <View style={styles.dialogMessageWrap}>
-            {REPORT_BLOCKED_MESSAGE_LINES.map((line) => (
-              <Text
-                adjustsFontSizeToFit
-                allowFontScaling={false}
-                key={line}
-                minimumFontScale={0.82}
-                numberOfLines={1}
-                style={styles.dialogMessage}
-              >
-                {line}
-              </Text>
-            ))}
+            <Text allowFontScaling={false} style={styles.dialogMessage}>
+              {REPORT_BLOCKED_MESSAGE}
+            </Text>
           </View>
           <View style={styles.dialogDivider} />
           <Pressable
@@ -214,42 +203,45 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'rgba(0, 0, 0, 0.24)',
-    paddingHorizontal: 24,
+    paddingHorizontal: 36,
   },
   dialogCard: {
     width: '100%',
-    maxWidth: 292,
+    maxWidth: 310,
     overflow: 'hidden',
-    borderRadius: 18,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#CDCDCD',
     backgroundColor: '#FFFFFF',
   },
   dialogMessageWrap: {
-    minHeight: 86,
+    minHeight: 81,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingHorizontal: 18,
-    paddingVertical: 16,
+    paddingHorizontal: 28,
+    paddingTop: 26,
+    paddingBottom: 14,
   },
   dialogMessage: {
     color: '#333333',
-    fontSize: 14,
-    fontWeight: '700',
-    lineHeight: 22,
+    fontFamily: 'HiraginoSans-W3',
+    fontSize: 12,
+    lineHeight: 18,
     textAlign: 'center',
   },
   dialogDivider: {
-    height: StyleSheet.hairlineWidth,
-    backgroundColor: '#D4D4D8',
+    height: 1,
+    backgroundColor: '#CDCDCD',
   },
   dialogButton: {
-    height: 44,
+    height: 38,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: '#FFFFFF',
   },
   dialogButtonText: {
     color: ACTIVE_COLOR,
-    fontSize: 17,
+    fontSize: 14,
     fontWeight: '400',
     lineHeight: 22,
     textAlign: 'center',


### PR DESCRIPTION
<!--
コミットメッセージは `.claude/rules/commit-message-rule.md` の規則（日本語 Conventional Commits）に従ってください。
-->

## 概要

- figmaの一次レビューに従って、警告ポップアップ画面の文字/表示枠の種類と大きさ・色・配置を修正しました。


## 関連 Issue

<!--
Closes #<issue>     ... この PR で完了する Story / Task
Refs #<issue>       ... 参照する Epic / Story
-->

- Closes #
- Refs #
- 今回はなし
## 変更内容

<!-- 主な変更点を箇条書きで。差分から自明なものは省略可 -->

- 修正はフォントの種類はfigmaの設定と合わせ、大きさと配置はfigmaのフレームワークを参考に全体からの比率をもとに設定しました。(一部どうしても合わないところはfontweightで太さ調整も行いました)

## スコープ外 / 残課題

<!-- 意図的にやらなかったこと、後続 PR / Issue で扱うことがあれば記載 -->

-

## 動作確認

<!-- task コマンドで再現できる手順を記載してください。UI 変更がある場合はスクリーンショット / 動画も添付 -->

```bash
# 例
task ci                       # backend と mobile の lint / typecheck / test を一括
task backend:dev              # http://localhost:8000/health で 200 を確認
task mobile:start             # Expo を起動して該当画面を確認
```
- task ci # backend と mobile の lint / typecheck / test を一括
- task ios. # モバイルシュミレーターで画面確認
- あと実機

### スクリーンショット / 動画

<!-- UI 変更がある場合のみ。before / after を並べると分かりやすい -->
- before
<img width="91" height="206" alt="スクリーンショット 2026-05-10 9 37 19" src="https://github.com/user-attachments/assets/c3595ec2-3c26-4a67-9e51-bd04d99b2b8a" />

- after
<img width="93" height="201" alt="スクリーンショット 2026-05-10 9 37 39" src="https://github.com/user-attachments/assets/4932e2e7-bd88-466c-b717-b6d3abf8a6b6" />


## チェックリスト

- [ ] `task ci` がローカルで通る（または該当する個別タスクが通る）
- [ ] 関連 Issue を `Closes` / `Refs` で正しく紐付けている
- [ ] 仕様書（`docs/requirements/requirements.md`）と矛盾していない、または差分を本文に明記している
- [ ] 破壊的変更がある場合はコミットメッセージに `BREAKING CHANGE:` を含めている
